### PR TITLE
Addressing some of the feedback that was recieved for general fixes on the repo.

### DIFF
--- a/Build.proj
+++ b/Build.proj
@@ -1,5 +1,12 @@
 <Project Sdk="Microsoft.Build.Traversal">
 
+  <!-- Ensure that packages are only created when GeneratePackOnBuild is set to true -->
+  <ItemDefinitionGroup>
+    <ProjectToBuild>
+      <Pack>false</Pack>
+    </ProjectToBuild>
+  </ItemDefinitionGroup>
+
   <ItemGroup>
     <!-- Build all src projects -->
     <ProjectToBuild Include="$(MSBuildThisFileDirectory)src\*\src\*.*proj" />
@@ -10,7 +17,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Subsets are already imported by Directory.Build.props. -->
     <ProjectReference Include="@(ProjectToBuild)" />
   </ItemGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,10 +11,6 @@
     <IsPackable>true</IsPackable>
     <EnablePackageValidation>true</EnablePackageValidation>
 
-    <!-- Set this property to false if you don't want to use the runtime
-          framework version defined in Versions.props -->
-    <UseCustomRuntimeVersion>true</UseCustomRuntimeVersion>
-    <RuntimeFrameworkVersion Condition="$(UseCustomRuntimeVersion)">$(MicrosoftNETCoreAppVersion)</RuntimeFrameworkVersion>
     <CommonPath>$(MSBuildThisFileDirectory)src/Common/</CommonPath>
   </PropertyGroup>
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -29,15 +29,6 @@
              Link="Resources/Common/SR$(DefaultLanguageSourceExtension)" />
   </ItemGroup>
 
-  <!-- Use a custom framework version -->
-  <ItemGroup>
-    <FrameworkReference Update="Microsoft.NETCore.App"
-                        Condition="'$(UseCustomRuntimeVersion)' == 'true' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'"
-                        TargetFramework="$(TargetFramework)"
-                        RuntimeFrameworkVersion="$(MicrosoftNETCoreAppVersion)"
-                        TargetingPackVersion="$(MicrosoftNETCoreAppVersion)" />
-  </ItemGroup>
-
   <Import Condition="'$(IsTestProject)' == 'true'" Project="$(RepositoryEngineeringDir)testing\runsettings.targets" />
 
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />

--- a/README.md
+++ b/README.md
@@ -1,3 +1,27 @@
-# Contributing
+# Maintenance Packages
+
+## Description
+
+This project hosts different packages from the .NET Platform whose original home/branch is not building any longer. The main purpose of it is to be able to have a servicing vehicle for them which uses the latest toolset.
+
+## Project FAQ
+
+- How do I know if a particular package belongs on this repo?
+  - As explained above, this repo is meant to be the home for packages that are no longer building in any supported repository/branch. Therefore, if a package/library is still building in one supported branch, then this repository is not the right place for it. The idea of this repo is to have a servicing vehicle for those packages, and if one package is still building in a supported branch, then by definition that is the servicing vehicle that should be used for servicing fixes to it.
+- Ok, I've determined that this package does belong on the repo, what is the process to add it?
+  - *ToDo*
+
+## How to produce stable package versions
+
+Package versions produced by official builds for this repo will automatically contain a prerelease suffix. This is in order to be able to iterate through changes until we are ready to have a final build when we are ready for a new servicing release. When that time comes, all that is needed in order to produce packages that don't have the prerelease suffix is to manually queue a build in the official pipeline, and set the variable `DotNetFinalVersionKind` to `release`. This will automatically cause Arcade to set the right version for the package, as well as use a dedicated NuGet feed to push the final build assets (in order to avoid potential version clashes).
+
+## How to service a library
+
+The default build will automatically build all of the libraries that have been added to the repo. That said, given this repository is used to service packages, and you won't always want to service all of the packages at the same time, packages for libraries are not built by default. Whenever a package needs to be serviced, the following steps will need to be follwed:
+
+1. Determine the ServiceVersion to be used. When servicing a fix on a library package, the ServiceVersion (third part of the NuGet package version) will need to be bumped. This property is found in the library's src project. It's also possible that the property is not in that file, in which case you'll need to add it to the project and set it to 1. If the property is already in the source project, then just increment the servicing version by 1.
+2. Ensure that the source project has the property `<GeneratePackageOnBuild>true</GeneratePackageOnBuild>` set. This will ensure that the package for this library will be produced as part of the build.
+
+## Contributing
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/eng/pipelines/maintenance-packages.yml
+++ b/eng/pipelines/maintenance-packages.yml
@@ -55,7 +55,6 @@ stages:
       archType: x64
       ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         isOfficialBuild: true
