### PR TITLE
Add .NET Standard 1.0 and 1.3 to the baseline package validation list of frameworks to ignore

### DIFF
--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -14,6 +14,7 @@
     <PackageValidationBaselineFrameworkToIgnore Include="netcoreapp3.0" />
     <PackageValidationBaselineFrameworkToIgnore Include="netcoreapp3.1" />
     <PackageValidationBaselineFrameworkToIgnore Include="net5.0" />
+    <PackageValidationBaselineFrameworkToIgnore Include="netstandard1.0" />
   </ItemGroup>
 
   <!-- Add a package README file from. -->

--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -15,6 +15,7 @@
     <PackageValidationBaselineFrameworkToIgnore Include="netcoreapp3.1" />
     <PackageValidationBaselineFrameworkToIgnore Include="net5.0" />
     <PackageValidationBaselineFrameworkToIgnore Include="netstandard1.0" />
+    <PackageValidationBaselineFrameworkToIgnore Include="netstandard1.3" />
   </ItemGroup>
 
   <!-- Add a package README file from. -->


### PR DESCRIPTION
I'll update the affected PRs after merging this:

- https://github.com/dotnet/maintenance-packages/pull/34
- https://github.com/dotnet/maintenance-packages/pull/38