### PR TITLE
Also suppress "netcore50" in package validation baseline frameworks to ignore.

### DIFF
--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -14,7 +14,7 @@
     <PackageValidationBaselineFrameworkToIgnore Include="netcoreapp3.0" />
     <PackageValidationBaselineFrameworkToIgnore Include="netcoreapp3.1" />
     <PackageValidationBaselineFrameworkToIgnore Include="net5.0" />
-    <PackageValidationBaselineFrameworkToIgnore Include="netcoreapp5.0" />
+    <PackageValidationBaselineFrameworkToIgnore Include="netcore50" />
     <PackageValidationBaselineFrameworkToIgnore Include="netstandard1.0" />
     <PackageValidationBaselineFrameworkToIgnore Include="netstandard1.3" />
   </ItemGroup>

--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -14,6 +14,7 @@
     <PackageValidationBaselineFrameworkToIgnore Include="netcoreapp3.0" />
     <PackageValidationBaselineFrameworkToIgnore Include="netcoreapp3.1" />
     <PackageValidationBaselineFrameworkToIgnore Include="net5.0" />
+    <PackageValidationBaselineFrameworkToIgnore Include="netcoreapp5.0" />
     <PackageValidationBaselineFrameworkToIgnore Include="netstandard1.0" />
     <PackageValidationBaselineFrameworkToIgnore Include="netstandard1.3" />
   </ItemGroup>


### PR DESCRIPTION
As mentioned in one of my PRs, this is not the same as net5.0. This tfm was used by UWP apps: https://github.com/dotnet/maintenance-packages/pull/34#discussion_r1472675288