-        runTests: false
         pool:
           name: NetCore1ESPool-Internal
           demands: ImageOverride -equals windows.vs2022preview.amd64

--- a/eng/pipelines/templates/build-job.yml
+++ b/eng/pipelines/templates/build-job.yml
@@ -12,7 +12,7 @@ jobs:
 - template: /eng/common/templates/jobs/jobs.yml
   parameters:
     enableTelemetry: true
-    helixRepo: dotnet/runtimelab
+    helixRepo: dotnet/maintenance-packages
     pool: ${{ parameters.pool }}
     enablePublishBuildArtifacts: true
     enablePublishBuildAssets: true

--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
   "sdk": {
-    "version": "7.0.100-rc.2.22477.23",
+    "version": "7.0.100",
     "allowPrerelease": true,
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "7.0.100-rc.2.22477.23"
+    "dotnet": "7.0.100"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.22554.2",

--- a/src/System.Buffers/Directory.Build.props
+++ b/src/System.Buffers/Directory.Build.props
@@ -1,8 +1,0 @@
-<Project>
-  <PropertyGroup>
-    <VersionPrefix>4.5.2</VersionPrefix>
-    <AssemblyVersion>4.0.3.0</AssemblyVersion>
-  </PropertyGroup>
-
-  <Import Project="$(MSBuildThisFileDirectory)../../Directory.Build.props" />
-</Project>

--- a/src/System.Buffers/src/System.Buffers.csproj
+++ b/src/System.Buffers/src/System.Buffers.csproj
@@ -3,8 +3,15 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard2.0;net461</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <PackageValidationBaselineVersion>4.5.1</PackageValidationBaselineVersion>
     <StrongNameKeyId>Open</StrongNameKeyId>
+    <AssemblyVersion>4.0.3.0</AssemblyVersion>
+    <!-- Bump the below version each time we need to service a new version and ensure GeneratePackageOnBuild is set to true -->
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <ServicingVersion>2</ServicingVersion>
+
+    <!-- Package version properties -->
+    <VersionPrefix>4.5.$(ServicingVersion)</VersionPrefix>
+    <PackageValidationBaselineVersion>4.5.$([MSBuild]::Subtract($(ServicingVersion), 1))</PackageValidationBaselineVersion>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
cc: @ViktorHofer @carlossanlop @ericstj @bartonjs @smasher164 

This PR is addressing most of the feedback that was received during the hand-off meeting. Not shown here but has also been done: I've configured the main branch of this repo to publish to the ".NET Libraries" channel as it was requested.

The main remaining thing is the ToDo item I added on the README file, where I will add the steps on how to onboard a new library into the repo.

More specifically, these are the items that have been covered here:

- Cleanup some comments from build.proj around subsets which are not relevant.
- Fill out Readme with useful documentation as well as docs on how to service new libraries.
- Upgrade to stable 7.0 SDK
- Fix line in yml that had the wrong repo name.
- Run tests on official builds as well, not just on PR builds.
- Switch servicing instructions to mimic what we do in dotnet/runtime: This simplifies servicing to only have to do two main things a) Set GeneratePackageOnBuild to true and b) bump ServicingVersion
- Package baseline validation doesn't need to be incremented any longer, and is now instead calculated based on the ServicingVersion.
- Removing library-specific Directory.Build.props, and having only one csproj that needs to be modified for servicing.