### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,14 +12,6 @@ indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
 
-# License header
-file_header_template = Licensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the MIT license.
-
-# C++ Files
-[*.{cpp,h,in}]
-curly_bracket_next_line = true
-indent_brace_style = Allman
-
 # Xml project files
 [*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,nativeproj,locproj}]
 indent_size = 2
@@ -27,12 +19,8 @@ indent_size = 2
 [*.{csproj,vbproj,proj,nativeproj,locproj}]
 charset = utf-8
 
-# Xml build files
-[*.builds]
-indent_size = 2
-
 # Xml files
-[*.{xml,stylecop,resx,ruleset}]
+[*.{xml,resx,ruleset}]
 indent_size = 2
 
 # Xml config files
@@ -40,7 +28,7 @@ indent_size = 2
 indent_size = 2
 
 # YAML config files
-[*.{yml,yaml}]
+[*.{yml}]
 indent_size = 2
 
 # Shell scripts
@@ -67,4 +55,5 @@ dotnet_style_allow_statement_immediately_after_block_experimental = false
 csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = false
 
 # IDE0073: The file header is missing or not located at the top of the file
+file_header_template = Licensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the MIT license.
 dotnet_diagnostic.IDE0073.severity = error

--- a/.editorconfig
+++ b/.editorconfig
@@ -68,4 +68,4 @@ dotnet_style_allow_statement_immediately_after_block_experimental = false
 csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = false
 
 # IDE0073: The file header is missing or not located at the top of the file
-dotnet_diagnostic.IDE0073.severity = warning
+dotnet_diagnostic.IDE0073.severity = error

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,50 @@
+# editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Default settings:
+# A newline ending every file
+# Use 4 spaces as indentation
+[*]
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+# License header
+file_header_template = Licensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the MIT license.
+
+# C++ Files
+[*.{cpp,h,in}]
+curly_bracket_next_line = true
+indent_brace_style = Allman
+
+# Xml project files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,nativeproj,locproj}]
+indent_size = 2
+
+[*.{csproj,vbproj,proj,nativeproj,locproj}]
+charset = utf-8
+
+# Xml build files
+[*.builds]
+indent_size = 2
+
+# Xml files
+[*.{xml,stylecop,resx,ruleset}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets,config,nuspec}]
+indent_size = 2
+
+# YAML config files
+[*.{yml,yaml}]
+indent_size = 2
+
+# Shell scripts
+[*.sh]
+end_of_line = lf
+[*.{cmd,bat}]
+end_of_line = crlf

--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,27 @@ indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
 
+# License header
+file_header_template = Licensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the MIT license.
+
+# IDE2000: Allow multiple blank lines
+dotnet_style_allow_multiple_blank_lines_experimental = false
+
+# IDE2001: Embedded statements must be on their own line
+csharp_style_allow_embedded_statements_on_same_line_experimental = false
+
+# IDE2002: Consecutive braces must not have blank line between them
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = false
+
+# IDE2003: Blank line required between block and subsequent statement
+dotnet_style_allow_statement_immediately_after_block_experimental = false
+
+# IDE2004: Blank line not allowed after constructor initializer colon
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = false
+
+# IDE0073: The file header is missing or not located at the top of the file
+dotnet_diagnostic.IDE0073.severity = error
+
 # C++ Files
 [*.{cpp,h,in}]
 curly_bracket_next_line = true
@@ -45,27 +66,3 @@ indent_size = 2
 end_of_line = lf
 [*.{cmd,bat}]
 end_of_line = crlf
-
-# Compile items
-[*.{cs,vb}]
-
-# License header
-file_header_template = Licensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the MIT license.
-
-# IDE2000: Allow multiple blank lines
-dotnet_style_allow_multiple_blank_lines_experimental = false
-
-# IDE2001: Embedded statements must be on their own line
-csharp_style_allow_embedded_statements_on_same_line_experimental = false
-
-# IDE2002: Consecutive braces must not have blank line between them
-csharp_style_allow_blank_lines_between_consecutive_braces_experimental = false
-
-# IDE2003: Blank line required between block and subsequent statement
-dotnet_style_allow_statement_immediately_after_block_experimental = false
-
-# IDE2004: Blank line not allowed after constructor initializer colon
-csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = false
-
-# IDE0073: The file header is missing or not located at the top of the file
-dotnet_diagnostic.IDE0073.severity = error

--- a/.editorconfig
+++ b/.editorconfig
@@ -15,24 +15,6 @@ trim_trailing_whitespace = true
 # License header
 file_header_template = Licensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the MIT license.
 
-# IDE2000: Allow multiple blank lines
-dotnet_style_allow_multiple_blank_lines_experimental = false
-
-# IDE2001: Embedded statements must be on their own line
-csharp_style_allow_embedded_statements_on_same_line_experimental = false
-
-# IDE2002: Consecutive braces must not have blank line between them
-csharp_style_allow_blank_lines_between_consecutive_braces_experimental = false
-
-# IDE2003: Blank line required between block and subsequent statement
-dotnet_style_allow_statement_immediately_after_block_experimental = false
-
-# IDE2004: Blank line not allowed after constructor initializer colon
-csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = false
-
-# IDE0073: The file header is missing or not located at the top of the file
-dotnet_diagnostic.IDE0073.severity = error
-
 # C++ Files
 [*.{cpp,h,in}]
 curly_bracket_next_line = true
