### PR TITLE
Add developer innerloop scripts from runtime

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -5,5 +5,5 @@ set _args=%*
 if "%~1"=="-?" set _args=-help
 if "%~1"=="/?" set _args=-help
 
-powershell -ExecutionPolicy ByPass -NoProfile -Command "& '%~dp0eng\common\build.ps1' -restore -build" %_args%
+powershell -ExecutionPolicy ByPass -NoProfile -Command "& '%~dp0eng\build.ps1'" %_args%
 exit /b %ERRORLEVEL%

--- a/dotnet.cmd
+++ b/dotnet.cmd
@@ -1,0 +1,22 @@
+@echo off
+
+powershell -ExecutionPolicy ByPass -NoProfile -Command "& { . '%~dp0eng\common\tools.ps1'; InitializeDotNetCli $true $true }"
+
+if NOT [%ERRORLEVEL%] == [0] (
+  echo Failed to install or invoke dotnet... 1>&2
+  exit /b %ERRORLEVEL%
+)
+
+set /p dotnetPath=<%~dp0artifacts\toolset\sdk.txt
+
+:: Clear the 'Platform' env variable for this session, as it's a per-project setting within the build, and
+:: misleading value (such as 'MCD' in HP PCs) may lead to build breakage (issue: #69).
+set Platform=
+
+:: Don't resolve runtime, shared framework, or SDK from other locations to ensure build determinism
+set DOTNET_MULTILEVEL_LOOKUP=0
+
+:: Disable first run since we want to control all package sources
+set DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+
+call "%dotnetPath%\dotnet.exe" %*

--- a/dotnet.cmd
+++ b/dotnet.cmd
@@ -13,10 +13,7 @@ set /p dotnetPath=<%~dp0artifacts\toolset\sdk.txt
 :: misleading value (such as 'MCD' in HP PCs) may lead to build breakage (issue: #69).
 set Platform=
 
-:: Don't resolve runtime, shared framework, or SDK from other locations to ensure build determinism
-set DOTNET_MULTILEVEL_LOOKUP=0
-
 :: Disable first run since we want to control all package sources
-set DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+set DOTNET_NOLOGO=1
 
 call "%dotnetPath%\dotnet.exe" %*

--- a/dotnet.sh
+++ b/dotnet.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 source="${BASH_SOURCE[0]}"
-
 # resolve $SOURCE until the file is no longer a symlink
 while [[ -h $source ]]; do
   scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
@@ -11,6 +10,18 @@ while [[ -h $source ]]; do
   # symlink file was located
   [[ $source != /* ]] && source="$scriptroot/$source"
 done
-
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
-"$scriptroot/eng/build.sh" $@
+
+# Don't resolve runtime, shared framework, or SDK from other locations to ensure build determinism
+export DOTNET_MULTILEVEL_LOOKUP=0
+
+# Disable first run since we want to control all package sources
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+
+source $scriptroot/eng/common/tools.sh
+
+InitializeDotNetCli true # Install
+__dotnetDir=${_InitializeDotNetCli}
+
+dotnetPath=${__dotnetDir}/dotnet
+${dotnetPath} "$@"

--- a/dotnet.sh
+++ b/dotnet.sh
@@ -12,11 +12,8 @@ while [[ -h $source ]]; do
 done
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 
-# Don't resolve runtime, shared framework, or SDK from other locations to ensure build determinism
-export DOTNET_MULTILEVEL_LOOKUP=0
-
 # Disable first run since we want to control all package sources
-export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+export DOTNET_NOLOGO=1
 
 source $scriptroot/eng/common/tools.sh
 

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -1,0 +1,91 @@
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+  [switch][Alias('h')]$help,
+  [switch][Alias('t')]$test,
+  [ValidateSet("Debug","Release","Checked")][string[]][Alias('c')]$configuration = @("Debug"),
+  [switch]$vs,
+  [string][Alias('v')]$verbosity = "minimal",
+  [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
+)
+
+function Get-Help() {
+  Write-Host "Common settings:"
+  Write-Host "  -binaryLog (-bl)               Output binary log."
+  Write-Host "  -configuration (-c)            Build configuration: Debug or Release."
+  Write-Host "                                 [Default: Debug]"
+  Write-Host "  -help (-h)                     Print help and exit."
+  Write-Host "  -projects <value>              Project or solution file(s) to build."
+  Write-Host "  -verbosity (-v)                MSBuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]."
+  Write-Host "                                 [Default: Minimal]"
+  Write-Host "  -vs                            Open the solution with Visual Studio using the locally acquired SDK."
+  Write-Host ""
+
+  Write-Host "Actions (defaults to -restore -build):"
+  Write-Host "  -build (-b)             Build all source projects."
+  Write-Host "                          This assumes -restore has been run already."
+  Write-Host "  -clean                  Clean the solution."
+  Write-Host "  -pack                   Package build outputs into NuGet packages."
+  Write-Host "  -publish                Publish artifacts (e.g. symbols)."
+  Write-Host "                          This assumes -build has been run already."
+  Write-Host "  -rebuild                Rebuild all source projects."
+  Write-Host "  -restore                Restore dependencies."
+  Write-Host "  -sign                   Sign build outputs."
+  Write-Host "  -test (-t)              Incrementally builds and runs tests."
+  Write-Host ""
+
+  Write-Host "Command-line arguments not listed above are passed through to MSBuild."
+  Write-Host "The above arguments can be shortened as much as to be unambiguous."
+  Write-Host "(Example: -con for configuration, -t for test, etc.)."
+  Write-Host ""
+}
+
+if ($help -or (($null -ne $properties) -and ($properties.Contains('/help') -or $properties.Contains('/?')))) {
+  Get-Help
+  exit 0
+}
+
+if ($vs) {
+  . $PSScriptRoot\common\tools.ps1
+
+  # This tells .NET Core to use the bootstrapped runtime
+  $env:DOTNET_ROOT=InitializeDotNetCli -install:$true -createSdkLocationFile:$true
+
+  # This tells MSBuild to load the SDK from the directory of the bootstrapped SDK
+  $env:DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR=$env:DOTNET_ROOT
+
+  # Put our local dotnet.exe on PATH first so Visual Studio knows which one to use
+  $env:PATH=($env:DOTNET_ROOT + ";" + $env:PATH);
+
+  # Launch Visual Studio with the locally defined environment variables
+  $solution = Split-Path $PSScriptRoot -Parent | Join-Path -ChildPath "MaintenancePackages.sln"
+  ."$solution"
+
+  exit 0
+}
+
+# Check if an action is passed in
+$actions = "b","build","r","restore","rebuild","sign","publish","clean","pack"
+$actionPassedIn = @(Compare-Object -ReferenceObject @($PSBoundParameters.Keys) -DifferenceObject $actions -ExcludeDifferent -IncludeEqual).Length -ne 0
+if ($null -ne $properties -and $actionPassedIn -ne $true) {
+  $actionPassedIn = @(Compare-Object -ReferenceObject $properties -DifferenceObject $actions.ForEach({ "-" + $_ }) -ExcludeDifferent -IncludeEqual).Length -ne 0
+}
+
+if (!$actionPassedIn) {
+  $arguments = "-restore -build"
+}
+
+foreach ($argument in $PSBoundParameters.Keys)
+{
+  switch($argument)
+  {
+    "properties"             { $arguments += " " + $properties }
+    "verbosity"              { $arguments += " -$argument " + $($PSBoundParameters[$argument]) }
+    "configuration"          { $configuration = (Get-Culture).TextInfo.ToTitleCase($($PSBoundParameters[$argument])); $arguments += " -configuration $configuration" }
+    default                  { $arguments += " /p:$argument=$($PSBoundParameters[$argument])" }
+  }
+}
+
+Invoke-Expression "& `"$PSScriptRoot/common/build.ps1`" $arguments"
+exit $lastExitCode
+
+exit 0

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+set -ue
+
+source="${BASH_SOURCE[0]}"
+
+# resolve $source until the file is no longer a symlink
+while [[ -h "$source" ]]; do
+  scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
+  source="$(readlink "$source")"
+  # if $source was a relative symlink, we need to resolve it relative to the path where the
+  # symlink file was located
+  [[ $source != /* ]] && source="$scriptroot/$source"
+done
+scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
+
+usage()
+{
+  echo "Common settings:"
+  echo "  --binaryLog (-bl)               Output binary log."
+  echo "  --configuration (-c)            Build configuration: Debug, Release or Checked."
+  echo "                                  [Default: Debug]"
+  echo "  --help (-h)                     Print help and exit."
+  echo "  --projects <value>              Project or solution file(s) to build."
+  echo "  --verbosity (-v)                MSBuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]."
+  echo "                                  [Default: Minimal]"
+  echo ""
+
+  echo "Actions (defaults to --restore --build):"
+  echo "  --build (-b)               Build all source projects."
+  echo "                             This assumes --restore has been run already."
+  echo "  --clean                    Clean the solution."
+  echo "  --pack                     Package build outputs into NuGet packages."
+  echo "  --publish                  Publish artifacts (e.g. symbols)."
+  echo "                             This assumes --build has been run already."
+  echo "  --rebuild                  Rebuild all source projects."
+  echo "  --restore (-r)             Restore dependencies."
+  echo "  --sign                     Sign build outputs."
+  echo "  --test (-t)                Incrementally builds and runs tests."
+  echo ""
+
+  echo "Command line arguments starting with '/p:' are passed through to MSBuild."
+  echo "Arguments can also be passed in with a single hyphen."
+  echo ""
+}
+
+arguments=''
+extraargs=''
+
+# Check if an action is passed in
+declare -a actions=("b" "build" "r" "restore" "rebuild" "sign" "publish" "clean")
+actInt=($(comm -12 <(printf '%s\n' "${actions[@]/#/-}" | sort) <(printf '%s\n' "${@/#--/-}" | sort)))
+
+while [[ $# > 0 ]]; do
+  opt="$(echo "${1/#--/-}" | awk '{print tolower($0)}')"
+
+  case "$opt" in
+     -help|-h)
+      usage
+      exit 0
+      ;;
+
+     -configuration|-c)
+      if [ -z ${2+x} ]; then
+        echo "No configuration supplied. See help (--help) for supported configurations." 1>&2
+        exit 1
+      fi
+      passedConfig="$(echo "$2" | awk '{print tolower($0)}')"
+      case "$passedConfig" in
+        debug|release)
+          val="$(tr '[:lower:]' '[:upper:]' <<< ${passedConfig:0:1})${passedConfig:1}"
+          ;;
+        *)
+          echo "Unsupported target configuration '$2'."
+          echo "The allowed values are Debug or Release."
+          exit 1
+          ;;
+      esac
+      arguments="$arguments -configuration $val"
+      shift 2
+      ;;
+
+      *)
+      extraargs="$extraargs $1"
+      shift 1
+      ;;
+  esac
+done
+
+if [ ${#actInt[@]} -eq 0 ]; then
+    arguments="-restore -build $arguments"
+fi
+
+"$scriptroot/common/build.sh" $arguments

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -45,7 +45,6 @@ usage()
 }
 
 arguments=''
-extraargs=''
 
 # Check if an action is passed in
 declare -a actions=("b" "build" "r" "restore" "rebuild" "sign" "publish" "clean")
@@ -81,7 +80,7 @@ while [[ $# > 0 ]]; do
       ;;
 
       *)
-      extraargs="$extraargs $1"
+      arguments="$arguments $1"
       shift 1
       ;;
   esac

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -18,7 +18,7 @@ usage()
 {
   echo "Common settings:"
   echo "  --binaryLog (-bl)               Output binary log."
-  echo "  --configuration (-c)            Build configuration: Debug, Release or Checked."
+  echo "  --configuration (-c)            Build configuration: Debug or Release."
   echo "                                  [Default: Debug]"
   echo "  --help (-h)                     Print help and exit."
   echo "  --projects <value>              Project or solution file(s) to build."


### PR DESCRIPTION
- dotnet.cmd/sh allows to build with the repo local SDK
- build.sh/build.ps1 introduces the -vs switch and better switch handling.