@@ -66,3 +48,23 @@ indent_size = 2
 end_of_line = lf
 [*.{cmd,bat}]
 end_of_line = crlf
+
+[*.cs]
+
+# IDE2000: Allow multiple blank lines
+dotnet_style_allow_multiple_blank_lines_experimental = false
+
+# IDE2001: Embedded statements must be on their own line
+csharp_style_allow_embedded_statements_on_same_line_experimental = false
+
+# IDE2002: Consecutive braces must not have blank line between them
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = false
+
+# IDE2003: Blank line required between block and subsequent statement
+dotnet_style_allow_statement_immediately_after_block_experimental = false
+
+# IDE2004: Blank line not allowed after constructor initializer colon
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = false
+
+# IDE0073: The file header is missing or not located at the top of the file
+dotnet_diagnostic.IDE0073.severity = error

--- a/.editorconfig
+++ b/.editorconfig
@@ -12,9 +12,6 @@ indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
 
-# License header
-file_header_template = Licensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the MIT license.
-
 # C++ Files
 [*.{cpp,h,in}]
 curly_bracket_next_line = true
@@ -48,3 +45,27 @@ indent_size = 2
 end_of_line = lf
 [*.{cmd,bat}]
 end_of_line = crlf
+
+# Compile items
+[*.{cs,vb}]
+
+# License header
+file_header_template = Licensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the MIT license.
+
+# IDE2000: Allow multiple blank lines
+dotnet_style_allow_multiple_blank_lines_experimental = false
+
+# IDE2001: Embedded statements must be on their own line
+csharp_style_allow_embedded_statements_on_same_line_experimental = false
+
+# IDE2002: Consecutive braces must not have blank line between them
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = false
+
+# IDE2003: Blank line required between block and subsequent statement
+dotnet_style_allow_statement_immediately_after_block_experimental = false
+
+# IDE2004: Blank line not allowed after constructor initializer colon
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = false
+
+# IDE0073: The file header is missing or not located at the top of the file
+dotnet_diagnostic.IDE0073.severity = warning

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,6 @@
     <LangVersion>Latest</LangVersion>
     <CommonPath>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'src', 'Common'))</CommonPath>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
-    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   </PropertyGroup>
 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,6 +11,7 @@
     <LangVersion>Latest</LangVersion>
     <CommonPath>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'src', 'Common'))</CommonPath>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
   </PropertyGroup>
 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,9 +10,9 @@
     <DebugSymbols>true</DebugSymbols>
     <LangVersion>Latest</LangVersion>
     <CommonPath>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'src', 'Common'))</CommonPath>
-    <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisMode>Recommended</AnalysisMode>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,8 @@
     <DebugSymbols>true</DebugSymbols>
     <LangVersion>Latest</LangVersion>
     <CommonPath>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'src', 'Common'))</CommonPath>
+    <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   </PropertyGroup>
 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,6 +12,7 @@
     <CommonPath>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'src', 'Common'))</CommonPath>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisMode>Recommended</AnalysisMode>
   </PropertyGroup>
 
 </Project>

--- a/src/Common/System/SR.cs
+++ b/src/Common/System/SR.cs
@@ -2,17 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable enable
+
 using System.Resources;
+
+#pragma warning disable CA1304,CA1305
 
 namespace System
 {
     internal static partial class SR
     {
-#if !NETSTANDARD1_1
         private static readonly bool s_usingResourceKeys = AppContext.TryGetSwitch("System.Resources.UseSystemResourceKeys", out bool usingResourceKeys) ? usingResourceKeys : false;
-#else
-        private static readonly bool s_usingResourceKeys = false;
-#endif
 
         // This method is used to decide if we need to append the exception message parameters to the message when calling SR.Format.
         // by default it returns the value of System.Resources.UseSystemResourceKeys AppContext switch or false if not specified.
@@ -31,11 +30,7 @@ namespace System
             try
             {
                 resourceString =
-#if SYSTEM_PRIVATE_CORELIB || NATIVEAOT
-                    InternalGetResourceString(resourceKey);
-#else
                     ResourceManager.GetString(resourceKey);
-#endif
             }
             catch (MissingManifestResourceException) { }
 

--- a/src/System.Buffers/tests/ArrayPool/ArrayPoolTest.cs
+++ b/src/System.Buffers/tests/ArrayPool/ArrayPoolTest.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.RemoteExecutor;
 using System.Diagnostics;

--- a/src/System.Buffers/tests/ArrayPool/UnitTests.cs
+++ b/src/System.Buffers/tests/ArrayPool/UnitTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;


### PR DESCRIPTION
Addresses

> Enable analyzer that suggests the correct license header.

from https://github.com/dotnet/maintenance-packages/issues/16