### PR TITLE
Migrate System.Runtime.WindowsRuntime.UI.Xaml

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,19 +1,10 @@
 <Project>
-
-  <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
-
+  <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <Copyright>$(CopyrightNetFoundation)</Copyright>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
-    <DebugType>embedded</DebugType>
-    <DebugSymbols>true</DebugSymbols>
-    <LangVersion>Latest</LangVersion>
-    <CommonPath>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'src', 'Common'))</CommonPath>
-    <EnableNETAnalyzers>true</EnableNETAnalyzers>
-    <AnalysisMode>Recommended</AnalysisMode>
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <DotNetUseShippingVersions>true</DotNetUseShippingVersions>
+    <AssemblyVersion>4.0.5.0</AssemblyVersion>
+    <StrongNameKeyId>ECMA</StrongNameKeyId>
+    <IsNETCoreApp>true</IsNETCoreApp>
+    <IsNETCoreAppRef>false</IsNETCoreAppRef>
+    <IsUAP>true</IsUAP>
   </PropertyGroup>
-
 </Project>

--- a/System.Runtime.WindowsRuntime.UI.Xaml.sln
+++ b/System.Runtime.WindowsRuntime.UI.Xaml.sln
@@ -1,0 +1,53 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27213.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Runtime.WindowsRuntime.UI.Xaml.Tests", "tests\System.Runtime.WindowsRuntime.UI.Xaml.Tests.csproj", "{69FC7EB5-64FD-4464-88B1-B8ADD3870640}"
+	ProjectSection(ProjectDependencies) = postProject
+		{263DA4F1-C3BC-4B43-98E7-9F38B419A131} = {263DA4F1-C3BC-4B43-98E7-9F38B419A131}
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Runtime.WindowsRuntime.UI.Xaml", "src\System.Runtime.WindowsRuntime.UI.Xaml.csproj", "{263DA4F1-C3BC-4B43-98E7-9F38B419A131}"
+	ProjectSection(ProjectDependencies) = postProject
+		{AA1600B8-C4D3-42A9-A28A-04D0C8282566} = {AA1600B8-C4D3-42A9-A28A-04D0C8282566}
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Runtime.WindowsRuntime.UI.Xaml", "ref\System.Runtime.WindowsRuntime.UI.Xaml.csproj", "{AA1600B8-C4D3-42A9-A28A-04D0C8282566}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{1A2F9F4A-A032-433E-B914-ADD5992BB178}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E893-4E87-987E-04EF0DCEAEFD}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{69FC7EB5-64FD-4464-88B1-B8ADD3870640}.Debug|Any CPU.ActiveCfg = uap-Windows_NT-Debug|Any CPU
+		{69FC7EB5-64FD-4464-88B1-B8ADD3870640}.Debug|Any CPU.Build.0 = uap-Windows_NT-Debug|Any CPU
+		{69FC7EB5-64FD-4464-88B1-B8ADD3870640}.Release|Any CPU.ActiveCfg = uap-Windows_NT-Release|Any CPU
+		{69FC7EB5-64FD-4464-88B1-B8ADD3870640}.Release|Any CPU.Build.0 = uap-Windows_NT-Release|Any CPU
+		{263DA4F1-C3BC-4B43-98E7-9F38B419A131}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
+		{263DA4F1-C3BC-4B43-98E7-9F38B419A131}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
+		{263DA4F1-C3BC-4B43-98E7-9F38B419A131}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
+		{263DA4F1-C3BC-4B43-98E7-9F38B419A131}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
+		{AA1600B8-C4D3-42A9-A28A-04D0C8282566}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
+		{AA1600B8-C4D3-42A9-A28A-04D0C8282566}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
+		{AA1600B8-C4D3-42A9-A28A-04D0C8282566}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
+		{AA1600B8-C4D3-42A9-A28A-04D0C8282566}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{69FC7EB5-64FD-4464-88B1-B8ADD3870640} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{263DA4F1-C3BC-4B43-98E7-9F38B419A131} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
+		{AA1600B8-C4D3-42A9-A28A-04D0C8282566} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {FC561FC1-C012-48C5-9A7A-DD35875B6AB1}
+	EndGlobalSection
+EndGlobal

--- a/pkg/System.Runtime.WindowsRuntime.UI.Xaml.pkgproj
+++ b/pkg/System.Runtime.WindowsRuntime.UI.Xaml.pkgproj
@@ -1,0 +1,59 @@
+<Project DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
+  <ItemGroup>
+    <ProjectReference Include="..\ref\System.Runtime.WindowsRuntime.UI.Xaml.csproj">
+      <SupportedFramework>net461;netcoreapp2.0;uap10.0.16299;$(AllXamarinFrameworks)</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Runtime.WindowsRuntime.UI.Xaml.csproj"/>
+
+    <HarvestIncludePaths Include="ref/netcore50" />
+    <HarvestIncludePaths Include="ref/netstandard1.1">
+      <SupportedFramework>net45;netcore45;wpa81;netcoreapp1.0</SupportedFramework>
+    </HarvestIncludePaths>
+
+    <!-- we've previously shipped higer netstandard reference assembly version,
+     this is OK since both of these frameworks will unify down to the inbox version -->
+    <ValidatePackageSuppression Include="PermitInboxRevsion">
+      <Value>.NETCore,Version=v4.5.1;WindowsPhoneApp,Version=v8.1</Value>
+    </ValidatePackageSuppression>
+
+    <!-- We can't harvest an asset from more than one path -->
+     <!-- Disable support for netcoreapp1.0 - netcoreapp2.0 for now.  To support these we need to build the src project for the old TFMs 
+    <File Include="$(NuGetPackageRoot)System.Runtime.WindowsRuntime.UI.Xaml\4.3.0\runtimes\win8\lib\netstandard1.3\System.Runtime.WindowsRuntime.UI.Xaml.dll">
+      <TargetPath>runtimes/win/lib/netcoreapp1.0</TargetPath>
+      <TargetFramework>netcoreapp1.0</TargetFramework>
+    </File>-->
+
+    <HarvestIncludePaths Include="runtimes/win/lib/netcore50" />
+
+    <File Include="$(PlaceHolderFile)">
+      <TargetPath>runtimes/win-aot/lib/uap10.0.16299</TargetPath>
+    </File>
+    <File Include="$(PlaceHolderFile)">
+      <TargetPath>runtimes/win/lib/uap10.0.16299</TargetPath>
+    </File>
+
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="uap10.0.16299" />
+    <InboxOnTargetFramework Include="portable-win8+wpa81" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wpa81" />
+
+    <!-- 
+        ResolveAssemblyReference was attempting to write binding redirects
+        for these assemblies (even though they are in the unification list).  
+        The included build targets explicitly reference System.Runtime
+        and add the facade references to the compiler.
+    -->
+    <PackageFile Include=".\build\net45\System.Runtime.WindowsRuntime.UI.Xaml.targets">
+      <TargetPath>\build\net45\</TargetPath>
+    </PackageFile>
+    <PackageFile Include=".\build\net461\System.Runtime.WindowsRuntime.UI.Xaml.targets">
+      <TargetPath>\build\net461\</TargetPath>
+    </PackageFile>
+    <!-- We need to manually ref S.R.WinRT since it is treated as inbox, but requires a package for reference -->
+    <ProjectReference Include="..\..\System.Runtime.WindowsRuntime\pkg\System.Runtime.WindowsRuntime.pkgproj" TargetFramework="net45" />
+
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
+</Project> 

--- a/pkg/build/net45/System.Runtime.WindowsRuntime.UI.Xaml.targets
+++ b/pkg/build/net45/System.Runtime.WindowsRuntime.UI.Xaml.targets
@@ -1,0 +1,31 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Choose>
+    <When Condition="'$(DoNotReferenceWinRT)' != 'true'">
+      <!-- 
+        ResolveAssemblyReference was attempting to write binding redirects
+        for these assemblies (even though they are in the unification list).
+      -->
+      <PropertyGroup>
+        <!-- ...include the reference to System.Runtime -->
+        <_HasReferenceToSystemRuntime>true</_HasReferenceToSystemRuntime>
+      </PropertyGroup>
+      <ItemGroup>
+        <ReferencePath Include="$(MSBuildThisFileDirectory)..\..\ref\netstandard1.1\System.Runtime.WindowsRuntime.UI.Xaml.dll">
+          <!-- Private = false to make these reference only -->
+          <Private>false</Private>
+          <!-- given this package does not have NugetPackage metadata it will not show in solution explorer, making it explicit -->
+          <Visible>false</Visible>
+        </ReferencePath>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <!-- when this package is referenced as a nuget reference the binding redirect is still present, add a target to remove it -->
+  <Target Name="_RemoveWindowsRuntimeUIXamlSuggestedRedirect" 
+      BeforeTargets="GenerateBindingRedirects" 
+      DependsOnTargets="ResolveAssemblyReferences"
+      Condition="'$(DoNotReferenceWinRT)' != 'true'">
+    <ItemGroup> 
+      <SuggestedBindingRedirects Remove="System.Runtime.WindowsRuntime.UI.Xaml, Culture=neutral, PublicKeyToken=b77a5c561934e089" /> 
+    </ItemGroup> 
+  </Target>
+</Project>

--- a/pkg/build/net461/System.Runtime.WindowsRuntime.UI.Xaml.targets
+++ b/pkg/build/net461/System.Runtime.WindowsRuntime.UI.Xaml.targets
@@ -1,0 +1,31 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Choose>
+    <When Condition="'$(DoNotReferenceWinRT)' != 'true'">
+      <!-- 
+        ResolveAssemblyReference was attempting to write binding redirects
+        for these assemblies (even though they are in the unification list).
+      -->
+      <PropertyGroup>
+        <!-- ...include the reference to System.Runtime -->
+        <DependsOnNETStandard>true</DependsOnNETStandard>
+      </PropertyGroup>
+      <ItemGroup>
+        <ReferencePath Include="$(MSBuildThisFileDirectory)..\..\ref\netstandard2.0\System.Runtime.WindowsRuntime.UI.Xaml.dll">
+          <!-- Private = false to make these reference only -->
+          <Private>false</Private>
+          <!-- given this package does not have NugetPackage metadata it will not show in solution explorer, making it explicit -->
+          <Visible>false</Visible>
+        </ReferencePath>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <!-- when this package is referenced as a nuget reference the binding redirect is still present, add a target to remove it -->
+  <Target Name="_RemoveWindowsRuntimeUIXamlSuggestedRedirect" 
+      BeforeTargets="GenerateBindingRedirects" 
+      DependsOnTargets="ResolveAssemblyReferences"
+      Condition="'$(DoNotReferenceWinRT)' != 'true'">
+    <ItemGroup> 
+      <SuggestedBindingRedirects Remove="System.Runtime.WindowsRuntime.UI.Xaml, Culture=neutral, PublicKeyToken=b77a5c561934e089" /> 
+    </ItemGroup> 
+  </Target>
+</Project>

--- a/ref/Configurations.props
+++ b/ref/Configurations.props
@@ -1,0 +1,12 @@
+﻿<Project DefaultTargets="Build">
+  <PropertyGroup>
+    <PackageConfigurations>
+      netstandard;
+    </PackageConfigurations>
+    <BuildConfigurations>
+      $(PackageConfigurations);
+      netcoreapp;
+      uap;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/ref/System.Runtime.WindowsRuntime.UI.Xaml.cs
+++ b/ref/System.Runtime.WindowsRuntime.UI.Xaml.cs
@@ -1,0 +1,252 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+namespace Windows.UI.Xaml
+{
+    public partial struct CornerRadius
+    {
+        private int _dummyPrimitive;
+        public CornerRadius(double uniformRadius) { throw null; }
+        public CornerRadius(double topLeft, double topRight, double bottomRight, double bottomLeft) { throw null; }
+        public double BottomLeft { get { throw null; } set { } }
+        public double BottomRight { get { throw null; } set { } }
+        public double TopLeft { get { throw null; } set { } }
+        public double TopRight { get { throw null; } set { } }
+        public override bool Equals(object obj) { throw null; }
+        public bool Equals(Windows.UI.Xaml.CornerRadius cornerRadius) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(Windows.UI.Xaml.CornerRadius cr1, Windows.UI.Xaml.CornerRadius cr2) { throw null; }
+        public static bool operator !=(Windows.UI.Xaml.CornerRadius cr1, Windows.UI.Xaml.CornerRadius cr2) { throw null; }
+        public override string ToString() { throw null; }
+    }
+    public partial struct Duration
+    {
+        private int _dummyPrimitive;
+        public Duration(System.TimeSpan timeSpan) { throw null; }
+        public static Windows.UI.Xaml.Duration Automatic { get { throw null; } }
+        public static Windows.UI.Xaml.Duration Forever { get { throw null; } }
+        public bool HasTimeSpan { get { throw null; } }
+        public System.TimeSpan TimeSpan { get { throw null; } }
+        public Windows.UI.Xaml.Duration Add(Windows.UI.Xaml.Duration duration) { throw null; }
+        public static int Compare(Windows.UI.Xaml.Duration t1, Windows.UI.Xaml.Duration t2) { throw null; }
+        public override bool Equals(object value) { throw null; }
+        public bool Equals(Windows.UI.Xaml.Duration duration) { throw null; }
+        public static bool Equals(Windows.UI.Xaml.Duration t1, Windows.UI.Xaml.Duration t2) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static Windows.UI.Xaml.Duration operator +(Windows.UI.Xaml.Duration t1, Windows.UI.Xaml.Duration t2) { throw null; }
+        public static bool operator ==(Windows.UI.Xaml.Duration t1, Windows.UI.Xaml.Duration t2) { throw null; }
+        public static bool operator >(Windows.UI.Xaml.Duration t1, Windows.UI.Xaml.Duration t2) { throw null; }
+        public static bool operator >=(Windows.UI.Xaml.Duration t1, Windows.UI.Xaml.Duration t2) { throw null; }
+        public static implicit operator Windows.UI.Xaml.Duration (System.TimeSpan timeSpan) { throw null; }
+        public static bool operator !=(Windows.UI.Xaml.Duration t1, Windows.UI.Xaml.Duration t2) { throw null; }
+        public static bool operator <(Windows.UI.Xaml.Duration t1, Windows.UI.Xaml.Duration t2) { throw null; }
+        public static bool operator <=(Windows.UI.Xaml.Duration t1, Windows.UI.Xaml.Duration t2) { throw null; }
+        public static Windows.UI.Xaml.Duration operator -(Windows.UI.Xaml.Duration t1, Windows.UI.Xaml.Duration t2) { throw null; }
+        public static Windows.UI.Xaml.Duration operator +(Windows.UI.Xaml.Duration duration) { throw null; }
+        public Windows.UI.Xaml.Duration Subtract(Windows.UI.Xaml.Duration duration) { throw null; }
+        public override string ToString() { throw null; }
+    }
+    public enum DurationType
+    {
+        Automatic = 0,
+        TimeSpan = 1,
+        Forever = 2,
+    }
+    public partial struct GridLength
+    {
+        private int _dummyPrimitive;
+        public GridLength(double pixels) { throw null; }
+        public GridLength(double value, Windows.UI.Xaml.GridUnitType type) { throw null; }
+        public static Windows.UI.Xaml.GridLength Auto { get { throw null; } }
+        public Windows.UI.Xaml.GridUnitType GridUnitType { get { throw null; } }
+        public bool IsAbsolute { get { throw null; } }
+        public bool IsAuto { get { throw null; } }
+        public bool IsStar { get { throw null; } }
+        public double Value { get { throw null; } }
+        public override bool Equals(object oCompare) { throw null; }
+        public bool Equals(Windows.UI.Xaml.GridLength gridLength) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(Windows.UI.Xaml.GridLength gl1, Windows.UI.Xaml.GridLength gl2) { throw null; }
+        public static bool operator !=(Windows.UI.Xaml.GridLength gl1, Windows.UI.Xaml.GridLength gl2) { throw null; }
+        public override string ToString() { throw null; }
+    }
+    public enum GridUnitType
+    {
+        Auto = 0,
+        Pixel = 1,
+        Star = 2,
+    }
+    public partial class LayoutCycleException : System.Exception
+    {
+        public LayoutCycleException() { }
+        protected LayoutCycleException(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
+        public LayoutCycleException(string message) { }
+        public LayoutCycleException(string message, System.Exception innerException) { }
+    }
+    public partial struct Thickness
+    {
+        private int _dummyPrimitive;
+        public Thickness(double uniformLength) { throw null; }
+        public Thickness(double left, double top, double right, double bottom) { throw null; }
+        public double Bottom { get { throw null; } set { } }
+        public double Left { get { throw null; } set { } }
+        public double Right { get { throw null; } set { } }
+        public double Top { get { throw null; } set { } }
+        public override bool Equals(object obj) { throw null; }
+        public bool Equals(Windows.UI.Xaml.Thickness thickness) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(Windows.UI.Xaml.Thickness t1, Windows.UI.Xaml.Thickness t2) { throw null; }
+        public static bool operator !=(Windows.UI.Xaml.Thickness t1, Windows.UI.Xaml.Thickness t2) { throw null; }
+        public override string ToString() { throw null; }
+    }
+}
+namespace Windows.UI.Xaml.Automation
+{
+    public partial class ElementNotAvailableException : System.Exception
+    {
+        public ElementNotAvailableException() { }
+        protected ElementNotAvailableException(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
+        public ElementNotAvailableException(string message) { }
+        public ElementNotAvailableException(string message, System.Exception innerException) { }
+    }
+    public partial class ElementNotEnabledException : System.Exception
+    {
+        public ElementNotEnabledException() { }
+        public ElementNotEnabledException(string message) { }
+        public ElementNotEnabledException(string message, System.Exception innerException) { }
+    }
+}
+namespace Windows.UI.Xaml.Controls.Primitives
+{
+    public partial struct GeneratorPosition
+    {
+        private int _dummyPrimitive;
+        public GeneratorPosition(int index, int offset) { throw null; }
+        public int Index { get { throw null; } set { } }
+        public int Offset { get { throw null; } set { } }
+        public override bool Equals(object o) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(Windows.UI.Xaml.Controls.Primitives.GeneratorPosition gp1, Windows.UI.Xaml.Controls.Primitives.GeneratorPosition gp2) { throw null; }
+        public static bool operator !=(Windows.UI.Xaml.Controls.Primitives.GeneratorPosition gp1, Windows.UI.Xaml.Controls.Primitives.GeneratorPosition gp2) { throw null; }
+        public override string ToString() { throw null; }
+    }
+}
+namespace Windows.UI.Xaml.Markup
+{
+    public partial class XamlParseException : System.Exception
+    {
+        public XamlParseException() { }
+        public XamlParseException(string message) { }
+        public XamlParseException(string message, System.Exception innerException) { }
+    }
+}
+namespace Windows.UI.Xaml.Media
+{
+    public partial struct Matrix : System.IFormattable
+    {
+        private int _dummyPrimitive;
+        public Matrix(double m11, double m12, double m21, double m22, double offsetX, double offsetY) { throw null; }
+        public static Windows.UI.Xaml.Media.Matrix Identity { get { throw null; } }
+        public bool IsIdentity { get { throw null; } }
+        public double M11 { get { throw null; } set { } }
+        public double M12 { get { throw null; } set { } }
+        public double M21 { get { throw null; } set { } }
+        public double M22 { get { throw null; } set { } }
+        public double OffsetX { get { throw null; } set { } }
+        public double OffsetY { get { throw null; } set { } }
+        public override bool Equals(object o) { throw null; }
+        public bool Equals(Windows.UI.Xaml.Media.Matrix value) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(Windows.UI.Xaml.Media.Matrix matrix1, Windows.UI.Xaml.Media.Matrix matrix2) { throw null; }
+        public static bool operator !=(Windows.UI.Xaml.Media.Matrix matrix1, Windows.UI.Xaml.Media.Matrix matrix2) { throw null; }
+        string System.IFormattable.ToString(string format, System.IFormatProvider provider) { throw null; }
+        public override string ToString() { throw null; }
+        public string ToString(System.IFormatProvider provider) { throw null; }
+        public Windows.Foundation.Point Transform(Windows.Foundation.Point point) { throw null; }
+    }
+}
+namespace Windows.UI.Xaml.Media.Animation
+{
+    public partial struct KeyTime
+    {
+        private int _dummyPrimitive;
+        public System.TimeSpan TimeSpan { get { throw null; } }
+        public override bool Equals(object value) { throw null; }
+        public bool Equals(Windows.UI.Xaml.Media.Animation.KeyTime value) { throw null; }
+        public static bool Equals(Windows.UI.Xaml.Media.Animation.KeyTime keyTime1, Windows.UI.Xaml.Media.Animation.KeyTime keyTime2) { throw null; }
+        public static Windows.UI.Xaml.Media.Animation.KeyTime FromTimeSpan(System.TimeSpan timeSpan) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(Windows.UI.Xaml.Media.Animation.KeyTime keyTime1, Windows.UI.Xaml.Media.Animation.KeyTime keyTime2) { throw null; }
+        public static implicit operator Windows.UI.Xaml.Media.Animation.KeyTime (System.TimeSpan timeSpan) { throw null; }
+        public static bool operator !=(Windows.UI.Xaml.Media.Animation.KeyTime keyTime1, Windows.UI.Xaml.Media.Animation.KeyTime keyTime2) { throw null; }
+        public override string ToString() { throw null; }
+    }
+    public partial struct RepeatBehavior : System.IFormattable
+    {
+        private int _dummyPrimitive;
+        public RepeatBehavior(double count) { throw null; }
+        public RepeatBehavior(System.TimeSpan duration) { throw null; }
+        public double Count { get { throw null; } set { } }
+        public System.TimeSpan Duration { get { throw null; } set { } }
+        public static Windows.UI.Xaml.Media.Animation.RepeatBehavior Forever { get { throw null; } }
+        public bool HasCount { get { throw null; } }
+        public bool HasDuration { get { throw null; } }
+        public Windows.UI.Xaml.Media.Animation.RepeatBehaviorType Type { get { throw null; } set { } }
+        public override bool Equals(object value) { throw null; }
+        public bool Equals(Windows.UI.Xaml.Media.Animation.RepeatBehavior repeatBehavior) { throw null; }
+        public static bool Equals(Windows.UI.Xaml.Media.Animation.RepeatBehavior repeatBehavior1, Windows.UI.Xaml.Media.Animation.RepeatBehavior repeatBehavior2) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(Windows.UI.Xaml.Media.Animation.RepeatBehavior repeatBehavior1, Windows.UI.Xaml.Media.Animation.RepeatBehavior repeatBehavior2) { throw null; }
+        public static bool operator !=(Windows.UI.Xaml.Media.Animation.RepeatBehavior repeatBehavior1, Windows.UI.Xaml.Media.Animation.RepeatBehavior repeatBehavior2) { throw null; }
+        string System.IFormattable.ToString(string format, System.IFormatProvider formatProvider) { throw null; }
+        public override string ToString() { throw null; }
+        public string ToString(System.IFormatProvider formatProvider) { throw null; }
+    }
+    public enum RepeatBehaviorType
+    {
+        Count = 0,
+        Duration = 1,
+        Forever = 2,
+    }
+}
+namespace Windows.UI.Xaml.Media.Media3D
+{
+    public partial struct Matrix3D : System.IFormattable
+    {
+        private int _dummyPrimitive;
+        public Matrix3D(double m11, double m12, double m13, double m14, double m21, double m22, double m23, double m24, double m31, double m32, double m33, double m34, double offsetX, double offsetY, double offsetZ, double m44) { throw null; }
+        public bool HasInverse { get { throw null; } }
+        public static Windows.UI.Xaml.Media.Media3D.Matrix3D Identity { get { throw null; } }
+        public bool IsIdentity { get { throw null; } }
+        public double M11 { get { throw null; } set { } }
+        public double M12 { get { throw null; } set { } }
+        public double M13 { get { throw null; } set { } }
+        public double M14 { get { throw null; } set { } }
+        public double M21 { get { throw null; } set { } }
+        public double M22 { get { throw null; } set { } }
+        public double M23 { get { throw null; } set { } }
+        public double M24 { get { throw null; } set { } }
+        public double M31 { get { throw null; } set { } }
+        public double M32 { get { throw null; } set { } }
+        public double M33 { get { throw null; } set { } }
+        public double M34 { get { throw null; } set { } }
+        public double M44 { get { throw null; } set { } }
+        public double OffsetX { get { throw null; } set { } }
+        public double OffsetY { get { throw null; } set { } }
+        public double OffsetZ { get { throw null; } set { } }
+        public override bool Equals(object o) { throw null; }
+        public bool Equals(Windows.UI.Xaml.Media.Media3D.Matrix3D value) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public void Invert() { }
+        public static bool operator ==(Windows.UI.Xaml.Media.Media3D.Matrix3D matrix1, Windows.UI.Xaml.Media.Media3D.Matrix3D matrix2) { throw null; }
+        public static bool operator !=(Windows.UI.Xaml.Media.Media3D.Matrix3D matrix1, Windows.UI.Xaml.Media.Media3D.Matrix3D matrix2) { throw null; }
+        public static Windows.UI.Xaml.Media.Media3D.Matrix3D operator *(Windows.UI.Xaml.Media.Media3D.Matrix3D matrix1, Windows.UI.Xaml.Media.Media3D.Matrix3D matrix2) { throw null; }
+        string System.IFormattable.ToString(string format, System.IFormatProvider provider) { throw null; }
+        public override string ToString() { throw null; }
+        public string ToString(System.IFormatProvider provider) { throw null; }
+    }
+}

--- a/ref/System.Runtime.WindowsRuntime.UI.Xaml.csproj
+++ b/ref/System.Runtime.WindowsRuntime.UI.Xaml.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <ProjectGuid>{AA1600B8-C4D3-42A9-A28A-04D0C8282566}</ProjectGuid>
+    <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release;uap-Debug;uap-Release</Configurations>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="System.Runtime.WindowsRuntime.UI.Xaml.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)'=='netcoreapp' or '$(TargetGroup)'=='uap'">
+    <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj" />
+    <ProjectReference Include="..\..\System.Runtime.WindowsRuntime\ref\System.Runtime.WindowsRuntime.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)'=='netstandard'">
+    <ProjectReference Include="..\..\System.Runtime.WindowsRuntime\ref\System.Runtime.WindowsRuntime.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Configurations.props
+++ b/src/Configurations.props
@@ -1,0 +1,14 @@
+<Project DefaultTargets="Build">
+  <PropertyGroup>
+    <PackageConfigurations>
+      netstandard1.1;
+      netstandard;
+      netcoreapp3.0-Windows_NT;
+    </PackageConfigurations>
+    <BuildConfigurations>
+      $(PackageConfigurations);
+      netcoreapp-Windows_NT;
+      uap-Windows_NT;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/src/Resources/Strings.resx
+++ b/src/Resources/Strings.resx
@@ -1,0 +1,81 @@
+﻿<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DirectUI_CornerRadius_InvalidMember" xml:space="preserve">
+    <value>Invalid value for {0} property on CornerRadius.</value>
+  </data>
+  <data name="DirectUI_InvalidArgument" xml:space="preserve">
+    <value>Invalid argument.</value>
+  </data>
+  <data name="ElementNotAvailable_Default" xml:space="preserve">
+    <value>The element is not available.</value>
+  </data>
+  <data name="ElementNotEnabled_Default" xml:space="preserve">
+    <value>The element is not enabled.</value>
+  </data>
+  <data name="XamlParse_Default" xml:space="preserve">
+    <value>XAML parsing failed.</value>
+  </data>
+  <data name="LayoutCycle_Default" xml:space="preserve">
+    <value>A cycle occurred while laying out the GUI.</value>
+  </data>
+  <data name="PlatformNotSupported_WindowsRuntime" xml:space="preserve">
+    <value>Windows Runtime (WinRT) is not supported on this platform.</value>
+  </data>
+</root>

--- a/src/Resources/System.Runtime.WindowsRuntime.UI.Xaml.rd.xml
+++ b/src/Resources/System.Runtime.WindowsRuntime.UI.Xaml.rd.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Library Name="System.Runtime.WindowsRuntime.UI.Xaml">
+    <!-- System.Private.Interop will create the following type through reflection, see GetMappingExceptionForHR for more info-->
+    <Type Name="Windows.UI.Xaml.Markup.XamlParseException" Dynamic="Required Public" />
+    <Type Name="Windows.UI.Xaml.Automation.ElementNotAvailableException" Dynamic="Required Public" />
+    <Type Name="Windows.UI.Xaml.Automation.ElementNotEnabledException" Dynamic="Required Public" />
+    <Type Name="Windows.UI.Xaml.LayoutCycleException" Dynamic="Required Public" />
+  </Library>
+</Directives>

--- a/src/System.Runtime.WindowsRuntime.UI.Xaml.csproj
+++ b/src/System.Runtime.WindowsRuntime.UI.Xaml.csproj
@@ -1,0 +1,47 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AssemblyName>System.Runtime.WindowsRuntime.UI.Xaml</AssemblyName>
+    <ProjectGuid>{263DA4F1-C3BC-4B43-98E7-9F38B419A131}</ProjectGuid>
+    <Configurations>netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netcoreapp3.0-Windows_NT-Debug;netcoreapp3.0-Windows_NT-Release;netstandard-Debug;netstandard-Release;netstandard1.1-Debug;netstandard1.1-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetGroup)' == 'netstandard1.1' or '$(TargetGroup)' == 'netstandard'">
+    <GeneratePlatformNotSupportedAssemblyMessage>SR.PlatformNotSupported_WindowsRuntime</GeneratePlatformNotSupportedAssemblyMessage>
+    <GeneratePlatformNotSupportedAssemblyWithGlobalPrefix>true</GeneratePlatformNotSupportedAssemblyWithGlobalPrefix>
+    <AssemblyVersion Condition="'$(TargetGroup)' == 'netstandard1.1'">4.0.1.0</AssemblyVersion>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the options -->
+  <ItemGroup Condition="'$(TargetsNetCoreApp)'=='true' or '$(TargetsUap)'=='true'">
+    <Compile Include="System\Runtime\InteropServices\HResults.cs" />
+    <Compile Include="System\Windows\CornerRadius.cs" />
+    <Compile Include="System\Windows\Duration.cs" />
+    <Compile Include="System\Windows\GridLength.cs" />
+    <Compile Include="System\Windows\Thickness.cs" />
+    <Compile Include="System\Windows\TokenizerHelper.cs" />
+    <Compile Include="System\Windows\LayoutCycleException.cs" />
+    <Compile Include="System\Windows\Automation\ElementNotAvailableException.cs" />
+    <Compile Include="System\Windows\Automation\ElementNotEnabledException.cs" />
+    <Compile Include="System\Windows\Controls\Primitives\GeneratorPosition.cs" />
+    <Compile Include="System\Windows\Markup\XamlParseException.cs" />
+    <Compile Include="System\Windows\Media\Matrix.cs" />
+    <Compile Include="System\Windows\Media\Animation\KeyTime.cs" />
+    <Compile Include="System\Windows\Media\Animation\RepeatBehavior.cs" />
+    <Compile Include="System\Windows\Media\Media3D\Matrix3D.cs" />
+    <Compile Include="$(CommonPath)\System\Runtime\InteropServices\WindowsRuntime\WindowsRuntimeImportAttribute.cs">
+      <Link>Common\System\Runtime\InteropServices\WindowsRuntime\WindowsRuntimeImportAttribute.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetCoreApp)'=='true' or '$(TargetsUap)'=='true'">
+    <Reference Include="System.Runtime" />
+    <Reference Include="System.Resources.ResourceManager" />
+    <Reference Include="System.Globalization" />
+    <Reference Include="System.Runtime.WindowsRuntime" />
+    <Reference Include="System.Runtime.Extensions" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetStandard)' == 'true'">
+    <Reference Include="System.Runtime" />
+    <Reference Include="System.IO" />
+    <Reference Include="System.Threading.Tasks" />
+    <Reference Include="System.Resources.ResourceManager" />
+    <Reference Include="System.Runtime.WindowsRuntime" />
+  </ItemGroup>
+</Project>

--- a/src/System/Runtime/InteropServices/HResults.cs
+++ b/src/System/Runtime/InteropServices/HResults.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace System.Runtime.InteropServices
+{
+    /// <summary>
+    /// mscorlib defines the HRESULT constants it uses in the internal class System.__HResults.
+    /// Since we cannot use that internal class in this assembly, we define the constants we need
+    /// in this class.
+    /// </summary>
+    internal static class HResults
+    {
+        internal const int E_XAMLPARSEFAILED = unchecked((int)0x802B000A);
+        internal const int E_LAYOUTCYCLE = unchecked((int)0x802B0014);
+        internal const int E_ELEMENTNOTENABLED = unchecked((int)0x802B001E);
+        internal const int E_ELEMENTNOTAVAILABLE = unchecked((int)0x802B001F);
+    }  // internal static sealed class HResults
+}  // namespace System.Runtime.InteropServices.WindowsRuntime
+
+// HResults.cs

--- a/src/System/Windows/Automation/ElementNotAvailableException.cs
+++ b/src/System/Windows/Automation/ElementNotAvailableException.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+/*=============================================================================
+**
+**
+**
+** Purpose: Exception class for representing Jupiter failures of some kind.
+** Corresponds with E_ELEMENTNOTAVAILABLE.
+**
+**
+=============================================================================*/
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.Serialization;
+
+namespace Windows.UI.Xaml.Automation
+{
+    [Serializable]
+    public class ElementNotAvailableException : Exception
+    {
+        public ElementNotAvailableException()
+            : base(SR.ElementNotAvailable_Default)
+        {
+            HResult = HResults.E_ELEMENTNOTAVAILABLE;
+        }
+
+        public ElementNotAvailableException(string message)
+            : base(message)
+        {
+            HResult = HResults.E_ELEMENTNOTAVAILABLE;
+        }
+
+        public ElementNotAvailableException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+            HResult = HResults.E_ELEMENTNOTAVAILABLE;
+        }
+
+        protected ElementNotAvailableException(SerializationInfo serializationInfo, StreamingContext streamingContext)
+            : base(serializationInfo, streamingContext)
+        {
+        }
+    }
+}

--- a/src/System/Windows/Automation/ElementNotEnabledException.cs
+++ b/src/System/Windows/Automation/ElementNotEnabledException.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+/*=============================================================================
+**
+**
+**
+** Purpose: Exception class for representing Jupiter failures of some kind.
+** Corresponds with E_ELEMENTNOTENABLED.
+**
+**
+=============================================================================*/
+using System;
+using System.Runtime.InteropServices;
+
+namespace Windows.UI.Xaml.Automation
+{
+    public class ElementNotEnabledException : Exception
+    {
+        public ElementNotEnabledException()
+            : base(SR.ElementNotEnabled_Default)
+        {
+            HResult = HResults.E_ELEMENTNOTENABLED;
+        }
+
+        public ElementNotEnabledException(string message)
+            : base(message)
+        {
+            HResult = HResults.E_ELEMENTNOTENABLED;
+        }
+
+        public ElementNotEnabledException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+            HResult = HResults.E_ELEMENTNOTENABLED;
+        }
+    }
+}

--- a/src/System/Windows/Controls/Primitives/GeneratorPosition.cs
+++ b/src/System/Windows/Controls/Primitives/GeneratorPosition.cs
@@ -1,0 +1,74 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+//
+
+//
+
+using System;
+using System.Globalization;
+using System.Runtime.InteropServices;
+
+#pragma warning disable 436   // Redefining types from Windows.Foundation
+
+namespace Windows.UI.Xaml.Controls.Primitives
+{
+    //
+    // GeneratorPosition is the managed projection of Windows.UI.Xaml.Controls.Primitives.GeneratorPosition.
+    // Any changes to the layout of this type must be exactly mirrored on the native WinRT side as well.
+    //
+    // Note that this type is owned by the Jupiter team.  Please contact them before making any
+    // changes here.
+    //
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct GeneratorPosition
+    {
+        private int _index;
+        private int _offset;
+
+        public int Index { get { return _index; } set { _index = value; } }
+        public int Offset { get { return _offset; } set { _offset = value; } }
+
+        public GeneratorPosition(int index, int offset)
+        {
+            _index = index;
+            _offset = offset;
+        }
+
+        public override int GetHashCode()
+        {
+            return _index.GetHashCode() + _offset.GetHashCode();
+        }
+
+        public override string ToString()
+        {
+            return string.Concat("GeneratorPosition (", _index.ToString(CultureInfo.InvariantCulture), ",", _offset.ToString(CultureInfo.InvariantCulture), ")");
+        }
+
+        public override bool Equals(object o)
+        {
+            if (o is GeneratorPosition)
+            {
+                GeneratorPosition that = (GeneratorPosition)o;
+                return _index == that._index &&
+                        _offset == that._offset;
+            }
+            return false;
+        }
+
+        public static bool operator ==(GeneratorPosition gp1, GeneratorPosition gp2)
+        {
+            return gp1._index == gp2._index &&
+                    gp1._offset == gp2._offset;
+        }
+
+        public static bool operator !=(GeneratorPosition gp1, GeneratorPosition gp2)
+        {
+            return !(gp1 == gp2);
+        }
+    }
+}
+
+#pragma warning restore 436

--- a/src/System/Windows/CornerRadius.cs
+++ b/src/System/Windows/CornerRadius.cs
@@ -1,0 +1,167 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+//
+
+//
+
+using System;
+using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Text;
+
+#pragma warning disable 436   // Redefining types from Windows.Foundation
+namespace Windows.UI.Xaml
+{
+    //
+    // CornerRadius is the managed projection of Windows.UI.Xaml.CornerRadius.  Any changes to the layout
+    // of this type must be exactly mirrored on the native WinRT side as well.
+    //
+    // Note that this type is owned by the Jupiter team.  Please contact them before making any
+    // changes here.
+    //
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct CornerRadius
+    {
+        private double _TopLeft;
+        private double _TopRight;
+        private double _BottomRight;
+        private double _BottomLeft;
+
+        public CornerRadius(double uniformRadius)
+        {
+            Validate(uniformRadius, uniformRadius, uniformRadius, uniformRadius);
+            _TopLeft = _TopRight = _BottomRight = _BottomLeft = uniformRadius;
+        }
+
+        public CornerRadius(double topLeft, double topRight, double bottomRight, double bottomLeft)
+        {
+            Validate(topLeft, topRight, bottomRight, bottomLeft);
+
+            _TopLeft = topLeft;
+            _TopRight = topRight;
+            _BottomRight = bottomRight;
+            _BottomLeft = bottomLeft;
+        }
+
+        private static void Validate(double topLeft, double topRight, double bottomRight, double bottomLeft)
+        {
+            if (topLeft < 0.0 || double.IsNaN(topLeft))
+                throw new ArgumentException(SR.Format(SR.DirectUI_CornerRadius_InvalidMember, "TopLeft"));
+
+            if (topRight < 0.0 || double.IsNaN(topRight))
+                throw new ArgumentException(SR.Format(SR.DirectUI_CornerRadius_InvalidMember, "TopRight"));
+
+            if (bottomRight < 0.0 || double.IsNaN(bottomRight))
+                throw new ArgumentException(SR.Format(SR.DirectUI_CornerRadius_InvalidMember, "BottomRight"));
+
+            if (bottomLeft < 0.0 || double.IsNaN(bottomLeft))
+                throw new ArgumentException(SR.Format(SR.DirectUI_CornerRadius_InvalidMember, "BottomLeft"));
+        }
+
+        public override string ToString()
+        {
+            return ToString(CultureInfo.InvariantCulture);
+        }
+
+        internal string ToString(CultureInfo cultureInfo)
+        {
+            char listSeparator = TokenizerHelper.GetNumericListSeparator(cultureInfo);
+
+            // Initial capacity [64] is an estimate based on a sum of:
+            // 48 = 4x double (twelve digits is generous for the range of values likely)
+            //  8 = 4x Unit Type string (approx two characters)
+            //  4 = 4x separator characters
+            StringBuilder sb = new StringBuilder(64);
+
+            sb.Append(InternalToString(_TopLeft, cultureInfo));
+            sb.Append(listSeparator);
+            sb.Append(InternalToString(_TopRight, cultureInfo));
+            sb.Append(listSeparator);
+            sb.Append(InternalToString(_BottomRight, cultureInfo));
+            sb.Append(listSeparator);
+            sb.Append(InternalToString(_BottomLeft, cultureInfo));
+            return sb.ToString();
+        }
+
+        internal string InternalToString(double l, CultureInfo cultureInfo)
+        {
+            if (double.IsNaN(l)) return "Auto";
+            return Convert.ToString(l, cultureInfo);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is CornerRadius)
+            {
+                CornerRadius otherObj = (CornerRadius)obj;
+                return (this == otherObj);
+            }
+            return (false);
+        }
+
+        public bool Equals(CornerRadius cornerRadius)
+        {
+            return (this == cornerRadius);
+        }
+
+        public override int GetHashCode()
+        {
+            return _TopLeft.GetHashCode() ^ _TopRight.GetHashCode() ^ _BottomLeft.GetHashCode() ^ _BottomRight.GetHashCode();
+        }
+
+        public static bool operator ==(CornerRadius cr1, CornerRadius cr2)
+        {
+            return cr1._TopLeft == cr2._TopLeft && cr1._TopRight == cr2._TopRight && cr1._BottomRight == cr2._BottomRight && cr1._BottomLeft == cr2._BottomLeft;
+        }
+
+        public static bool operator !=(CornerRadius cr1, CornerRadius cr2)
+        {
+            return (!(cr1 == cr2));
+        }
+
+        public double TopLeft
+        {
+            get { return _TopLeft; }
+            set
+            {
+                Validate(value, 0, 0, 0);
+                _TopLeft = value;
+            }
+        }
+
+        public double TopRight
+        {
+            get { return _TopRight; }
+            set
+            {
+                Validate(0, value, 0, 0);
+                _TopRight = value;
+            }
+        }
+
+        public double BottomRight
+        {
+            get { return _BottomRight; }
+            set
+            {
+                Validate(0, 0, value, 0);
+                _BottomRight = value;
+            }
+        }
+
+        public double BottomLeft
+        {
+            get { return _BottomLeft; }
+            set
+            {
+                Validate(0, 0, 0, value);
+                _BottomLeft = value;
+            }
+        }
+    }
+}
+
+#pragma warning restore 436

--- a/src/System/Windows/Duration.cs
+++ b/src/System/Windows/Duration.cs
@@ -1,0 +1,321 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+//
+
+//
+
+using System;
+using System.Runtime.InteropServices;
+
+#pragma warning disable 436   // Redefining types from Windows.Foundation
+
+namespace Windows.UI.Xaml
+{
+    //
+    // Duration is the managed projection of Windows.UI.Xaml.Duration.  Any changes to the layout
+    // of this type must be exactly mirrored on the native WinRT side as well.
+    //
+    // DurationType is the managed projection of Windows.UI.Xaml.DurationType. Any changes to this
+    // enumeration must be exactly mirrored on the native WinRT side as well.
+    //
+    // Note that these types are owned by the Jupiter team.  Please contact them before making any
+    // changes here.
+    //
+
+    public enum DurationType
+    {
+        Automatic,
+        TimeSpan,
+        Forever
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Duration
+    {
+        private TimeSpan _timeSpan;
+        private DurationType _durationType;
+
+        public Duration(TimeSpan timeSpan)
+        {
+            _durationType = DurationType.TimeSpan;
+            _timeSpan = timeSpan;
+        }
+
+        public static implicit operator Duration(TimeSpan timeSpan)
+        {
+            return new Duration(timeSpan);
+        }
+
+        public static Duration operator +(Duration t1, Duration t2)
+        {
+            if (t1.HasTimeSpan && t2.HasTimeSpan)
+            {
+                return new Duration(t1._timeSpan + t2._timeSpan);
+            }
+            else if (t1._durationType != DurationType.Automatic
+                     && t2._durationType != DurationType.Automatic)
+            {
+                return Duration.Forever;
+            }
+            else
+            {
+                // Automatic + anything is Automatic
+                return Duration.Automatic;
+            }
+        }
+
+        public static Duration operator -(Duration t1, Duration t2)
+        {
+            if (t1.HasTimeSpan && t2.HasTimeSpan)
+            {
+                return new Duration(t1._timeSpan - t2._timeSpan);
+            }
+            else if (t1._durationType == DurationType.Forever
+                     && t2.HasTimeSpan)
+            {
+                return Duration.Forever;
+            }
+            else
+            {
+                return Duration.Automatic;
+            }
+        }
+
+        public static bool operator ==(Duration t1, Duration t2)
+        {
+            return t1.Equals(t2);
+        }
+
+        public static bool operator !=(Duration t1, Duration t2)
+        {
+            return !(t1.Equals(t2));
+        }
+
+        public static bool operator >(Duration t1, Duration t2)
+        {
+            if (t1.HasTimeSpan && t2.HasTimeSpan)
+            {
+                return t1._timeSpan > t2._timeSpan;
+            }
+            else if (t1.HasTimeSpan && t2._durationType == DurationType.Forever)
+            {
+                return false;
+            }
+            else if (t1._durationType == DurationType.Forever && t2.HasTimeSpan)
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public static bool operator >=(Duration t1, Duration t2)
+        {
+            if (t1._durationType == DurationType.Automatic && t2._durationType == DurationType.Automatic)
+            {
+                return true;
+            }
+            else if (t1._durationType == DurationType.Automatic || t2._durationType == DurationType.Automatic)
+            {
+                return false;
+            }
+            else
+            {
+                return !(t1 < t2);
+            }
+        }
+
+        public static bool operator <(Duration t1, Duration t2)
+        {
+            if (t1.HasTimeSpan && t2.HasTimeSpan)
+            {
+                return t1._timeSpan < t2._timeSpan;
+            }
+            else if (t1.HasTimeSpan && t2._durationType == DurationType.Forever)
+            {
+                return true;
+            }
+            else if (t1._durationType == DurationType.Forever && t2.HasTimeSpan)
+            {
+                return false;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public static bool operator <=(Duration t1, Duration t2)
+        {
+            if (t1._durationType == DurationType.Automatic && t2._durationType == DurationType.Automatic)
+            {
+                return true;
+            }
+            else if (t1._durationType == DurationType.Automatic || t2._durationType == DurationType.Automatic)
+            {
+                return false;
+            }
+            else
+            {
+                return !(t1 > t2);
+            }
+        }
+
+        public static int Compare(Duration t1, Duration t2)
+        {
+            if (t1._durationType == DurationType.Automatic)
+            {
+                if (t2._durationType == DurationType.Automatic)
+                {
+                    return 0;
+                }
+                else
+                {
+                    return -1;
+                }
+            }
+            else if (t2._durationType == DurationType.Automatic)
+            {
+                return 1;
+            }
+            else
+            {
+                if (t1 < t2)
+                {
+                    return -1;
+                }
+                else if (t1 > t2)
+                {
+                    return 1;
+                }
+                else
+                {
+                    return 0;
+                }
+            }
+        }
+
+        public static Duration operator +(Duration duration)
+        {
+            return duration;
+        }
+
+        public bool HasTimeSpan
+        {
+            get
+            {
+                return (_durationType == DurationType.TimeSpan);
+            }
+        }
+
+        public static Duration Automatic
+        {
+            get
+            {
+                Duration duration = new Duration();
+                duration._durationType = DurationType.Automatic;
+
+                return duration;
+            }
+        }
+
+        public static Duration Forever
+        {
+            get
+            {
+                Duration duration = new Duration();
+                duration._durationType = DurationType.Forever;
+
+                return duration;
+            }
+        }
+
+        public TimeSpan TimeSpan
+        {
+            get
+            {
+                if (HasTimeSpan)
+                {
+                    return _timeSpan;
+                }
+                else
+                {
+                    throw new InvalidOperationException();
+                }
+            }
+        }
+
+        public Duration Add(Duration duration)
+        {
+            return this + duration;
+        }
+
+        public override bool Equals(object value)
+        {
+            return value is Duration && Equals((Duration)value);
+        }
+
+        public bool Equals(Duration duration)
+        {
+            if (HasTimeSpan)
+            {
+                if (duration.HasTimeSpan)
+                {
+                    return _timeSpan == duration._timeSpan;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                return _durationType == duration._durationType;
+            }
+        }
+
+        public static bool Equals(Duration t1, Duration t2)
+        {
+            return t1.Equals(t2);
+        }
+
+        public override int GetHashCode()
+        {
+            if (HasTimeSpan)
+            {
+                return _timeSpan.GetHashCode();
+            }
+            else
+            {
+                return _durationType.GetHashCode() + 17;
+            }
+        }
+
+        public Duration Subtract(Duration duration)
+        {
+            return this - duration;
+        }
+
+        public override string ToString()
+        {
+            if (HasTimeSpan)
+            {
+                return _timeSpan.ToString(); // "00"; //TypeDescriptor.GetConverter(_timeSpan).ConvertToString(_timeSpan);
+            }
+            else if (_durationType == DurationType.Forever)
+            {
+                return "Forever";
+            }
+            else // IsAutomatic
+            {
+                return "Automatic";
+            }
+        }
+    }
+}
+
+#pragma warning restore 436

--- a/src/System/Windows/GridLength.cs
+++ b/src/System/Windows/GridLength.cs
@@ -1,0 +1,141 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+//
+
+//
+
+using System;
+using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Text;
+
+#pragma warning disable 436   // Redefining types from Windows.Foundation
+namespace Windows.UI.Xaml
+{
+    //
+    // GridLength is the managed projection of Windows.UI.Xaml.GridLength.  Any changes to the layout
+    // of this type must be exactly mirrored on the native WinRT side as well.
+    //
+    // GridUnitType is the managed projection of Windows.UI.Xaml.GridUnitType.  Any changes to this
+    // enumeration must be exactly mirrored on the native WinRT side as well.
+    //
+    // Note that these types are owned by the Jupiter team.  Please contact them before making any
+    // changes here.
+    //
+    public enum GridUnitType
+    {
+        Auto = 0,
+        Pixel,
+        Star,
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct GridLength
+    {
+        private double _unitValue;
+        private GridUnitType _unitType;
+
+        private const double Default = 1.0;
+        private static readonly GridLength s_auto = new GridLength(Default, GridUnitType.Auto);
+
+        public GridLength(double pixels)
+            : this(pixels, GridUnitType.Pixel)
+        {
+        }
+
+        public GridLength(double value, GridUnitType type)
+        {
+            if (!double.IsFinite(value) || value < 0.0)
+            {
+                throw new ArgumentException(SR.DirectUI_InvalidArgument, nameof(value));
+            }
+            if (type != GridUnitType.Auto && type != GridUnitType.Pixel && type != GridUnitType.Star)
+            {
+                throw new ArgumentException(SR.DirectUI_InvalidArgument, nameof(type));
+            }
+
+            _unitValue = (type == GridUnitType.Auto) ? Default : value;
+            _unitType = type;
+        }
+
+
+        public double Value { get { return ((_unitType == GridUnitType.Auto) ? s_auto._unitValue : _unitValue); } }
+        public GridUnitType GridUnitType { get { return (_unitType); } }
+
+
+        public bool IsAbsolute { get { return (_unitType == GridUnitType.Pixel); } }
+        public bool IsAuto { get { return (_unitType == GridUnitType.Auto); } }
+        public bool IsStar { get { return (_unitType == GridUnitType.Star); } }
+
+        public static GridLength Auto
+        {
+            get { return (s_auto); }
+        }
+
+
+        public static bool operator ==(GridLength gl1, GridLength gl2)
+        {
+            return (gl1.GridUnitType == gl2.GridUnitType
+                    && gl1.Value == gl2.Value);
+        }
+
+        public static bool operator !=(GridLength gl1, GridLength gl2)
+        {
+            return (gl1.GridUnitType != gl2.GridUnitType
+                    || gl1.Value != gl2.Value);
+        }
+
+        override public bool Equals(object oCompare)
+        {
+            if (oCompare is GridLength)
+            {
+                GridLength l = (GridLength)oCompare;
+                return (this == l);
+            }
+            else
+                return false;
+        }
+
+        public bool Equals(GridLength gridLength)
+        {
+            return (this == gridLength);
+        }
+
+        public override int GetHashCode()
+        {
+            return ((int)_unitValue + (int)_unitType);
+        }
+
+        public override string ToString()
+        {
+            return this.ToString(CultureInfo.InvariantCulture);
+        }
+
+        internal string ToString(CultureInfo cultureInfo)
+        {
+            char listSeparator = TokenizerHelper.GetNumericListSeparator(cultureInfo);
+
+            // Initial capacity [64] is an estimate based on a sum of:
+            // 12 = 1x double (twelve digits is generous for the range of values likely)
+            //  8 = 4x Unit Type string (approx two characters)
+            //  2 = 2x separator characters
+
+            if (_unitType == GridUnitType.Auto)
+            {
+                return "Auto";
+            }
+            else if (_unitType == GridUnitType.Pixel)
+            {
+                return Convert.ToString(_unitValue, cultureInfo);
+            }
+            else
+            {
+                return Convert.ToString(_unitValue, cultureInfo) + "*";
+            }
+        }
+    }
+}
+
+#pragma warning restore 436

--- a/src/System/Windows/LayoutCycleException.cs
+++ b/src/System/Windows/LayoutCycleException.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+/*=============================================================================
+**
+**
+**
+** Purpose: Exception class for representing Jupiter GUI layout problems,
+** corresponding with E_LAYOUTCYCLE.
+**
+**
+=============================================================================*/
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.Serialization;
+
+namespace Windows.UI.Xaml
+{
+    [Serializable]
+    public class LayoutCycleException : Exception
+    {
+        public LayoutCycleException()
+            : base(SR.LayoutCycle_Default)
+        {
+            HResult = HResults.E_LAYOUTCYCLE;
+        }
+
+        public LayoutCycleException(string message)
+            : base(message)
+        {
+            HResult = HResults.E_LAYOUTCYCLE;
+        }
+
+        public LayoutCycleException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+            HResult = HResults.E_LAYOUTCYCLE;
+        }
+
+        protected LayoutCycleException(SerializationInfo serializationInfo, StreamingContext streamingContext)
+            : base (serializationInfo, streamingContext)
+        {
+        }
+    }
+}

--- a/src/System/Windows/Markup/XamlParseException.cs
+++ b/src/System/Windows/Markup/XamlParseException.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+/*=============================================================================
+**
+**
+**
+** Purpose: Exception class for representing Jupiter XAML parsing failures,
+** corresponding with E_XAMLPARSEFAILED.
+**
+**
+=============================================================================*/
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Windows.UI.Xaml.Markup
+{
+    public class XamlParseException : Exception
+    {
+        public XamlParseException()
+            : base(SR.XamlParse_Default)
+        {
+            HResult = HResults.E_XAMLPARSEFAILED;
+        }
+
+        public XamlParseException(string message)
+            : base(message)
+        {
+            HResult = HResults.E_XAMLPARSEFAILED;
+        }
+
+        public XamlParseException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+            HResult = HResults.E_XAMLPARSEFAILED;
+        }
+    }
+}

--- a/src/System/Windows/Media/Animation/KeyTime.cs
+++ b/src/System/Windows/Media/Animation/KeyTime.cs
@@ -1,0 +1,93 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+//
+
+//
+
+using System;
+using System.Runtime.InteropServices;
+
+#pragma warning disable 436   // Redefining types from Windows.Foundation
+
+namespace Windows.UI.Xaml.Media.Animation
+{
+    //
+    // KeyTime is the managed projection of Windows.UI.Xaml.Media.Animation.KeyTime.
+    // Any changes to the layout of this type must be exactly mirrored on the native WinRT side as well.
+    //
+    // Note that these types are owned by the Jupiter team.  Please contact them before making any
+    // changes here.
+    //
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct KeyTime
+    {
+        private TimeSpan _timeSpan;
+
+        public static KeyTime FromTimeSpan(TimeSpan timeSpan)
+        {
+            if (timeSpan < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(timeSpan));
+            }
+
+            KeyTime keyTime = new KeyTime();
+
+            keyTime._timeSpan = timeSpan;
+
+            return keyTime;
+        }
+
+        public static bool Equals(KeyTime keyTime1, KeyTime keyTime2)
+        {
+            return (keyTime1._timeSpan == keyTime2._timeSpan);
+        }
+
+        public static bool operator ==(KeyTime keyTime1, KeyTime keyTime2)
+        {
+            return KeyTime.Equals(keyTime1, keyTime2);
+        }
+
+        public static bool operator !=(KeyTime keyTime1, KeyTime keyTime2)
+        {
+            return !KeyTime.Equals(keyTime1, keyTime2);
+        }
+
+        public bool Equals(KeyTime value)
+        {
+            return KeyTime.Equals(this, value);
+        }
+
+        public override bool Equals(object value)
+        {
+            return value is KeyTime && this == (KeyTime)value;
+        }
+
+        public override int GetHashCode()
+        {
+            return _timeSpan.GetHashCode();
+        }
+
+        public override string ToString()
+        {
+            return _timeSpan.ToString();
+        }
+
+        public static implicit operator KeyTime(TimeSpan timeSpan)
+        {
+            return KeyTime.FromTimeSpan(timeSpan);
+        }
+
+        public TimeSpan TimeSpan
+        {
+            get
+            {
+                return _timeSpan;
+            }
+        }
+    }
+}
+
+#pragma warning restore 436

--- a/src/System/Windows/Media/Animation/RepeatBehavior.cs
+++ b/src/System/Windows/Media/Animation/RepeatBehavior.cs
@@ -1,0 +1,234 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+//
+
+//
+
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+#pragma warning disable 436   // Redefining types from Windows.Foundation
+
+namespace Windows.UI.Xaml.Media.Animation
+{
+    //
+    // RepeatBehavior is the managed projection of Windows.UI.Xaml.Media.Animation.RepeatBehavior.
+    // Any changes to the layout of this type must be exactly mirrored on the native WinRT side as well.
+    //
+    // RepeatBehaviorType is the managed projection of Windows.UI.Xaml.Media.Animation.RepeatBehaviorType.
+    // Any changes to this enumeration must be exactly mirrored on the native WinRT side as well.
+    //
+    // Note that these types are owned by the Jupiter team.  Please contact them before making any
+    // changes here.
+    //
+
+    public enum RepeatBehaviorType
+    {
+        Count,
+        Duration,
+        Forever
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RepeatBehavior : IFormattable
+    {
+        private double _Count;
+        private TimeSpan _Duration;
+        private RepeatBehaviorType _Type;
+
+        public RepeatBehavior(double count)
+        {
+            if (!double.IsFinite(count) || count < 0.0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
+
+            _Duration = new TimeSpan(0);
+            _Count = count;
+            _Type = RepeatBehaviorType.Count;
+        }
+
+        public RepeatBehavior(TimeSpan duration)
+        {
+            if (duration < new TimeSpan(0))
+            {
+                throw new ArgumentOutOfRangeException(nameof(duration));
+            }
+
+            _Duration = duration;
+            _Count = 0.0;
+            _Type = RepeatBehaviorType.Duration;
+        }
+
+        public static RepeatBehavior Forever
+        {
+            get
+            {
+                RepeatBehavior forever = new RepeatBehavior();
+                forever.Type = RepeatBehaviorType.Forever;
+
+                return forever;
+            }
+        }
+
+        public bool HasCount
+        {
+            get
+            {
+                return Type == RepeatBehaviorType.Count;
+            }
+        }
+
+        public bool HasDuration
+        {
+            get
+            {
+                return Type == RepeatBehaviorType.Duration;
+            }
+        }
+
+        public double Count
+        {
+            get { return _Count; }
+            set { _Count = value; }
+        }
+
+        public TimeSpan Duration
+        {
+            get { return _Duration; }
+            set { _Duration = value; }
+        }
+
+        public RepeatBehaviorType Type
+        {
+            get { return _Type; }
+            set { _Type = value; }
+        }
+
+        public override string ToString()
+        {
+            return InternalToString(null, null);
+        }
+
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return InternalToString(null, formatProvider);
+        }
+
+        string IFormattable.ToString(string format, IFormatProvider formatProvider)
+        {
+            return InternalToString(format, formatProvider);
+        }
+
+        internal string InternalToString(string format, IFormatProvider formatProvider)
+        {
+            switch (_Type)
+            {
+                case RepeatBehaviorType.Forever:
+
+                    return "Forever";
+
+                case RepeatBehaviorType.Count:
+
+                    StringBuilder sb = new StringBuilder();
+
+                    sb.AppendFormat(
+                        formatProvider,
+                        "{0:" + format + "}x",
+                        _Count);
+
+                    return sb.ToString();
+
+                case RepeatBehaviorType.Duration:
+
+                    return _Duration.ToString();
+
+                default:
+                    return null;
+            }
+        }
+
+        public override bool Equals(object value)
+        {
+            if (value is RepeatBehavior)
+            {
+                return this.Equals((RepeatBehavior)value);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public bool Equals(RepeatBehavior repeatBehavior)
+        {
+            if (_Type == repeatBehavior._Type)
+            {
+                switch (_Type)
+                {
+                    case RepeatBehaviorType.Forever:
+
+                        return true;
+
+                    case RepeatBehaviorType.Count:
+
+                        return _Count == repeatBehavior._Count;
+
+                    case RepeatBehaviorType.Duration:
+
+                        return _Duration == repeatBehavior._Duration;
+
+                    default:
+                        return false;
+                }
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public static bool Equals(RepeatBehavior repeatBehavior1, RepeatBehavior repeatBehavior2)
+        {
+            return repeatBehavior1.Equals(repeatBehavior2);
+        }
+
+        public override int GetHashCode()
+        {
+            switch (_Type)
+            {
+                case RepeatBehaviorType.Count:
+
+                    return _Count.GetHashCode();
+
+                case RepeatBehaviorType.Duration:
+
+                    return _Duration.GetHashCode();
+
+                case RepeatBehaviorType.Forever:
+
+                    // We try to choose an unlikely hash code value for Forever.
+                    // All Forevers need to return the same hash code value.
+                    return int.MaxValue - 42;
+
+                default:
+                    return base.GetHashCode();
+            }
+        }
+
+        public static bool operator ==(RepeatBehavior repeatBehavior1, RepeatBehavior repeatBehavior2)
+        {
+            return repeatBehavior1.Equals(repeatBehavior2);
+        }
+
+        public static bool operator !=(RepeatBehavior repeatBehavior1, RepeatBehavior repeatBehavior2)
+        {
+            return !repeatBehavior1.Equals(repeatBehavior2);
+        }
+    }
+}
+
+#pragma warning restore 436

--- a/src/System/Windows/Media/Matrix.cs
+++ b/src/System/Windows/Media/Matrix.cs
@@ -1,0 +1,266 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+//
+
+//
+
+using System;
+using System.Runtime.InteropServices;
+using Point = Windows.Foundation.Point;
+
+using Windows.Foundation;
+
+#pragma warning disable 436   // Redefining types from Windows.Foundation
+
+namespace Windows.UI.Xaml.Media
+{
+    //
+    // Matrix is the managed projection of Windows.UI.Xaml.Media.Matrix. Any changes to the layout of
+    // this type must be exactly mirrored on the native WinRT side as well.
+    //
+    // Note that this type is owned by the Jupiter team.  Please contact them before making any
+    // changes here.
+    //
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix : IFormattable
+    {
+        public Matrix(double m11, double m12,
+                      double m21, double m22,
+                      double offsetX, double offsetY)
+        {
+            _m11 = m11;
+            _m12 = m12;
+            _m21 = m21;
+            _m22 = m22;
+            _offsetX = offsetX;
+            _offsetY = offsetY;
+        }
+
+        // the transform is identity by default
+        private static Matrix s_identity = CreateIdentity();
+
+        public double M11
+        {
+            get
+            {
+                return _m11;
+            }
+            set
+            {
+                _m11 = value;
+            }
+        }
+
+        public double M12
+        {
+            get
+            {
+                return _m12;
+            }
+            set
+            {
+                _m12 = value;
+            }
+        }
+
+        public double M21
+        {
+            get
+            {
+                return _m21;
+            }
+            set
+            {
+                _m21 = value;
+            }
+        }
+
+        public double M22
+        {
+            get
+            {
+                return _m22;
+            }
+            set
+            {
+                _m22 = value;
+            }
+        }
+
+        public double OffsetX
+        {
+            get
+            {
+                return _offsetX;
+            }
+            set
+            {
+                _offsetX = value;
+            }
+        }
+
+        public double OffsetY
+        {
+            get
+            {
+                return _offsetY;
+            }
+            set
+            {
+                _offsetY = value;
+            }
+        }
+
+        public static Matrix Identity
+        {
+            get
+            {
+                return s_identity;
+            }
+        }
+
+        public bool IsIdentity
+        {
+            get
+            {
+                return (_m11 == 1 && _m12 == 0 && _m21 == 0 && _m22 == 1 && _offsetX == 0 && _offsetY == 0);
+            }
+        }
+
+        public override string ToString()
+        {
+            // Delegate to the internal method which implements all ToString calls.
+            return ConvertToString(null /* format string */, null /* format provider */);
+        }
+
+        public string ToString(IFormatProvider provider)
+        {
+            // Delegate to the internal method which implements all ToString calls.
+            return ConvertToString(null /* format string */, provider);
+        }
+
+        string IFormattable.ToString(string format, IFormatProvider provider)
+        {
+            // Delegate to the internal method which implements all ToString calls.
+            return ConvertToString(format, provider);
+        }
+
+        private string ConvertToString(string format, IFormatProvider provider)
+        {
+            if (IsIdentity)
+            {
+                return "Identity";
+            }
+
+            // Helper to get the numeric list separator for a given culture.
+            char separator = TokenizerHelper.GetNumericListSeparator(provider);
+            return string.Format(provider,
+                                 "{1:" + format + "}{0}{2:" + format + "}{0}{3:" + format + "}{0}{4:" + format + "}{0}{5:" + format + "}{0}{6:" + format + "}",
+                                 separator,
+                                 _m11,
+                                 _m12,
+                                 _m21,
+                                 _m22,
+                                 _offsetX,
+                                 _offsetY);
+        }
+
+        public Point Transform(Point point)
+        {
+            float x = (float)point.X;
+            float y = (float)point.Y;
+            this.MultiplyPoint(ref x, ref y);
+            Point point2 = new Point(x, y);
+            return point2;
+        }
+
+        public override int GetHashCode()
+        {
+            // Perform field-by-field XOR of HashCodes
+            return M11.GetHashCode() ^
+                   M12.GetHashCode() ^
+                   M21.GetHashCode() ^
+                   M22.GetHashCode() ^
+                   OffsetX.GetHashCode() ^
+                   OffsetY.GetHashCode();
+        }
+
+        public override bool Equals(object o)
+        {
+            return o is Matrix && Matrix.Equals(this, (Matrix)o);
+        }
+
+        public bool Equals(Matrix value)
+        {
+            return Matrix.Equals(this, value);
+        }
+
+        public static bool operator ==(Matrix matrix1, Matrix matrix2)
+        {
+            return matrix1.M11 == matrix2.M11 &&
+                   matrix1.M12 == matrix2.M12 &&
+                   matrix1.M21 == matrix2.M21 &&
+                   matrix1.M22 == matrix2.M22 &&
+                   matrix1.OffsetX == matrix2.OffsetX &&
+                   matrix1.OffsetY == matrix2.OffsetY;
+        }
+
+        public static bool operator !=(Matrix matrix1, Matrix matrix2)
+        {
+            return !(matrix1 == matrix2);
+        }
+
+        private static Matrix CreateIdentity()
+        {
+            Matrix matrix = new Matrix();
+            matrix.SetMatrix(1, 0,
+                             0, 1,
+                             0, 0);
+            return matrix;
+        }
+
+        private void SetMatrix(double m11, double m12,
+                               double m21, double m22,
+                               double offsetX, double offsetY)
+        {
+            _m11 = m11;
+            _m12 = m12;
+            _m21 = m21;
+            _m22 = m22;
+            _offsetX = offsetX;
+            _offsetY = offsetY;
+        }
+
+        private void MultiplyPoint(ref float x, ref float y)
+        {
+            double num = (y * _m21) + _offsetX;
+            double num2 = (x * _m12) + _offsetY;
+            x *= (float)_m11;
+            x += (float)num;
+            y *= (float)_m22;
+            y += (float)num2;
+        }
+
+        private static bool Equals(Matrix matrix1, Matrix matrix2)
+        {
+            return matrix1.M11.Equals(matrix2.M11) &&
+                   matrix1.M12.Equals(matrix2.M12) &&
+                   matrix1.M21.Equals(matrix2.M21) &&
+                   matrix1.M22.Equals(matrix2.M22) &&
+                   matrix1.OffsetX.Equals(matrix2.OffsetX) &&
+                   matrix1.OffsetY.Equals(matrix2.OffsetY);
+        }
+
+        private double _m11;
+        private double _m12;
+        private double _m21;
+        private double _m22;
+        private double _offsetX;
+        private double _offsetY;
+    }
+}
+
+#pragma warning restore 436

--- a/src/System/Windows/Media/Media3D/Matrix3D.cs
+++ b/src/System/Windows/Media/Media3D/Matrix3D.cs
@@ -1,0 +1,712 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+//
+
+//
+
+using System;
+using System.Runtime.InteropServices;
+
+using Windows.Foundation;
+
+#pragma warning disable 436   // Redefining types from Windows.Foundation
+
+namespace Windows.UI.Xaml.Media.Media3D
+{
+    //
+    // Matrix3D is the managed projection of Windows.UI.Xaml.Media.Media3D.Matrix3D. Any
+    // changes to the layout of this type must be exactly mirrored on the native WinRT side as well.
+    //
+    // Note that this type is owned by the Jupiter team.  Please contact them before making any
+    // changes here.
+    //
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix3D : IFormattable
+    {
+        // Assuming this matrix has fourth column of 0,0,0,1 and isn't identity this function:
+        // Returns false if HasInverse is false, otherwise inverts the matrix.
+        private bool NormalizedAffineInvert()
+        {
+            double z20 = _m12 * _m23 - _m22 * _m13;
+            double z10 = _m32 * _m13 - _m12 * _m33;
+            double z00 = _m22 * _m33 - _m32 * _m23;
+            double det = _m31 * z20 + _m21 * z10 + _m11 * z00;
+
+            if (IsZero(det))
+            {
+                return false;
+            }
+
+            // Compute 3x3 non-zero cofactors for the 2nd column
+            double z21 = _m21 * _m13 - _m11 * _m23;
+            double z11 = _m11 * _m33 - _m31 * _m13;
+            double z01 = _m31 * _m23 - _m21 * _m33;
+
+            // Compute all six 2x2 determinants of 1st two columns
+            double y01 = _m11 * _m22 - _m21 * _m12;
+            double y02 = _m11 * _m32 - _m31 * _m12;
+            double y03 = _m11 * _offsetY - _offsetX * _m12;
+            double y12 = _m21 * _m32 - _m31 * _m22;
+            double y13 = _m21 * _offsetY - _offsetX * _m22;
+            double y23 = _m31 * _offsetY - _offsetX * _m32;
+
+            // Compute all non-zero and non-one 3x3 cofactors for 2nd
+            // two columns
+            double z23 = _m23 * y03 - _offsetZ * y01 - _m13 * y13;
+            double z13 = _m13 * y23 - _m33 * y03 + _offsetZ * y02;
+            double z03 = _m33 * y13 - _offsetZ * y12 - _m23 * y23;
+            double z22 = y01;
+            double z12 = -y02;
+            double z02 = y12;
+
+            double rcp = 1.0 / det;
+
+            // Multiply all 3x3 cofactors by reciprocal & transpose
+            _m11 = (z00 * rcp);
+            _m12 = (z10 * rcp);
+            _m13 = (z20 * rcp);
+
+            _m21 = (z01 * rcp);
+            _m22 = (z11 * rcp);
+            _m23 = (z21 * rcp);
+
+            _m31 = (z02 * rcp);
+            _m32 = (z12 * rcp);
+            _m33 = (z22 * rcp);
+
+            _offsetX = (z03 * rcp);
+            _offsetY = (z13 * rcp);
+            _offsetZ = (z23 * rcp);
+
+            return true;
+        }
+
+        // RETURNS true if has inverse & invert was done.  Otherwise returns false & leaves matrix unchanged.
+        private bool InvertCore()
+        {
+            if (IsAffine)
+            {
+                return NormalizedAffineInvert();
+            }
+
+            // compute all six 2x2 determinants of 2nd two columns
+            double y01 = _m13 * _m24 - _m23 * _m14;
+            double y02 = _m13 * _m34 - _m33 * _m14;
+            double y03 = _m13 * _m44 - _offsetZ * _m14;
+            double y12 = _m23 * _m34 - _m33 * _m24;
+            double y13 = _m23 * _m44 - _offsetZ * _m24;
+            double y23 = _m33 * _m44 - _offsetZ * _m34;
+
+            // Compute 3x3 cofactors for 1st the column
+            double z30 = _m22 * y02 - _m32 * y01 - _m12 * y12;
+            double z20 = _m12 * y13 - _m22 * y03 + _offsetY * y01;
+            double z10 = _m32 * y03 - _offsetY * y02 - _m12 * y23;
+            double z00 = _m22 * y23 - _m32 * y13 + _offsetY * y12;
+
+            // Compute 4x4 determinant
+            double det = _offsetX * z30 + _m31 * z20 + _m21 * z10 + _m11 * z00;
+
+            if (IsZero(det))
+            {
+                return false;
+            }
+
+            // Compute 3x3 cofactors for the 2nd column
+            double z31 = _m11 * y12 - _m21 * y02 + _m31 * y01;
+            double z21 = _m21 * y03 - _offsetX * y01 - _m11 * y13;
+            double z11 = _m11 * y23 - _m31 * y03 + _offsetX * y02;
+            double z01 = _m31 * y13 - _offsetX * y12 - _m21 * y23;
+
+            // Compute all six 2x2 determinants of 1st two columns
+            y01 = _m11 * _m22 - _m21 * _m12;
+            y02 = _m11 * _m32 - _m31 * _m12;
+            y03 = _m11 * _offsetY - _offsetX * _m12;
+            y12 = _m21 * _m32 - _m31 * _m22;
+            y13 = _m21 * _offsetY - _offsetX * _m22;
+            y23 = _m31 * _offsetY - _offsetX * _m32;
+
+            // Compute all 3x3 cofactors for 2nd two columns
+            double z33 = _m13 * y12 - _m23 * y02 + _m33 * y01;
+            double z23 = _m23 * y03 - _offsetZ * y01 - _m13 * y13;
+            double z13 = _m13 * y23 - _m33 * y03 + _offsetZ * y02;
+            double z03 = _m33 * y13 - _offsetZ * y12 - _m23 * y23;
+            double z32 = _m24 * y02 - _m34 * y01 - _m14 * y12;
+            double z22 = _m14 * y13 - _m24 * y03 + _m44 * y01;
+            double z12 = _m34 * y03 - _m44 * y02 - _m14 * y23;
+            double z02 = _m24 * y23 - _m34 * y13 + _m44 * y12;
+
+            double rcp = 1.0 / det;
+
+            // Multiply all 3x3 cofactors by reciprocal & transpose
+            _m11 = (z00 * rcp);
+            _m12 = (z10 * rcp);
+            _m13 = (z20 * rcp);
+            _m14 = (z30 * rcp);
+
+            _m21 = (z01 * rcp);
+            _m22 = (z11 * rcp);
+            _m23 = (z21 * rcp);
+            _m24 = (z31 * rcp);
+
+            _m31 = (z02 * rcp);
+            _m32 = (z12 * rcp);
+            _m33 = (z22 * rcp);
+            _m34 = (z32 * rcp);
+
+            _offsetX = (z03 * rcp);
+            _offsetY = (z13 * rcp);
+            _offsetZ = (z23 * rcp);
+            _m44 = (z33 * rcp);
+
+            return true;
+        }
+
+        public Matrix3D(double m11, double m12, double m13, double m14,
+                        double m21, double m22, double m23, double m24,
+                        double m31, double m32, double m33, double m34,
+                        double offsetX, double offsetY, double offsetZ, double m44)
+        {
+            _m11 = m11;
+            _m12 = m12;
+            _m13 = m13;
+            _m14 = m14;
+            _m21 = m21;
+            _m22 = m22;
+            _m23 = m23;
+            _m24 = m24;
+            _m31 = m31;
+            _m32 = m32;
+            _m33 = m33;
+            _m34 = m34;
+            _offsetX = offsetX;
+            _offsetY = offsetY;
+            _offsetZ = offsetZ;
+            _m44 = m44;
+        }
+
+        // the transform is identity by default
+        // Actually fill in the fields - some (internal) code uses the fields directly for perf.
+        private static Matrix3D s_identity = CreateIdentity();
+
+        public double M11
+        {
+            get
+            {
+                return _m11;
+            }
+            set
+            {
+                _m11 = value;
+            }
+        }
+
+        public double M12
+        {
+            get
+            {
+                return _m12;
+            }
+            set
+            {
+                _m12 = value;
+            }
+        }
+
+        public double M13
+        {
+            get
+            {
+                return _m13;
+            }
+            set
+            {
+                _m13 = value;
+            }
+        }
+
+        public double M14
+        {
+            get
+            {
+                return _m14;
+            }
+            set
+            {
+                _m14 = value;
+            }
+        }
+
+        public double M21
+        {
+            get
+            {
+                return _m21;
+            }
+            set
+            {
+                _m21 = value;
+            }
+        }
+
+        public double M22
+        {
+            get
+            {
+                return _m22;
+            }
+            set
+            {
+                _m22 = value;
+            }
+        }
+
+        public double M23
+        {
+            get
+            {
+                return _m23;
+            }
+            set
+            {
+                _m23 = value;
+            }
+        }
+
+        public double M24
+        {
+            get
+            {
+                return _m24;
+            }
+            set
+            {
+                _m24 = value;
+            }
+        }
+
+        public double M31
+        {
+            get
+            {
+                return _m31;
+            }
+            set
+            {
+                _m31 = value;
+            }
+        }
+
+        public double M32
+        {
+            get
+            {
+                return _m32;
+            }
+            set
+            {
+                _m32 = value;
+            }
+        }
+
+        public double M33
+        {
+            get
+            {
+                return _m33;
+            }
+            set
+            {
+                _m33 = value;
+            }
+        }
+
+        public double M34
+        {
+            get
+            {
+                return _m34;
+            }
+            set
+            {
+                _m34 = value;
+            }
+        }
+
+        public double OffsetX
+        {
+            get
+            {
+                return _offsetX;
+            }
+            set
+            {
+                _offsetX = value;
+            }
+        }
+
+        public double OffsetY
+        {
+            get
+            {
+                return _offsetY;
+            }
+            set
+            {
+                _offsetY = value;
+            }
+        }
+
+        public double OffsetZ
+        {
+            get
+            {
+                return _offsetZ;
+            }
+            set
+            {
+                _offsetZ = value;
+            }
+        }
+
+        public double M44
+        {
+            get
+            {
+                return _m44;
+            }
+            set
+            {
+                _m44 = value;
+            }
+        }
+
+        public static Matrix3D Identity
+        {
+            get
+            {
+                return s_identity;
+            }
+        }
+
+        public bool IsIdentity
+        {
+            get
+            {
+                return (_m11 == 1 && _m12 == 0 && _m13 == 0 && _m14 == 0 &&
+                         _m21 == 0 && _m22 == 1 && _m23 == 0 && _m24 == 0 &&
+                         _m31 == 0 && _m32 == 0 && _m33 == 1 && _m34 == 0 &&
+                         _offsetX == 0 && _offsetY == 0 && _offsetZ == 0 && _m44 == 1);
+            }
+        }
+
+        public override string ToString()
+        {
+            // Delegate to the internal method which implements all ToString calls.
+            return ConvertToString(null /* format string */, null /* format provider */);
+        }
+
+        public string ToString(IFormatProvider provider)
+        {
+            // Delegate to the internal method which implements all ToString calls.
+            return ConvertToString(null /* format string */, provider);
+        }
+
+        string IFormattable.ToString(string format, IFormatProvider provider)
+        {
+            // Delegate to the internal method which implements all ToString calls.
+            return ConvertToString(format, provider);
+        }
+
+        private string ConvertToString(string format, IFormatProvider provider)
+        {
+            if (IsIdentity)
+            {
+                return "Identity";
+            }
+
+            // Helper to get the numeric list separator for a given culture.
+            char separator = TokenizerHelper.GetNumericListSeparator(provider);
+            return string.Format(provider,
+                                 "{1:" + format + "}{0}{2:" + format + "}{0}{3:" + format + "}{0}{4:" + format + "}{0}{5:" + format +
+                                 "}{0}{6:" + format + "}{0}{7:" + format + "}{0}{8:" + format + "}{0}{9:" + format + "}{0}{10:" + format +
+                                 "}{0}{11:" + format + "}{0}{12:" + format + "}{0}{13:" + format + "}{0}{14:" + format + "}{0}{15:" + format + "}{0}{16:" + format + "}",
+                                 separator,
+                                 _m11, _m12, _m13, _m14,
+                                 _m21, _m22, _m23, _m24,
+                                 _m31, _m32, _m33, _m34,
+                                 _offsetX, _offsetY, _offsetZ, _m44);
+        }
+
+        public override int GetHashCode()
+        {
+            // Perform field-by-field XOR of HashCodes
+            return M11.GetHashCode() ^
+                   M12.GetHashCode() ^
+                   M13.GetHashCode() ^
+                   M14.GetHashCode() ^
+                   M21.GetHashCode() ^
+                   M22.GetHashCode() ^
+                   M23.GetHashCode() ^
+                   M24.GetHashCode() ^
+                   M31.GetHashCode() ^
+                   M32.GetHashCode() ^
+                   M33.GetHashCode() ^
+                   M34.GetHashCode() ^
+                   OffsetX.GetHashCode() ^
+                   OffsetY.GetHashCode() ^
+                   OffsetZ.GetHashCode() ^
+                   M44.GetHashCode();
+        }
+
+        public override bool Equals(object o)
+        {
+            return o is Matrix3D && Matrix3D.Equals(this, (Matrix3D)o);
+        }
+
+        public bool Equals(Matrix3D value)
+        {
+            return Matrix3D.Equals(this, value);
+        }
+
+        public static bool operator ==(Matrix3D matrix1, Matrix3D matrix2)
+        {
+            return matrix1.M11 == matrix2.M11 &&
+                   matrix1.M12 == matrix2.M12 &&
+                   matrix1.M13 == matrix2.M13 &&
+                   matrix1.M14 == matrix2.M14 &&
+                   matrix1.M21 == matrix2.M21 &&
+                   matrix1.M22 == matrix2.M22 &&
+                   matrix1.M23 == matrix2.M23 &&
+                   matrix1.M24 == matrix2.M24 &&
+                   matrix1.M31 == matrix2.M31 &&
+                   matrix1.M32 == matrix2.M32 &&
+                   matrix1.M33 == matrix2.M33 &&
+                   matrix1.M34 == matrix2.M34 &&
+                   matrix1.OffsetX == matrix2.OffsetX &&
+                   matrix1.OffsetY == matrix2.OffsetY &&
+                   matrix1.OffsetZ == matrix2.OffsetZ &&
+                   matrix1.M44 == matrix2.M44;
+        }
+
+        public static bool operator !=(Matrix3D matrix1, Matrix3D matrix2)
+        {
+            return !(matrix1 == matrix2);
+        }
+
+        public static Matrix3D operator *(Matrix3D matrix1, Matrix3D matrix2)
+        {
+            Matrix3D matrix3D = new Matrix3D();
+
+            matrix3D.M11 = matrix1.M11 * matrix2.M11 +
+                           matrix1.M12 * matrix2.M21 +
+                           matrix1.M13 * matrix2.M31 +
+                           matrix1.M14 * matrix2.OffsetX;
+            matrix3D.M12 = matrix1.M11 * matrix2.M12 +
+                           matrix1.M12 * matrix2.M22 +
+                           matrix1.M13 * matrix2.M32 +
+                           matrix1.M14 * matrix2.OffsetY;
+            matrix3D.M13 = matrix1.M11 * matrix2.M13 +
+                           matrix1.M12 * matrix2.M23 +
+                           matrix1.M13 * matrix2.M33 +
+                           matrix1.M14 * matrix2.OffsetZ;
+            matrix3D.M14 = matrix1.M11 * matrix2.M14 +
+                           matrix1.M12 * matrix2.M24 +
+                           matrix1.M13 * matrix2.M34 +
+                           matrix1.M14 * matrix2.M44;
+            matrix3D.M21 = matrix1.M21 * matrix2.M11 +
+                           matrix1.M22 * matrix2.M21 +
+                           matrix1.M23 * matrix2.M31 +
+                           matrix1.M24 * matrix2.OffsetX;
+            matrix3D.M22 = matrix1.M21 * matrix2.M12 +
+                           matrix1.M22 * matrix2.M22 +
+                           matrix1.M23 * matrix2.M32 +
+                           matrix1.M24 * matrix2.OffsetY;
+            matrix3D.M23 = matrix1.M21 * matrix2.M13 +
+                           matrix1.M22 * matrix2.M23 +
+                           matrix1.M23 * matrix2.M33 +
+                           matrix1.M24 * matrix2.OffsetZ;
+            matrix3D.M24 = matrix1.M21 * matrix2.M14 +
+                           matrix1.M22 * matrix2.M24 +
+                           matrix1.M23 * matrix2.M34 +
+                           matrix1.M24 * matrix2.M44;
+            matrix3D.M31 = matrix1.M31 * matrix2.M11 +
+                           matrix1.M32 * matrix2.M21 +
+                           matrix1.M33 * matrix2.M31 +
+                           matrix1.M34 * matrix2.OffsetX;
+            matrix3D.M32 = matrix1.M31 * matrix2.M12 +
+                           matrix1.M32 * matrix2.M22 +
+                           matrix1.M33 * matrix2.M32 +
+                           matrix1.M34 * matrix2.OffsetY;
+            matrix3D.M33 = matrix1.M31 * matrix2.M13 +
+                           matrix1.M32 * matrix2.M23 +
+                           matrix1.M33 * matrix2.M33 +
+                           matrix1.M34 * matrix2.OffsetZ;
+            matrix3D.M34 = matrix1.M31 * matrix2.M14 +
+                           matrix1.M32 * matrix2.M24 +
+                           matrix1.M33 * matrix2.M34 +
+                           matrix1.M34 * matrix2.M44;
+            matrix3D.OffsetX = matrix1.OffsetX * matrix2.M11 +
+                           matrix1.OffsetY * matrix2.M21 +
+                           matrix1.OffsetZ * matrix2.M31 +
+                           matrix1.M44 * matrix2.OffsetX;
+            matrix3D.OffsetY = matrix1.OffsetX * matrix2.M12 +
+                           matrix1.OffsetY * matrix2.M22 +
+                           matrix1.OffsetZ * matrix2.M32 +
+                           matrix1.M44 * matrix2.OffsetY;
+            matrix3D.OffsetZ = matrix1.OffsetX * matrix2.M13 +
+                           matrix1.OffsetY * matrix2.M23 +
+                           matrix1.OffsetZ * matrix2.M33 +
+                           matrix1.M44 * matrix2.OffsetZ;
+            matrix3D.M44 = matrix1.OffsetX * matrix2.M14 +
+                           matrix1.OffsetY * matrix2.M24 +
+                           matrix1.OffsetZ * matrix2.M34 +
+                           matrix1.M44 * matrix2.M44;
+
+            // matrix3D._type is not set.
+
+            return matrix3D;
+        }
+
+        public bool HasInverse
+        {
+            get
+            {
+                return !IsZero(Determinant);
+            }
+        }
+
+        public void Invert()
+        {
+            if (!InvertCore())
+            {
+                throw new InvalidOperationException();
+            }
+        }
+
+        private static Matrix3D CreateIdentity()
+        {
+            Matrix3D matrix3D = new Matrix3D();
+            matrix3D.SetMatrix(1, 0, 0, 0,
+                               0, 1, 0, 0,
+                               0, 0, 1, 0,
+                               0, 0, 0, 1);
+            return matrix3D;
+        }
+
+        private void SetMatrix(double m11, double m12, double m13, double m14,
+                               double m21, double m22, double m23, double m24,
+                               double m31, double m32, double m33, double m34,
+                               double offsetX, double offsetY, double offsetZ, double m44)
+        {
+            _m11 = m11;
+            _m12 = m12;
+            _m13 = m13;
+            _m14 = m14;
+            _m21 = m21;
+            _m22 = m22;
+            _m23 = m23;
+            _m24 = m24;
+            _m31 = m31;
+            _m32 = m32;
+            _m33 = m33;
+            _m34 = m34;
+            _offsetX = offsetX;
+            _offsetY = offsetY;
+            _offsetZ = offsetZ;
+            _m44 = m44;
+        }
+
+        private static bool Equals(Matrix3D matrix1, Matrix3D matrix2)
+        {
+            return matrix1.M11.Equals(matrix2.M11) &&
+                   matrix1.M12.Equals(matrix2.M12) &&
+                   matrix1.M13.Equals(matrix2.M13) &&
+                   matrix1.M14.Equals(matrix2.M14) &&
+                   matrix1.M21.Equals(matrix2.M21) &&
+                   matrix1.M22.Equals(matrix2.M22) &&
+                   matrix1.M23.Equals(matrix2.M23) &&
+                   matrix1.M24.Equals(matrix2.M24) &&
+                   matrix1.M31.Equals(matrix2.M31) &&
+                   matrix1.M32.Equals(matrix2.M32) &&
+                   matrix1.M33.Equals(matrix2.M33) &&
+                   matrix1.M34.Equals(matrix2.M34) &&
+                   matrix1.OffsetX.Equals(matrix2.OffsetX) &&
+                   matrix1.OffsetY.Equals(matrix2.OffsetY) &&
+                   matrix1.OffsetZ.Equals(matrix2.OffsetZ) &&
+                   matrix1.M44.Equals(matrix2.M44);
+        }
+
+        private double GetNormalizedAffineDeterminant()
+        {
+            double z20 = _m12 * _m23 - _m22 * _m13;
+            double z10 = _m32 * _m13 - _m12 * _m33;
+            double z00 = _m22 * _m33 - _m32 * _m23;
+
+            return _m31 * z20 + _m21 * z10 + _m11 * z00;
+        }
+
+        private bool IsAffine
+        {
+            get
+            {
+                return (_m14 == 0.0 && _m24 == 0.0 && _m34 == 0.0 && _m44 == 1.0);
+            }
+        }
+
+        private double Determinant
+        {
+            get
+            {
+                if (IsAffine)
+                {
+                    return GetNormalizedAffineDeterminant();
+                }
+
+                // compute all six 2x2 determinants of 2nd two columns
+                double y01 = _m13 * _m24 - _m23 * _m14;
+                double y02 = _m13 * _m34 - _m33 * _m14;
+                double y03 = _m13 * _m44 - _offsetZ * _m14;
+                double y12 = _m23 * _m34 - _m33 * _m24;
+                double y13 = _m23 * _m44 - _offsetZ * _m24;
+                double y23 = _m33 * _m44 - _offsetZ * _m34;
+
+                // Compute 3x3 cofactors for 1st the column
+                double z30 = _m22 * y02 - _m32 * y01 - _m12 * y12;
+                double z20 = _m12 * y13 - _m22 * y03 + _offsetY * y01;
+                double z10 = _m32 * y03 - _offsetY * y02 - _m12 * y23;
+                double z00 = _m22 * y23 - _m32 * y13 + _offsetY * y12;
+
+                return _offsetX * z30 + _m31 * z20 + _m21 * z10 + _m11 * z00;
+            }
+        }
+
+        private static bool IsZero(double value)
+        {
+            return Math.Abs(value) < 10.0 * DBL_EPSILON_RELATIVE_1;
+        }
+
+        private const double DBL_EPSILON_RELATIVE_1 = 1.1102230246251567e-016; /* smallest such that 1.0+DBL_EPSILON != 1.0 */
+
+        private double _m11;
+        private double _m12;
+        private double _m13;
+        private double _m14;
+        private double _m21;
+        private double _m22;
+        private double _m23;
+        private double _m24;
+        private double _m31;
+        private double _m32;
+        private double _m33;
+        private double _m34;
+        private double _offsetX;
+        private double _offsetY;
+        private double _offsetZ;
+        private double _m44;
+    }
+}
+
+#pragma warning restore 436

--- a/src/System/Windows/Thickness.cs
+++ b/src/System/Windows/Thickness.cs
@@ -1,0 +1,133 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+//
+
+//
+
+using System;
+using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Text;
+
+#pragma warning disable 436   // Redefining types from Windows.Foundation
+namespace Windows.UI.Xaml
+{
+    //
+    // Thickness is the managed projection of Windows.UI.Xaml.Thickness.  Any changes to the layout
+    // of this type must be exactly mirrored on the native WinRT side as well.
+    //
+    // Note that this type is owned by the Jupiter team.  Please contact them before making any
+    // changes here.
+    //
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Thickness
+    {
+        private double _Left;
+        private double _Top;
+        private double _Right;
+        private double _Bottom;
+
+        public Thickness(double uniformLength)
+        {
+            _Left = _Top = _Right = _Bottom = uniformLength;
+        }
+
+        public Thickness(double left, double top, double right, double bottom)
+        {
+            _Left = left;
+            _Top = top;
+            _Right = right;
+            _Bottom = bottom;
+        }
+
+        public double Left
+        {
+            get { return _Left; }
+            set { _Left = value; }
+        }
+
+        public double Top
+        {
+            get { return _Top; }
+            set { _Top = value; }
+        }
+
+        public double Right
+        {
+            get { return _Right; }
+            set { _Right = value; }
+        }
+
+        public double Bottom
+        {
+            get { return _Bottom; }
+            set { _Bottom = value; }
+        }
+
+        public override string ToString()
+        {
+            return ToString(CultureInfo.InvariantCulture);
+        }
+
+        internal string ToString(CultureInfo cultureInfo)
+        {
+            char listSeparator = TokenizerHelper.GetNumericListSeparator(cultureInfo);
+
+            // Initial capacity [64] is an estimate based on a sum of:
+            // 48 = 4x double (twelve digits is generous for the range of values likely)
+            //  8 = 4x Unit Type string (approx two characters)
+            //  4 = 4x separator characters
+            StringBuilder sb = new StringBuilder(64);
+
+            sb.Append(InternalToString(_Left, cultureInfo));
+            sb.Append(listSeparator);
+            sb.Append(InternalToString(_Top, cultureInfo));
+            sb.Append(listSeparator);
+            sb.Append(InternalToString(_Right, cultureInfo));
+            sb.Append(listSeparator);
+            sb.Append(InternalToString(_Bottom, cultureInfo));
+            return sb.ToString();
+        }
+
+        internal string InternalToString(double l, CultureInfo cultureInfo)
+        {
+            if (double.IsNaN(l)) return "Auto";
+            return Convert.ToString(l, cultureInfo);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Thickness)
+            {
+                Thickness otherObj = (Thickness)obj;
+                return (this == otherObj);
+            }
+            return (false);
+        }
+
+        public bool Equals(Thickness thickness)
+        {
+            return (this == thickness);
+        }
+
+        public override int GetHashCode()
+        {
+            return _Left.GetHashCode() ^ _Top.GetHashCode() ^ _Right.GetHashCode() ^ _Bottom.GetHashCode();
+        }
+
+        public static bool operator ==(Thickness t1, Thickness t2)
+        {
+            return t1._Left == t2._Left && t1._Top == t2._Top && t1._Right == t2._Right && t1._Bottom == t2._Bottom;
+        }
+
+        public static bool operator !=(Thickness t1, Thickness t2)
+        {
+            return (!(t1 == t2));
+        }
+    }
+}
+
+#pragma warning restore 436

--- a/src/System/Windows/TokenizerHelper.cs
+++ b/src/System/Windows/TokenizerHelper.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+//
+
+//
+
+using System;
+using System.Globalization;
+using System.Runtime.InteropServices;
+
+#pragma warning disable 436   // Redefining types from Windows.Foundation
+namespace Windows.UI.Xaml
+{
+    //
+    // Note that this type is owned by the Jupiter team.  Please contact them before making any
+    // changes here.
+    //
+
+    internal static class TokenizerHelper
+    {
+        internal static char GetNumericListSeparator(IFormatProvider provider)
+        {
+            char numericSeparator = ',';
+
+            // Get the NumberFormatInfo out of the provider, if possible
+            // If the IFormatProvider doesn't not contain a NumberFormatInfo, then
+            // this method returns the current culture's NumberFormatInfo.
+            NumberFormatInfo numberFormat = NumberFormatInfo.GetInstance(provider);
+
+            // Is the decimal separator is the same as the list separator?
+            // If so, we use the ";".
+            if ((numberFormat.NumberDecimalSeparator.Length > 0) && (numericSeparator == numberFormat.NumberDecimalSeparator[0]))
+            {
+                numericSeparator = ';';
+            }
+
+            return numericSeparator;
+        }
+    }
+}
+
+#pragma warning restore 436

--- a/tests/Configurations.props
+++ b/tests/Configurations.props
@@ -1,0 +1,7 @@
+﻿<Project DefaultTargets="Build">
+  <PropertyGroup>
+    <BuildConfigurations>
+      uap-Windows_NT;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/tests/System.Runtime.WindowsRuntime.UI.Xaml.Tests.csproj
+++ b/tests/System.Runtime.WindowsRuntime.UI.Xaml.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <ProjectGuid>{69FC7EB5-64FD-4464-88B1-B8ADD3870640}</ProjectGuid>
+    <Configurations>uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Windows\UI\Xaml\CornerRadiusTests.cs" />
+    <Compile Include="Windows\UI\Xaml\DurationTests.cs" />
+    <Compile Include="Windows\UI\Xaml\GridLengthTests.cs" />
+    <Compile Include="Windows\UI\Xaml\LayoutCycleExceptionTests.cs" />
+    <Compile Include="Windows\UI\Xaml\ThicknessTests.cs" />
+    <Compile Include="Windows\UI\Xaml\Automation\ElementNotEnabledExceptionTests.cs" />
+    <Compile Include="Windows\UI\Xaml\Automation\ElementNotAvailableExceptionTests.cs" />
+    <Compile Include="Windows\UI\Xaml\Controls\Primitives\GeneratorPositionTests.cs" />
+    <Compile Include="Windows\UI\Xaml\Markup\XamlParseExceptionTests.cs" />
+    <Compile Include="Windows\UI\Xaml\Media\MatrixTests.cs" />
+    <Compile Include="Windows\UI\Xaml\Media\Animation\KeyTimeTests.cs" />
+    <Compile Include="Windows\UI\Xaml\Media\Animation\RepeatBehaviorTests.cs" />
+    <Compile Include="Windows\UI\Xaml\Media3D\Matrix3DTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ReferenceFromRuntime Include="System.Runtime.WindowsRuntime.UI.Xaml" />
+  </ItemGroup>
+</Project>

--- a/tests/Windows/UI/Xaml/Automation/ElementNotAvailableExceptionTests.cs
+++ b/tests/Windows/UI/Xaml/Automation/ElementNotAvailableExceptionTests.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+
+namespace Windows.UI.Xaml.Automation.Tests
+{
+    public class ElementNotAvailableExceptionTests
+    {
+        private const int E_ELEMENTNOTAVAILABLE = unchecked((int)0x802B001F);
+
+        [Fact]
+        public void Ctor_Default()
+        {
+            var exception = new ElementNotAvailableException();
+            Assert.NotEmpty(exception.Message);
+            Assert.Null(exception.InnerException);
+            Assert.Equal(E_ELEMENTNOTAVAILABLE, exception.HResult);
+        }
+
+        [Fact]
+        public void Ctor_Message()
+        {
+            var exception = new ElementNotAvailableException("Message");
+            Assert.Equal("Message", exception.Message);
+            Assert.Null(exception.InnerException);
+            Assert.Equal(E_ELEMENTNOTAVAILABLE, exception.HResult);
+        }
+
+        [Fact]
+        public void Ctor_Message_InnerException()
+        {
+            var innerException = new Exception();
+            var exception = new ElementNotAvailableException("Message", innerException);
+            Assert.Equal("Message", exception.Message);
+            Assert.Same(innerException, exception.InnerException);
+            Assert.Equal(E_ELEMENTNOTAVAILABLE, exception.HResult);
+        }
+    }
+}

--- a/tests/Windows/UI/Xaml/Automation/ElementNotEnabledExceptionTests.cs
+++ b/tests/Windows/UI/Xaml/Automation/ElementNotEnabledExceptionTests.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+
+namespace Windows.UI.Xaml.Automation.Tests
+{
+    public class ElementNotEnabledExceptionTests
+    {
+        private const int E_ELEMENTNOTENABLED = unchecked((int)0x802B001E);
+
+        [Fact]
+        public void Ctor_Default()
+        {
+            var exception = new ElementNotEnabledException();
+            Assert.NotEmpty(exception.Message);
+            Assert.Null(exception.InnerException);
+            Assert.Equal(E_ELEMENTNOTENABLED, exception.HResult);
+        }
+
+        [Fact]
+        public void Ctor_Message()
+        {
+            var exception = new ElementNotEnabledException("Message");
+            Assert.Equal("Message", exception.Message);
+            Assert.Null(exception.InnerException);
+            Assert.Equal(E_ELEMENTNOTENABLED, exception.HResult);
+        }
+
+        [Fact]
+        public void Ctor_Message_InnerException()
+        {
+            var innerException = new Exception();
+            var exception = new ElementNotEnabledException("Message", innerException);
+            Assert.Equal("Message", exception.Message);
+            Assert.Same(innerException, exception.InnerException);
+            Assert.Equal(E_ELEMENTNOTENABLED, exception.HResult);
+        }
+    }
+}

--- a/tests/Windows/UI/Xaml/Controls/Primitives/GeneratorPositionTests.cs
+++ b/tests/Windows/UI/Xaml/Controls/Primitives/GeneratorPositionTests.cs
@@ -1,0 +1,83 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace Windows.UI.Xaml.Controls.Primitives.Tests
+{
+    public class GeneratorPositionTests
+    {
+        [Fact]
+        public void Ctor_Default()
+        {
+            var position = new GeneratorPosition();
+            Assert.Equal(0, position.Index);
+            Assert.Equal(0, position.Offset);
+        }
+
+        [Theory]
+        [InlineData(-1, -2)]
+        [InlineData(0, 0)]
+        [InlineData(1, 2)]
+        public void Ctor_Index_Offset(int index, int offset)
+        {
+            var position = new GeneratorPosition(index, offset);
+            Assert.Equal(index, position.Index);
+            Assert.Equal(offset, position.Offset);
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void Index_Set_GetReturnsExpected(int value)
+        {
+            var thickness = new GeneratorPosition { Index = value };
+            Assert.Equal(value, thickness.Index);
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void Offset_Set_GetReturnsExpected(int value)
+        {
+            var thickness = new GeneratorPosition { Offset = value };
+            Assert.Equal(value, thickness.Offset);
+        }
+
+        public static IEnumerable<object[]> Equals_TestData()
+        {
+            yield return new object[] { new GeneratorPosition(1, 2), new GeneratorPosition(1, 2), true };
+            yield return new object[] { new GeneratorPosition(1, 2), new GeneratorPosition(2, 2), false };
+            yield return new object[] { new GeneratorPosition(1, 2), new GeneratorPosition(1, 3), false };
+
+            yield return new object[] { new GeneratorPosition(1, 2), new object(), false };
+            yield return new object[] { new GeneratorPosition(1, 2), null, false };
+        }
+
+        [Theory]
+        [MemberData(nameof(Equals_TestData))]
+        public void Equals_Object_ReturnsExpected(GeneratorPosition position, object other, bool expected)
+        {
+            Assert.Equal(expected, position.Equals(other));
+            if (other is GeneratorPosition otherPosition)
+            {
+                Assert.Equal(expected, position.Equals(otherPosition));
+                Assert.Equal(expected, position == otherPosition);
+                Assert.Equal(!expected, position != otherPosition);
+                Assert.Equal(expected, position.GetHashCode().Equals(otherPosition.GetHashCode()));
+            }
+        }
+
+        [Fact]
+        public void ToString_Invoke_ReturnsExpected()
+        {
+            var position = new GeneratorPosition(1, 2);
+            Assert.Equal("GeneratorPosition (1,2)", position.ToString());
+        }
+    }
+}

--- a/tests/Windows/UI/Xaml/CornerRadiusTests.cs
+++ b/tests/Windows/UI/Xaml/CornerRadiusTests.cs
@@ -1,0 +1,219 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace Windows.UI.Xaml.Tests
+{
+    public class CornerRadiusTests
+    {
+        [Fact]
+        public void Ctor_Default()
+        {
+            var cornerRadius = new CornerRadius();
+            Assert.Equal(0, cornerRadius.TopLeft);
+            Assert.Equal(0, cornerRadius.TopRight);
+            Assert.Equal(0, cornerRadius.BottomRight);
+            Assert.Equal(0, cornerRadius.BottomLeft);
+        }
+
+        public static IEnumerable<object[]> ValidDoubles_TestData()
+        {
+            yield return new object[] { 0 };
+            yield return new object[] { 1 };
+            yield return new object[] { double.MaxValue };
+            yield return new object[] { double.PositiveInfinity };
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidDoubles_TestData))]
+        public void Ctor_UniformRadius(double uniformRadius)
+        {
+            var cornerRadius = new CornerRadius(uniformRadius);
+            Assert.Equal(uniformRadius, cornerRadius.TopLeft);
+            Assert.Equal(uniformRadius, cornerRadius.TopRight);
+            Assert.Equal(uniformRadius, cornerRadius.BottomRight);
+            Assert.Equal(uniformRadius, cornerRadius.BottomLeft);
+        }
+
+        private static List<double> InvalidDoubles { get; } = new List<double> { -1, double.NaN, double.NegativeInfinity };
+
+        public static IEnumerable<object[]> InvalidDoubles_TestData() => InvalidDoubles.Select(f => new object[] { f });
+
+        [Theory]
+        [MemberData(nameof(InvalidDoubles_TestData))]
+        public void Ctor_InvalidUniformRadius_ThrowsArgumentException(double uniformRadius)
+        {
+            AssertExtensions.Throws<ArgumentException>(null, () => new CornerRadius(uniformRadius));
+        }
+
+        [Theory]
+        [InlineData(0, 0, 0, 0)]
+        [InlineData(1, 2, 3, 4)]
+        [InlineData(double.PositiveInfinity, double.PositiveInfinity, double.PositiveInfinity, double.PositiveInfinity)]
+        [InlineData(double.MaxValue, double.MaxValue, double.MaxValue, double.MaxValue)]
+        public void Ctor_TopLeft_TopRight_BottomRight_BottomLeft(double topLeft, double topRight, double bottomRight, double bottomLeft)
+        {
+            var cornerRadius = new CornerRadius(topLeft, topRight, bottomRight, bottomLeft);
+            Assert.Equal(topLeft, cornerRadius.TopLeft);
+            Assert.Equal(topRight, cornerRadius.TopRight);
+            Assert.Equal(bottomRight, cornerRadius.BottomRight);
+            Assert.Equal(bottomLeft, cornerRadius.BottomLeft);
+        }
+
+        public static IEnumerable<object[]> Ctor_InvalidValues_TestData()
+        {
+            foreach (double invalidValue in InvalidDoubles)
+            {
+                yield return new object[] { invalidValue, 0, 0, 0 };
+                yield return new object[] { 0, invalidValue, 0, 0 };
+                yield return new object[] { 0, 0, invalidValue, 0 };
+                yield return new object[] { 0, 0, 0, invalidValue };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(Ctor_InvalidValues_TestData))]
+        public void Ctor_InvalidValues_ThrowsArgumentException(double topLeft, double topRight, double bottomRight, double bottomLeft)
+        {
+            AssertExtensions.Throws<ArgumentException>(null, () => new CornerRadius(topLeft, topRight, bottomRight, bottomLeft));
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidDoubles_TestData))]
+        public void TopLeft_SetValid_GetReturnsExpected(double value)
+        {
+            var cornerRadius = new CornerRadius { TopLeft = value };
+            Assert.Equal(value, cornerRadius.TopLeft);
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidDoubles_TestData))]
+        public void TopLeft_SetInvalid_ThrowsArgumentException(double value)
+        {
+            var cornerRadius = new CornerRadius();
+            AssertExtensions.Throws<ArgumentException>(null, () => cornerRadius.TopLeft = value);
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidDoubles_TestData))]
+        public void TopRight_SetValid_GetReturnsExpected(double value)
+        {
+            var cornerRadius = new CornerRadius { TopRight = value };
+            Assert.Equal(value, cornerRadius.TopRight);
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidDoubles_TestData))]
+        public void TopRight_SetInvalid_ThrowsArgumentException(double value)
+        {
+            var cornerRadius = new CornerRadius();
+            AssertExtensions.Throws<ArgumentException>(null, () => cornerRadius.TopRight = value);
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidDoubles_TestData))]
+        public void BottomRight_SetValid_GetReturnsExpected(double value)
+        {
+            var cornerRadius = new CornerRadius { BottomRight = value };
+            Assert.Equal(value, cornerRadius.BottomRight);
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidDoubles_TestData))]
+        public void BottomRight_SetInvalid_ThrowsArgumentException(double value)
+        {
+            var cornerRadius = new CornerRadius();
+            AssertExtensions.Throws<ArgumentException>(null, () => cornerRadius.BottomRight = value);
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidDoubles_TestData))]
+        public void BottomLeft_SetValid_GetReturnsExpected(double value)
+        {
+            var cornerRadius = new CornerRadius { BottomLeft = value };
+            Assert.Equal(value, cornerRadius.BottomLeft);
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidDoubles_TestData))]
+        public void BottomLeft_SetInvalid_ThrowsArgumentException(double value)
+        {
+            var cornerRadius = new CornerRadius();
+            AssertExtensions.Throws<ArgumentException>(null, () => cornerRadius.BottomLeft = value);
+        }
+
+        public static IEnumerable<object[]> Equals_TestData()
+        {
+            yield return new object[] { new CornerRadius(1, 2, 3, 4), new CornerRadius(1, 2, 3, 4), true };
+            yield return new object[] { new CornerRadius(1, 2, 3, 4), new CornerRadius(2, 2, 3, 4), false };
+            yield return new object[] { new CornerRadius(1, 2, 3, 4), new CornerRadius(1, 3, 3, 4), false };
+            yield return new object[] { new CornerRadius(1, 2, 3, 4), new CornerRadius(1, 2, 4, 4), false };
+            yield return new object[] { new CornerRadius(1, 2, 3, 4), new CornerRadius(1, 2, 3, 5), false };
+
+            yield return new object[] { new CornerRadius(1, 2, 3, 4), new object(), false };
+            yield return new object[] { new CornerRadius(1, 2, 3, 4), null, false };
+        }
+
+        [Theory]
+        [MemberData(nameof(Equals_TestData))]
+        public void Equals_Object_ReturnsExpected(CornerRadius cornerRadius, object other, bool expected)
+        {
+            Assert.Equal(expected, cornerRadius.Equals(other));
+            if (other is CornerRadius otherCornerRadius)
+            {
+                Assert.Equal(expected, cornerRadius.Equals(otherCornerRadius));
+                Assert.Equal(expected, cornerRadius == otherCornerRadius);
+                Assert.Equal(!expected, cornerRadius != otherCornerRadius);
+                Assert.Equal(expected, cornerRadius.GetHashCode().Equals(otherCornerRadius.GetHashCode()));
+            }
+        }
+
+        [Fact]
+        public void ToString_Invoke_ReturnsExpected()
+        {
+            var cornerRadius = new CornerRadius(1, 2.2, 3, 4);
+            Assert.Equal("1,2.2,3,4", cornerRadius.ToString());
+        }
+
+        [Fact]
+        public void ToString_NaN_ReturnsAuto()
+        {
+            CornerRadius cornerRadius = new FakeCornerRadius
+            {
+                TopLeft = double.NaN,
+                TopRight = double.NaN,
+                BottomRight = double.NaN,
+                BottomLeft = double.NaN
+            }.ToActual();
+            Assert.Equal("Auto,Auto,Auto,Auto", cornerRadius.ToString());
+        }
+
+        public struct FakeCornerRadius
+        {
+            public double TopRight;
+            public double TopLeft;
+            public double BottomRight;
+            public double BottomLeft;
+
+            public CornerRadius ToActual()
+            {
+                CornerRadiusWrapper wrapper = default(CornerRadiusWrapper);
+                wrapper.Fake = this;
+                return wrapper.Actual;
+            }
+        }
+
+        [StructLayout(LayoutKind.Explicit)]
+        public struct CornerRadiusWrapper
+        {
+            [FieldOffset(0)] public CornerRadius Actual;
+            [FieldOffset(0)] public FakeCornerRadius Fake;
+        }
+    }
+}

--- a/tests/Windows/UI/Xaml/DurationTests.cs
+++ b/tests/Windows/UI/Xaml/DurationTests.cs
@@ -1,0 +1,173 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Windows.UI.Xaml.Tests
+{
+    public class DurationTests
+    {
+        [Fact]
+        public void Ctor_Default()
+        {
+            var duration = new Duration();
+            Assert.False(duration.HasTimeSpan);
+            Assert.Throws<InvalidOperationException>(() => duration.TimeSpan);
+        }
+
+        [Fact]
+        public void Ctor_TimeSpan()
+        {
+            var duration = new Duration(TimeSpan.FromSeconds(2));
+            Assert.True(duration.HasTimeSpan);
+            Assert.Equal(TimeSpan.FromSeconds(2), duration.TimeSpan);
+        }
+
+        [Fact]
+        public void Operator_Duration_ReturnsExpected()
+        {
+            Duration duration = TimeSpan.FromSeconds(2);
+            Assert.True(duration.HasTimeSpan);
+            Assert.Equal(TimeSpan.FromSeconds(2), duration.TimeSpan);
+        }
+
+        [Fact]
+        public void Operator_UnaryPlus_ReturnsExpected()
+        {
+            Duration duration = +new Duration(TimeSpan.FromSeconds(2));
+            Assert.True(duration.HasTimeSpan);
+            Assert.Equal(TimeSpan.FromSeconds(2), duration.TimeSpan);
+        }
+
+        [Fact]
+        public void Automatic_Get_ReturnsExpected()
+        {
+            Duration duration = Duration.Automatic;
+            Assert.False(duration.HasTimeSpan);
+            Assert.Throws<InvalidOperationException>(() => duration.TimeSpan);
+        }
+
+        [Fact]
+        public void Forever_Get_ReturnsExpected()
+        {
+            Duration duration = Duration.Forever;
+            Assert.False(duration.HasTimeSpan);
+            Assert.Throws<InvalidOperationException>(() => duration.TimeSpan);
+        }
+
+        public static IEnumerable<object[]> Add_TestData()
+        {
+            yield return new object[] { Duration.Automatic, Duration.Automatic, Duration.Automatic };
+            yield return new object[] { Duration.Automatic, Duration.Forever, Duration.Automatic };
+            yield return new object[] { Duration.Forever, Duration.Forever, Duration.Forever };
+
+            yield return new object[] { Duration.Automatic, new Duration(TimeSpan.FromSeconds(2)), Duration.Automatic };
+            yield return new object[] { Duration.Forever, new Duration(TimeSpan.FromSeconds(2)), Duration.Forever };
+
+            yield return new object[] { new Duration(TimeSpan.FromSeconds(1)), new Duration(TimeSpan.FromSeconds(2)), new Duration(TimeSpan.FromSeconds(3)) };
+        }
+
+        [Theory]
+        [MemberData(nameof(Add_TestData))]
+        public void Add_Durations_ReturnsExpected(Duration duration1, Duration duration2, Duration expected)
+        {
+            Assert.Equal(expected, duration1.Add(duration2));
+            Assert.Equal(expected, duration1 + duration2);
+
+            Assert.Equal(expected, duration2.Add(duration1));
+            Assert.Equal(expected, duration2 + duration1);
+        }
+
+        public static IEnumerable<object[]> Subtract_TestData()
+        {
+            yield return new object[] { Duration.Automatic, Duration.Automatic, Duration.Automatic };
+            yield return new object[] { Duration.Automatic, Duration.Forever, Duration.Automatic };
+            yield return new object[] { Duration.Forever, Duration.Automatic, Duration.Automatic };
+            yield return new object[] { Duration.Forever, Duration.Forever, Duration.Automatic };
+
+            yield return new object[] { Duration.Automatic, new Duration(TimeSpan.FromSeconds(2)), Duration.Automatic };
+            yield return new object[] { Duration.Forever, new Duration(TimeSpan.FromSeconds(2)), Duration.Forever };
+
+            yield return new object[] { new Duration(TimeSpan.FromSeconds(3)), new Duration(TimeSpan.FromSeconds(2)), new Duration(TimeSpan.FromSeconds(1)) };
+        }
+
+        [Theory]
+        [MemberData(nameof(Subtract_TestData))]
+        public void Subtract_Durations_ReturnsExpected(Duration duration1, Duration duration2, Duration expected)
+        {
+            Assert.Equal(expected, duration1.Subtract(duration2));
+            Assert.Equal(expected, duration1 - duration2);
+        }
+
+        public static IEnumerable<object[]> Compare_TestData()
+        {
+            yield return new object[] { new Duration(TimeSpan.FromSeconds(1)), new Duration(TimeSpan.FromSeconds(2)), -1 };
+            yield return new object[] { new Duration(TimeSpan.FromSeconds(2)), new Duration(TimeSpan.FromSeconds(1)), 1 };
+            yield return new object[] { new Duration(TimeSpan.FromSeconds(1)), new Duration(TimeSpan.FromSeconds(1)), 0 };
+            yield return new object[] { new Duration(TimeSpan.FromSeconds(1)), Duration.Automatic, 1 };
+            yield return new object[] { new Duration(TimeSpan.FromSeconds(2)), Duration.Forever, -1 };
+
+            yield return new object[] { Duration.Forever, Duration.Forever, 0 };
+            yield return new object[] { Duration.Forever, new Duration(TimeSpan.FromSeconds(2)), 1 };
+            yield return new object[] { Duration.Forever, Duration.Automatic, 1 };
+
+            yield return new object[] { Duration.Automatic, Duration.Automatic, 0 };
+            yield return new object[] { Duration.Automatic, new Duration(TimeSpan.FromSeconds(2)), -1 };
+            yield return new object[] { Duration.Automatic, Duration.Forever, -1 };
+        }
+
+        [Theory]
+        [MemberData(nameof(Compare_TestData))]
+        public void Compare_TestData(Duration duration1, Duration duration2, int expected)
+        {
+            bool bothOrNoneAutomatic = (duration1 == Duration.Automatic) == (duration2 == Duration.Automatic);
+
+            Assert.Equal(expected, Duration.Compare(duration1, duration2));
+
+            Assert.Equal(expected <= 0 && bothOrNoneAutomatic, duration1 <= duration2);
+            Assert.Equal(expected < 0 && bothOrNoneAutomatic, duration1 < duration2);
+
+            Assert.Equal(expected == 0 && bothOrNoneAutomatic, duration1 == duration2);
+            Assert.Equal(expected != 0, duration1 != duration2);
+
+            Assert.Equal(expected >= 0 && bothOrNoneAutomatic, duration1 >= duration2);
+            Assert.Equal(expected > 0 && bothOrNoneAutomatic, duration1 > duration2);
+        }
+        public static IEnumerable<object[]> Equals_TestData()
+        {
+            yield return new object[] { new Duration(), new object(), -1 };
+            yield return new object[] { new Duration(), null, -1 };
+        }
+
+        [Theory]
+        [MemberData(nameof(Equals_TestData))]
+        [MemberData(nameof(Compare_TestData))]
+        public void Equals_Object_ReturnsExpected(Duration duration, object other, int expected)
+        {
+            Assert.Equal(expected == 0, duration.Equals(other));
+            if (other is Duration otherDuration)
+            {
+                Assert.Equal(expected == 0, Duration.Equals(duration, otherDuration));
+                Assert.Equal(expected == 0, duration.Equals(otherDuration));
+                Assert.Equal(expected == 0, duration.GetHashCode().Equals(otherDuration.GetHashCode()));
+            }
+        }
+
+        public static IEnumerable<object[]> ToString_TestData()
+        {
+            yield return new object[] { Duration.Automatic, "Automatic" };
+            yield return new object[] { Duration.Forever, "Forever" };
+            yield return new object[] { new Duration(TimeSpan.FromSeconds(2)), TimeSpan.FromSeconds(2).ToString() };
+        }
+
+        [Theory]
+        [MemberData(nameof(ToString_TestData))]
+        public void ToString_Invoke_ReturnsExpected(Duration duration, string expected)
+        {
+            Assert.Equal(expected, duration.ToString());
+        }
+    }
+}

--- a/tests/Windows/UI/Xaml/GridLengthTests.cs
+++ b/tests/Windows/UI/Xaml/GridLengthTests.cs
@@ -1,0 +1,124 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Windows.UI.Xaml.Tests
+{
+    public class GridLengthTests
+    {
+        [Fact]
+        public void Ctor_Default()
+        {
+            var gridLength = new GridLength();
+            Assert.Equal(GridUnitType.Auto, gridLength.GridUnitType);
+            Assert.False(gridLength.IsAbsolute);
+            Assert.True(gridLength.IsAuto);
+            Assert.False(gridLength.IsStar);
+            Assert.Equal(1, gridLength.Value);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(10)]
+        [InlineData(float.MaxValue)]
+        public void Ctor_Pixels(double pixels)
+        {
+            var gridLength = new GridLength(pixels);
+            Assert.Equal(GridUnitType.Pixel, gridLength.GridUnitType);
+            Assert.True(gridLength.IsAbsolute);
+            Assert.False(gridLength.IsAuto);
+            Assert.False(gridLength.IsStar);
+            Assert.Equal(pixels, gridLength.Value);
+        }
+
+        [Theory]
+        [InlineData(0, GridUnitType.Auto, 1)]
+        [InlineData(0, GridUnitType.Pixel, 0)]
+        [InlineData(0, GridUnitType.Star, 0)]
+        [InlineData(10, GridUnitType.Pixel, 10)]
+        [InlineData(float.MaxValue, GridUnitType.Star, float.MaxValue)]
+        public void Ctor_Value_UnitType(double value, GridUnitType unitType, double expectedValue)
+        {
+            var gridLength = new GridLength(value, unitType);
+            Assert.Equal(unitType, gridLength.GridUnitType);
+            Assert.Equal(unitType == GridUnitType.Pixel, gridLength.IsAbsolute);
+            Assert.Equal(unitType == GridUnitType.Auto, gridLength.IsAuto);
+            Assert.Equal(unitType == GridUnitType.Star, gridLength.IsStar);
+            Assert.Equal(expectedValue, gridLength.Value);
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(double.NaN)]
+        [InlineData(double.PositiveInfinity)]
+        [InlineData(double.NegativeInfinity)]
+        public void Ctor_InvalidValue_ThrowsArgumentException(double value)
+        {
+            AssertExtensions.Throws<ArgumentException>("value", () => new GridLength(value));
+            AssertExtensions.Throws<ArgumentException>("value", () => new GridLength(value, GridUnitType.Pixel));
+        }
+
+        [Theory]
+        [InlineData(GridUnitType.Auto - 1)]
+        [InlineData(GridUnitType.Star + 1)]
+        public void Ctor_InvalidUnitType_ThrowsArgumentException(GridUnitType unitType)
+        {
+            AssertExtensions.Throws<ArgumentException>("type", () => new GridLength(1, unitType));
+        }
+
+        [Fact]
+        public void Auto_Get_ReturnsExpected()
+        {
+            GridLength gridLength = GridLength.Auto;
+            Assert.Equal(GridUnitType.Auto, gridLength.GridUnitType);
+            Assert.False(gridLength.IsAbsolute);
+            Assert.True(gridLength.IsAuto);
+            Assert.False(gridLength.IsStar);
+            Assert.Equal(1, gridLength.Value);
+        }
+
+        public static IEnumerable<object[]> Equals_TestData()
+        {
+            yield return new object[] { new GridLength(10, GridUnitType.Pixel), new GridLength(10, GridUnitType.Pixel), true };
+            yield return new object[] { new GridLength(10, GridUnitType.Pixel), new GridLength(11, GridUnitType.Pixel), false };
+            yield return new object[] { new GridLength(10, GridUnitType.Pixel), new GridLength(10, GridUnitType.Auto), false };
+            yield return new object[] { new GridLength(10, GridUnitType.Pixel), new GridLength(10, GridUnitType.Star), false };
+            yield return new object[] { new GridLength(10, GridUnitType.Auto), GridLength.Auto, true };
+
+            yield return new object[] { new GridLength(10, GridUnitType.Pixel), new object(), false };
+            yield return new object[] { new GridLength(10, GridUnitType.Pixel), null, false };
+        }
+
+        [Theory]
+        [MemberData(nameof(Equals_TestData))]
+        public void Equals_Object_ReturnsExpected(GridLength gridLength, object other, bool expected)
+        {
+            Assert.Equal(expected, gridLength.Equals(other));
+            if (other is GridLength otherGridLength)
+            {
+                Assert.Equal(expected, gridLength.Equals(otherGridLength));
+                Assert.Equal(expected, gridLength == otherGridLength);
+                Assert.Equal(!expected, gridLength != otherGridLength);
+                Assert.Equal(expected, gridLength.GetHashCode().Equals(otherGridLength.GetHashCode()));
+            }
+        }
+
+        public static IEnumerable<object[]> ToString_TestData()
+        {
+            yield return new object[] { GridLength.Auto, "Auto" };
+            yield return new object[] { new GridLength(10, GridUnitType.Pixel), "10" };
+            yield return new object[] { new GridLength(10, GridUnitType.Star), "10*" };
+        }
+
+        [Theory]
+        [MemberData(nameof(ToString_TestData))]
+        public void ToString_Invoke_ReturnsExpected(GridLength gridLength, string expected)
+        {
+            Assert.Equal(expected, gridLength.ToString());
+        }
+    }
+}

--- a/tests/Windows/UI/Xaml/LayoutCycleExceptionTests.cs
+++ b/tests/Windows/UI/Xaml/LayoutCycleExceptionTests.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+
+namespace Windows.UI.Xaml.Tests
+{
+    public class LayoutCycleExceptionTests
+    {
+        private const int E_LAYOUTCYCLE = unchecked((int)0x802B0014);
+
+        [Fact]
+        public void Ctor_Default()
+        {
+            var exception = new LayoutCycleException();
+            Assert.NotEmpty(exception.Message);
+            Assert.Null(exception.InnerException);
+            Assert.Equal(E_LAYOUTCYCLE, exception.HResult);
+        }
+
+        [Fact]
+        public void Ctor_Message()
+        {
+            var exception = new LayoutCycleException("Message");
+            Assert.Equal("Message", exception.Message);
+            Assert.Null(exception.InnerException);
+            Assert.Equal(E_LAYOUTCYCLE, exception.HResult);
+        }
+
+        [Fact]
+        public void Ctor_Message_InnerException()
+        {
+            var innerException = new Exception();
+            var exception = new LayoutCycleException("Message", innerException);
+            Assert.Equal("Message", exception.Message);
+            Assert.Same(innerException, exception.InnerException);
+            Assert.Equal(E_LAYOUTCYCLE, exception.HResult);
+        }
+    }
+}

--- a/tests/Windows/UI/Xaml/Markup/XamlParseExceptionTests.cs
+++ b/tests/Windows/UI/Xaml/Markup/XamlParseExceptionTests.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+
+namespace Windows.UI.Xaml.Markup.Tests
+{
+    public class XamlParseExceptionTests
+    {
+        private const int E_XAMLPARSEFAILED = unchecked((int)0x802B000A);
+
+        [Fact]
+        public void Ctor_Default()
+        {
+            var exception = new XamlParseException();
+            Assert.NotEmpty(exception.Message);
+            Assert.Null(exception.InnerException);
+            Assert.Equal(E_XAMLPARSEFAILED, exception.HResult);
+        }
+
+        [Fact]
+        public void Ctor_Message()
+        {
+            var exception = new XamlParseException("Message");
+            Assert.Equal("Message", exception.Message);
+            Assert.Null(exception.InnerException);
+            Assert.Equal(E_XAMLPARSEFAILED, exception.HResult);
+        }
+
+        [Fact]
+        public void Ctor_Message_InnerException()
+        {
+            var innerException = new Exception();
+            var exception = new XamlParseException("Message", innerException);
+            Assert.Equal("Message", exception.Message);
+            Assert.Same(innerException, exception.InnerException);
+            Assert.Equal(E_XAMLPARSEFAILED, exception.HResult);
+        }
+    }
+}

--- a/tests/Windows/UI/Xaml/Media/Animation/KeyTimeTests.cs
+++ b/tests/Windows/UI/Xaml/Media/Animation/KeyTimeTests.cs
@@ -1,0 +1,85 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Windows.UI.Xaml.Media.Animation.Tests
+{
+    public class KeyTimeTests
+    {
+        [Fact]
+        public void Ctor_Default()
+        {
+            var keyTime = new KeyTime();
+            Assert.Equal(TimeSpan.Zero, keyTime.TimeSpan);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void FromTimeSpan_ValidTimeSpan_ReturnsExpected(int seconds)
+        {
+            KeyTime keyTime = KeyTime.FromTimeSpan(TimeSpan.FromSeconds(seconds));
+            Assert.Equal(TimeSpan.FromSeconds(seconds), keyTime.TimeSpan);
+        }
+
+        [Fact]
+        public void FromTimeSpan_NegativeTimeSpan_ThrowsArgumentOutOfRangeException()
+        {
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("timeSpan", () => KeyTime.FromTimeSpan(TimeSpan.FromTicks(-1)));
+        }
+
+        [Fact]
+        public void Operator_ValidTimeSpan_ReturnsExpected()
+        {
+            KeyTime keyTime = TimeSpan.FromSeconds(2);
+            Assert.Equal(TimeSpan.FromSeconds(2), keyTime);
+        }
+
+        [Fact]
+        public void Operator_NegativeTimeSpan_ThrowsArgumentOutOfRangeException()
+        {
+            TimeSpan timeSpan = TimeSpan.FromTicks(-1);
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("timeSpan", () => (KeyTime)timeSpan);
+        }
+
+        public static IEnumerable<object[]> Equals_TestData()
+        {
+            yield return new object[] { KeyTime.FromTimeSpan(TimeSpan.FromSeconds(2)), KeyTime.FromTimeSpan(TimeSpan.FromSeconds(2)), true };
+            yield return new object[] { KeyTime.FromTimeSpan(TimeSpan.FromSeconds(2)), KeyTime.FromTimeSpan(TimeSpan.FromSeconds(1)), false };
+
+            yield return new object[] { KeyTime.FromTimeSpan(TimeSpan.FromSeconds(2)), new object(), false };
+            yield return new object[] { KeyTime.FromTimeSpan(TimeSpan.FromSeconds(2)), null, false };
+        }
+
+        [Theory]
+        [MemberData(nameof(Equals_TestData))]
+        public void Equals_Object_ReturnsExpected(KeyTime keyTime, object other, bool expected)
+        {
+            Assert.Equal(expected, keyTime.Equals(other));
+            if (other is KeyTime otherKeyTime)
+            {
+                Assert.Equal(expected, keyTime.Equals(otherKeyTime));
+                Assert.Equal(expected, keyTime == otherKeyTime);
+                Assert.Equal(!expected, keyTime != otherKeyTime);
+                Assert.Equal(expected, keyTime.GetHashCode().Equals(otherKeyTime.GetHashCode()));
+            }
+        }
+
+        public static IEnumerable<object[]> ToString_TestData()
+        {
+            yield return new object[] { new KeyTime(), TimeSpan.Zero.ToString() };
+            yield return new object[] { KeyTime.FromTimeSpan(TimeSpan.FromSeconds(2)), TimeSpan.FromSeconds(2).ToString() };
+        }
+
+        [Theory]
+        [MemberData(nameof(ToString_TestData))]
+        public void ToString_Invoke_ReturnsExpected(KeyTime keyTime, string expected)
+        {
+            Assert.Equal(expected, keyTime.ToString());
+        }
+    }
+}

--- a/tests/Windows/UI/Xaml/Media/Animation/RepeatBehaviorTests.cs
+++ b/tests/Windows/UI/Xaml/Media/Animation/RepeatBehaviorTests.cs
@@ -1,0 +1,215 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Xunit;
+
+namespace Windows.UI.Xaml.Media.Animation.Tests
+{
+    public class RepeatBehaviorTests
+    {
+        [Fact]
+        public void Ctor_Default()
+        {
+            var repeatBehaviour = new RepeatBehavior();
+            Assert.True(repeatBehaviour.HasCount);
+            Assert.Equal(0, repeatBehaviour.Count);
+
+            Assert.False(repeatBehaviour.HasDuration);
+            Assert.Equal(TimeSpan.Zero, repeatBehaviour.Duration);
+
+            Assert.Equal(RepeatBehaviorType.Count, repeatBehaviour.Type);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(10)]
+        [InlineData(double.MaxValue)]
+        public void Ctor_Count(double count)
+        {
+            var repeatBehaviour = new RepeatBehavior(count);
+            Assert.True(repeatBehaviour.HasCount);
+            Assert.Equal(count, repeatBehaviour.Count);
+
+            Assert.False(repeatBehaviour.HasDuration);
+            Assert.Equal(TimeSpan.Zero, repeatBehaviour.Duration);
+
+            Assert.Equal(RepeatBehaviorType.Count, repeatBehaviour.Type);
+            Assert.Equal(count.GetHashCode(), repeatBehaviour.GetHashCode());
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(double.NaN)]
+        [InlineData(double.PositiveInfinity)]
+        [InlineData(double.NegativeInfinity)]
+        public void Ctor_InvalidCount_ThrowsArgumentOutOfRangeException(double count)
+        {
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => new RepeatBehavior(count));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void Ctor_TimeSpan(int seconds)
+        {
+            var repeatBehaviour = new RepeatBehavior(TimeSpan.FromSeconds(seconds));
+            Assert.False(repeatBehaviour.HasCount);
+            Assert.Equal(0, repeatBehaviour.Count);
+
+            Assert.True(repeatBehaviour.HasDuration);
+            Assert.Equal(TimeSpan.FromSeconds(seconds), repeatBehaviour.Duration);
+
+            Assert.Equal(RepeatBehaviorType.Duration, repeatBehaviour.Type);
+            Assert.Equal(TimeSpan.FromSeconds(seconds).GetHashCode(), repeatBehaviour.GetHashCode());
+        }
+
+        [Fact]
+        public void Ctor_NegativeTimeSpan_ThrowsArgumentOutOfRangeException()
+        {
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("duration", () => new RepeatBehavior(TimeSpan.FromTicks(-1)));
+        }
+
+        [Fact]
+        public void Forever_Get_ReturnsExpected()
+        {
+            RepeatBehavior forever = RepeatBehavior.Forever;
+            Assert.False(forever.HasCount);
+            Assert.Equal(0, forever.Count);
+
+            Assert.False(forever.HasDuration);
+            Assert.Equal(TimeSpan.Zero, forever.Duration);
+
+            Assert.Equal(RepeatBehaviorType.Forever, forever.Type);
+
+            Assert.Equal(int.MaxValue - 42, forever.GetHashCode());
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(10)]
+        [InlineData(double.MaxValue)]
+        [InlineData(double.NaN)]
+        [InlineData(double.PositiveInfinity)]
+        [InlineData(double.NegativeInfinity)]
+        public void Count_Set_GetReturnsExpected(double value)
+        {
+            var repeatBehaviour = new RepeatBehavior(TimeSpan.MaxValue) { Count = value };
+            Assert.False(repeatBehaviour.HasCount);
+            Assert.Equal(value, repeatBehaviour.Count);
+
+            // Although we set a count, the type is unchanged.
+            Assert.Equal(RepeatBehaviorType.Duration, repeatBehaviour.Type);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(-1)]
+        public void Duration_Set_GetReturnsExpected(int seconds)
+        {
+            var repeatBehaviour = new RepeatBehavior(1) { Duration = TimeSpan.FromSeconds(seconds) };
+            Assert.False(repeatBehaviour.HasDuration);
+            Assert.Equal(TimeSpan.FromSeconds(seconds), repeatBehaviour.Duration);
+
+            // Although we set a duration, the type is unchanged.
+            Assert.Equal(RepeatBehaviorType.Count, repeatBehaviour.Type);
+        }
+
+        [Theory]
+        [InlineData(RepeatBehaviorType.Count - 1)]
+        [InlineData(RepeatBehaviorType.Count)]
+        [InlineData(RepeatBehaviorType.Duration)]
+        [InlineData(RepeatBehaviorType.Forever)]
+        [InlineData(RepeatBehaviorType.Forever + 1)]
+        public void Type_Set_GetReturnsExpected(RepeatBehaviorType type)
+        {
+            var repeatBehaviour = new RepeatBehavior(1) { Type = type };
+            Assert.Equal(type == RepeatBehaviorType.Count, repeatBehaviour.HasCount);
+            Assert.Equal(type == RepeatBehaviorType.Duration, repeatBehaviour.HasDuration);
+        }
+
+        public static IEnumerable<object[]> Equals_TestData()
+        {
+            yield return new object[] { new RepeatBehavior(2), new RepeatBehavior(2), true };
+            yield return new object[] { new RepeatBehavior(2), new RepeatBehavior(1), false };
+            yield return new object[] { new RepeatBehavior(2), RepeatBehavior.Forever, false };
+            yield return new object[] { new RepeatBehavior(2), new RepeatBehavior(TimeSpan.FromSeconds(2)), false };
+
+            yield return new object[] { new RepeatBehavior(TimeSpan.FromSeconds(2)), new RepeatBehavior(TimeSpan.FromSeconds(2)), true };
+            yield return new object[] { new RepeatBehavior(TimeSpan.FromSeconds(2)), new RepeatBehavior(TimeSpan.FromSeconds(1)), false };
+            yield return new object[] { new RepeatBehavior(TimeSpan.FromSeconds(2)), RepeatBehavior.Forever, false };
+            yield return new object[] { new RepeatBehavior(TimeSpan.FromSeconds(2)), new RepeatBehavior(2), false };
+
+            yield return new object[] { RepeatBehavior.Forever, RepeatBehavior.Forever, true };
+            yield return new object[] { RepeatBehavior.Forever, new RepeatBehavior(TimeSpan.FromSeconds(2)), false };
+            yield return new object[] { RepeatBehavior.Forever, new RepeatBehavior(2), false };
+
+            yield return new object[] { new RepeatBehavior { Type = RepeatBehaviorType.Count - 1 }, new RepeatBehavior { Type = RepeatBehaviorType.Count - 1 }, false };
+            yield return new object[] { new RepeatBehavior { Type = RepeatBehaviorType.Forever + 1 }, new RepeatBehavior { Type = RepeatBehaviorType.Count + 1 }, false };
+            yield return new object[] { new RepeatBehavior(TimeSpan.FromSeconds(2)), new object(), false };
+            yield return new object[] { new RepeatBehavior(TimeSpan.FromSeconds(2)), null, false };
+        }
+
+        [Theory]
+        [MemberData(nameof(Equals_TestData))]
+        public void Equals_Object_ReturnsExpected(RepeatBehavior repeatBehaviour, object other, bool expected)
+        {
+            Assert.Equal(expected, repeatBehaviour.Equals(other));
+            if (other is RepeatBehavior otherRepeatBehaviour)
+            {
+                Assert.Equal(expected, RepeatBehavior.Equals(repeatBehaviour, otherRepeatBehaviour));
+                Assert.Equal(expected, repeatBehaviour.Equals(otherRepeatBehaviour));
+                Assert.Equal(expected, repeatBehaviour == otherRepeatBehaviour);
+                Assert.Equal(!expected, repeatBehaviour != otherRepeatBehaviour);
+
+                if (repeatBehaviour.Type >= RepeatBehaviorType.Count && repeatBehaviour.Type <= RepeatBehaviorType.Forever)
+                {
+                    Assert.Equal(expected, repeatBehaviour.GetHashCode().Equals(otherRepeatBehaviour.GetHashCode()));
+                }
+                else if (repeatBehaviour.Type == otherRepeatBehaviour.Type)
+                {
+                    Assert.Equal(repeatBehaviour.GetHashCode(), otherRepeatBehaviour.GetHashCode());
+                }
+            }
+        }
+
+        public static IEnumerable<object[]> ToString_TestData()
+        {
+            yield return new object[] { RepeatBehavior.Forever, null, null, "Forever" };
+            yield return new object[] { RepeatBehavior.Forever, "InvalidFormat", CultureInfo.CurrentCulture, "Forever" };
+
+            yield return new object[] { new RepeatBehavior(TimeSpan.FromSeconds(2)), null, null, TimeSpan.FromSeconds(2).ToString() };
+            yield return new object[] { new RepeatBehavior(TimeSpan.FromSeconds(2)), "InvalidFormat", CultureInfo.CurrentCulture, TimeSpan.FromSeconds(2).ToString() };
+
+            var culture = new CultureInfo("en-US");
+            culture.NumberFormat.NumberDecimalSeparator = "|";
+            yield return new object[] { new RepeatBehavior(2.2), "abc", culture, "abcx" };
+            yield return new object[] { new RepeatBehavior(2.2), "N4", culture, "2|2000x" };
+            yield return new object[] { new RepeatBehavior(2.2), null, culture, "2|2x" };
+
+            yield return new object[] { new RepeatBehavior(2.2), null, null, $"{2.2.ToString()}x" };
+        }
+
+        [Theory]
+        [MemberData(nameof(ToString_TestData))]
+        public void ToString_Invoke_ReturnsExpected(RepeatBehavior keyTime, string format, IFormatProvider formatProvider, string expected)
+        {
+            if (format == null)
+            {
+                if (formatProvider == null)
+                {
+                    Assert.Equal(expected, keyTime.ToString());
+                }
+
+                Assert.Equal(expected, keyTime.ToString(formatProvider));
+            }
+
+            Assert.Equal(expected, ((IFormattable)keyTime).ToString(format, formatProvider));
+        }
+    }
+}

--- a/tests/Windows/UI/Xaml/Media/MatrixTests.cs
+++ b/tests/Windows/UI/Xaml/Media/MatrixTests.cs
@@ -1,0 +1,368 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Windows.Foundation;
+using Xunit;
+
+namespace Windows.UI.Xaml.Media.Media3D.Tests
+{
+    public class Matrix3DTests
+    {
+        [Fact]
+        public void Ctor_Default()
+        {
+            var matrix = new Matrix3D();
+            Assert.Equal(0, matrix.M11);
+            Assert.Equal(0, matrix.M12);
+            Assert.Equal(0, matrix.M13);
+            Assert.Equal(0, matrix.M14);
+            Assert.Equal(0, matrix.M21);
+            Assert.Equal(0, matrix.M22);
+            Assert.Equal(0, matrix.M23);
+            Assert.Equal(0, matrix.M24);
+            Assert.Equal(0, matrix.M31);
+            Assert.Equal(0, matrix.M32);
+            Assert.Equal(0, matrix.M33);
+            Assert.Equal(0, matrix.M34);
+            Assert.Equal(0, matrix.OffsetX);
+            Assert.Equal(0, matrix.OffsetY);
+            Assert.Equal(0, matrix.OffsetZ);
+            Assert.Equal(0, matrix.M44);
+
+            Assert.False(matrix.IsIdentity);
+        }
+
+        [Theory]
+        [InlineData(-1, -2, -3, -4, -5, -6, -7, -8, -9, -10, -11, -12, -13, -14, -15, -16, false, false)]
+        [InlineData(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, false, false)]
+        [InlineData(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, false, false)]
+        [InlineData(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, true, true)]
+        [InlineData(1, 2, 0, 0, 0, 1, 2, 0, 4, 0, 1, 2, 0, 4, 0, 1, false, true)]
+        [InlineData(double.NaN, double.NaN, double.NaN, double.NaN, double.NaN, double.NaN, double.NaN, double.NaN, double.NaN, double.NaN, double.NaN, double.NaN, double.NaN, double.NaN, double.NaN, double.NaN, false, true)]
+        [InlineData(double.PositiveInfinity, double.PositiveInfinity, double.PositiveInfinity, double.PositiveInfinity, double.PositiveInfinity, double.PositiveInfinity, double.PositiveInfinity, double.PositiveInfinity, double.PositiveInfinity, double.PositiveInfinity, double.PositiveInfinity, double.PositiveInfinity, double.PositiveInfinity, double.PositiveInfinity, double.PositiveInfinity, double.PositiveInfinity, false, true)]
+        [InlineData(double.NegativeInfinity, double.NegativeInfinity, double.NegativeInfinity, double.NegativeInfinity, double.NegativeInfinity, double.NegativeInfinity, double.NegativeInfinity, double.NegativeInfinity, double.NegativeInfinity, double.NegativeInfinity, double.NegativeInfinity, double.NegativeInfinity, double.NegativeInfinity, double.NegativeInfinity, double.NegativeInfinity, double.NegativeInfinity, false, true)]
+        public void Ctor_Values(double m11, double m12, double m13, double m14,
+                                double m21, double m22, double m23, double m24,
+                                double m31, double m32, double m33, double m34, 
+                                double offsetX, double offsetY, double offsetZ, double m44, bool expectedIsIdentity, bool expectedHasInverse)
+        {
+            var matrix = new Matrix3D(m11, m12, m13, m14, m21, m22, m23, m24, m31, m32, m33, m34, offsetX, offsetY, offsetZ, m44);
+            Assert.Equal(m11, matrix.M11);
+            Assert.Equal(m12, matrix.M12);
+            Assert.Equal(m13, matrix.M13);
+            Assert.Equal(m14, matrix.M14);
+            Assert.Equal(m21, matrix.M21);
+            Assert.Equal(m22, matrix.M22);
+            Assert.Equal(m23, matrix.M23);
+            Assert.Equal(m24, matrix.M24);
+            Assert.Equal(m31, matrix.M31);
+            Assert.Equal(m32, matrix.M32);
+            Assert.Equal(m33, matrix.M33);
+            Assert.Equal(m34, matrix.M34);
+            Assert.Equal(offsetX, matrix.OffsetX);
+            Assert.Equal(offsetY, matrix.OffsetY);
+            Assert.Equal(offsetZ, matrix.OffsetZ);
+            Assert.Equal(m44, matrix.M44);
+
+            Assert.Equal(expectedIsIdentity, matrix.IsIdentity);
+            Assert.Equal(expectedHasInverse, matrix.HasInverse);
+        }
+
+        [Fact]
+        public void Identity_Get_ReturnsExpected()
+        {
+            Matrix3D matrix = Matrix3D.Identity;
+            Assert.Equal(1, matrix.M11);
+            Assert.Equal(0, matrix.M12);
+            Assert.Equal(0, matrix.M13);
+            Assert.Equal(0, matrix.M14);
+            Assert.Equal(0, matrix.M21);
+            Assert.Equal(1, matrix.M22);
+            Assert.Equal(0, matrix.M23);
+            Assert.Equal(0, matrix.M24);
+            Assert.Equal(0, matrix.M31);
+            Assert.Equal(0, matrix.M32);
+            Assert.Equal(1, matrix.M33);
+            Assert.Equal(0, matrix.M34);
+            Assert.Equal(0, matrix.OffsetX);
+            Assert.Equal(0, matrix.OffsetY);
+            Assert.Equal(0, matrix.OffsetZ);
+            Assert.Equal(1, matrix.M44);
+
+            Assert.True(matrix.IsIdentity);
+            Assert.True(matrix.HasInverse);
+        }
+
+        public static IEnumerable<object[]> Values_TestData()
+        {
+            yield return new object[] { -1 };
+            yield return new object[] { 0 };
+            yield return new object[] { 1 };
+            yield return new object[] { float.NaN };
+            yield return new object[] { float.PositiveInfinity };
+            yield return new object[] { float.NegativeInfinity };
+        }
+
+        [Theory]
+        [MemberData(nameof(Values_TestData))]
+        public void M11_Set_GetReturnsExpected(double value)
+        {
+            var matrix = new Matrix3D { M11 = value };
+            Assert.Equal(value, matrix.M11);
+        }
+
+        [Theory]
+        [MemberData(nameof(Values_TestData))]
+        public void M12_Set_GetReturnsExpected(double value)
+        {
+            var matrix = new Matrix3D { M12 = value };
+            Assert.Equal(value, matrix.M12);
+        }
+
+        [Theory]
+        [MemberData(nameof(Values_TestData))]
+        public void M13_Set_GetReturnsExpected(double value)
+        {
+            var matrix = new Matrix3D { M13 = value };
+            Assert.Equal(value, matrix.M13);
+        }
+
+        [Theory]
+        [MemberData(nameof(Values_TestData))]
+        public void M14_Set_GetReturnsExpected(double value)
+        {
+            var matrix = new Matrix3D { M14 = value };
+            Assert.Equal(value, matrix.M14);
+        }
+
+        [Theory]
+        [MemberData(nameof(Values_TestData))]
+        public void M21_Set_GetReturnsExpected(double value)
+        {
+            var matrix = new Matrix3D { M21 = value };
+            Assert.Equal(value, matrix.M21);
+        }
+
+        [Theory]
+        [MemberData(nameof(Values_TestData))]
+        public void M22_Set_GetReturnsExpected(double value)
+        {
+            var matrix = new Matrix3D { M22 = value };
+            Assert.Equal(value, matrix.M22);
+        }
+
+        [Theory]
+        [MemberData(nameof(Values_TestData))]
+        public void M23_Set_GetReturnsExpected(double value)
+        {
+            var matrix = new Matrix3D { M23 = value };
+            Assert.Equal(value, matrix.M23);
+        }
+
+        [Theory]
+        [MemberData(nameof(Values_TestData))]
+        public void M24_Set_GetReturnsExpected(double value)
+        {
+            var matrix = new Matrix3D { M24 = value };
+            Assert.Equal(value, matrix.M24);
+        }
+        [Theory]
+        [MemberData(nameof(Values_TestData))]
+        public void M31_Set_GetReturnsExpected(double value)
+        {
+            var matrix = new Matrix3D { M31 = value };
+            Assert.Equal(value, matrix.M31);
+        }
+
+        [Theory]
+        [MemberData(nameof(Values_TestData))]
+        public void M32_Set_GetReturnsExpected(double value)
+        {
+            var matrix = new Matrix3D { M32 = value };
+            Assert.Equal(value, matrix.M32);
+        }
+
+        [Theory]
+        [MemberData(nameof(Values_TestData))]
+        public void M33_Set_GetReturnsExpected(double value)
+        {
+            var matrix = new Matrix3D { M33 = value };
+            Assert.Equal(value, matrix.M33);
+        }
+
+        [Theory]
+        [MemberData(nameof(Values_TestData))]
+        public void M34_Set_GetReturnsExpected(double value)
+        {
+            var matrix = new Matrix3D { M34 = value };
+            Assert.Equal(value, matrix.M34);
+        }
+
+        [Theory]
+        [MemberData(nameof(Values_TestData))]
+        public void OffsetX_Set_GetReturnsExpected(double value)
+        {
+            var matrix = new Matrix3D { OffsetX = value };
+            Assert.Equal(value, matrix.OffsetX);
+        }
+
+        [Theory]
+        [MemberData(nameof(Values_TestData))]
+        public void OffsetY_Set_GetReturnsExpected(double value)
+        {
+            var matrix = new Matrix3D { OffsetY = value };
+            Assert.Equal(value, matrix.OffsetY);
+        }
+
+        [Theory]
+        [MemberData(nameof(Values_TestData))]
+        public void OffsetZ_Set_GetReturnsExpected(double value)
+        {
+            var matrix = new Matrix3D { OffsetZ = value };
+            Assert.Equal(value, matrix.OffsetZ);
+        }
+
+        [Theory]
+        [MemberData(nameof(Values_TestData))]
+        public void M44_Set_GetReturnsExpected(double value)
+        {
+            var matrix = new Matrix3D { M44 = value };
+            Assert.Equal(value, matrix.M44);
+        }
+
+        public static IEnumerable<object[]> Equals_TestData()
+        {
+            var matrix = new Matrix3D(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+
+            yield return new object[] { matrix, new Matrix3D(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16), true };
+            yield return new object[] { matrix, new Matrix3D(2, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16), false };
+            yield return new object[] { matrix, new Matrix3D(1, 3, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16), false };
+            yield return new object[] { matrix, new Matrix3D(1, 2, 4, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16), false };
+            yield return new object[] { matrix, new Matrix3D(1, 2, 3, 5, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16), false };
+            yield return new object[] { matrix, new Matrix3D(1, 2, 3, 4, 6, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16), false };
+            yield return new object[] { matrix, new Matrix3D(1, 2, 3, 4, 5, 7, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16), false };
+            yield return new object[] { matrix, new Matrix3D(1, 2, 3, 4, 5, 6, 8, 8, 9, 10, 11, 12, 13, 14, 15, 16), false };
+            yield return new object[] { matrix, new Matrix3D(1, 2, 3, 4, 5, 6, 7, 9, 9, 10, 11, 12, 13, 14, 15, 16), false };
+            yield return new object[] { matrix, new Matrix3D(1, 2, 3, 4, 5, 6, 7, 8, 10, 10, 11, 12, 13, 14, 15, 16), false };
+            yield return new object[] { matrix, new Matrix3D(1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 11, 12, 13, 14, 15, 16), false };
+            yield return new object[] { matrix, new Matrix3D(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 12, 13, 14, 15, 16), false };
+            yield return new object[] { matrix, new Matrix3D(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 13, 14, 15, 16), false };
+            yield return new object[] { matrix, new Matrix3D(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 14, 15, 16), false };
+            yield return new object[] { matrix, new Matrix3D(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15, 15, 16), false };
+            yield return new object[] { matrix, new Matrix3D(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 16), false };
+            yield return new object[] { matrix, new Matrix3D(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 17), false };
+
+            yield return new object[] { Matrix3D.Identity, Matrix3D.Identity, true };
+            yield return new object[] { Matrix3D.Identity, new Matrix3D(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1), true };
+            yield return new object[] { Matrix3D.Identity, new Matrix3D(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1), false };
+
+            yield return new object[] { Matrix3D.Identity, new object(), false };
+            yield return new object[] { Matrix3D.Identity, null, false };
+        }
+
+        [Theory]
+        [MemberData(nameof(Equals_TestData))]
+        public void Equals_Object_ReturnsExpected(Matrix3D matrix, object other, bool expected)
+        {
+            Assert.Equal(expected, matrix.Equals(other));
+            if (other is Matrix3D otherMatrix)
+            {
+                Assert.Equal(expected, matrix.Equals(otherMatrix));
+                Assert.Equal(expected, matrix == otherMatrix);
+                Assert.Equal(!expected, matrix != otherMatrix);
+                Assert.Equal(expected, matrix.GetHashCode().Equals(otherMatrix.GetHashCode()));
+            }
+        }
+
+        [Fact]
+        public void Multiply_Matrices_ReturnsExpected()
+        {
+            var matrix1 = new Matrix3D(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+            var matrix2 = new Matrix3D(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+
+            Matrix3D result = matrix1 * matrix2;
+            Assert.Equal(new Matrix3D(90, 100, 110, 120, 202, 228, 254, 280, 314, 356, 398, 440, 426, 484, 542, 600), result);
+
+            Assert.False(result.IsIdentity);
+            Assert.False(result.HasInverse);
+        }
+
+        [Fact]
+        public void Invert_Affine_ReturnsExpected()
+        {
+            var matrix = new Matrix3D(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);
+            matrix.Invert();
+
+            Assert.Equal(new Matrix3D(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1), matrix);
+        }
+
+        [Fact]
+        public void Invert_NonAffine_ReturnsExpected()
+        {
+            var matrix = new Matrix3D(1, 2, 0, 0, 0, 1, 2, 0, 4, 0, 1, 2, 0, 4, 0, 1);
+            matrix.Invert();
+
+            string expected = ((IFormattable)new Matrix3D(0.515151515151515, -0.0606060606060606, 0.121212121212121, -0.242424242424242, 0.242424242424242, 0.0303030303030303, -0.0606060606060606, 0.121212121212121, -0.121212121212121, 0.484848484848485, 0.0303030303030303, -0.0606060606060606, -0.96969696969697, -0.121212121212121, 0.242424242424242, 0.515151515151515)).ToString("N2", null);
+            Assert.Equal(expected, ((IFormattable)matrix).ToString("N2", null));
+        }
+
+        [Fact]
+        public void Invert_NotInvertible_ThrowsInvalidOperationException()
+        {
+            var matrix = new Matrix3D(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+            Assert.Throws<InvalidOperationException>(() => matrix.Invert());
+        }
+
+        [Fact]
+        public void Invert_AffineNotInvertible_ThrowsInvalidOperationException()
+        {
+            var matrix = new Matrix3D(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1);
+            Assert.Throws<InvalidOperationException>(() => matrix.Invert());
+        }
+
+        public static IEnumerable<object[]> ToString_TestData()
+        {
+            string cultureSeparator = CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator;
+            char decimalSeparator = cultureSeparator.Length > 0 && cultureSeparator[0] == ',' ? ';' : ',';
+
+            yield return new object[] { Matrix3D.Identity, null, null, "Identity" };
+            yield return new object[] { Matrix3D.Identity, "InvalidFormat", CultureInfo.CurrentCulture, "Identity" };
+            yield return new object[] { new Matrix3D(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16), null, null, $"1{decimalSeparator}2{decimalSeparator}3{decimalSeparator}4{decimalSeparator}5{decimalSeparator}6{decimalSeparator}7{decimalSeparator}8{decimalSeparator}9{decimalSeparator}10{decimalSeparator}11{decimalSeparator}12{decimalSeparator}13{decimalSeparator}14{decimalSeparator}15{decimalSeparator}16" };
+
+            var matrix = new Matrix3D(2.2, 2.2, 2.2, 2.2, 2.2, 2.2, 2.2, 2.2, 2.2, 2.2, 2.2, 2.2, 2.2, 2.2, 2.2, 2.2);
+
+            var culture = new CultureInfo("en-US");
+            culture.NumberFormat.NumberDecimalSeparator = "|";
+            yield return new object[] { matrix, "abc", culture, "abc,abc,abc,abc,abc,abc,abc,abc,abc,abc,abc,abc,abc,abc,abc,abc" };
+            yield return new object[] { matrix, "N4", culture, "2|2000,2|2000,2|2000,2|2000,2|2000,2|2000,2|2000,2|2000,2|2000,2|2000,2|2000,2|2000,2|2000,2|2000,2|2000,2|2000" };
+            yield return new object[] { matrix, null, culture, "2|2,2|2,2|2,2|2,2|2,2|2,2|2,2|2,2|2,2|2,2|2,2|2,2|2,2|2,2|2,2|2" };
+
+            var commaCulture = new CultureInfo("en-US");
+            commaCulture.NumberFormat.NumberDecimalSeparator = ",";
+            yield return new object[] { matrix, null, commaCulture, "2,2;2,2;2,2;2,2;2,2;2,2;2,2;2,2;2,2;2,2;2,2;2,2;2,2;2,2;2,2;2,2" };
+
+            yield return new object[] { matrix, null, null, $"{2.2.ToString()}{decimalSeparator}{2.2.ToString()}{decimalSeparator}{2.2.ToString()}{decimalSeparator}{2.2.ToString()}{decimalSeparator}{2.2.ToString()}{decimalSeparator}{2.2.ToString()}{decimalSeparator}{2.2.ToString()}{decimalSeparator}{2.2.ToString()}{decimalSeparator}{2.2.ToString()}{decimalSeparator}{2.2.ToString()}{decimalSeparator}{2.2.ToString()}{decimalSeparator}{2.2.ToString()}{decimalSeparator}{2.2.ToString()}{decimalSeparator}{2.2.ToString()}{decimalSeparator}{2.2.ToString()}{decimalSeparator}{2.2.ToString()}" };
+        }
+
+        [Theory]
+        [MemberData(nameof(ToString_TestData))]
+        public void ToString_Invoke_ReturnsExpected(Matrix3D matrix, string format, IFormatProvider formatProvider, string expected)
+        {
+            if (format == null)
+            {
+                if (formatProvider == null)
+                {
+                    Assert.Equal(expected, matrix.ToString());
+                }
+
+                Assert.Equal(expected, matrix.ToString(formatProvider));
+            }
+
+            Assert.Equal(expected, ((IFormattable)matrix).ToString(format, formatProvider));
+        }
+    }
+}

--- a/tests/Windows/UI/Xaml/Media3D/Matrix3DTests.cs
+++ b/tests/Windows/UI/Xaml/Media3D/Matrix3DTests.cs
@@ -1,0 +1,211 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using Windows.Foundation;
+using Xunit;
+
+namespace Windows.UI.Xaml.Media.Tests
+{
+    public class MatrixTests
+    {
+        [Fact]
+        public void Ctor_Default()
+        {
+            var matrix = new Matrix();
+            Assert.Equal(0, matrix.M11);
+            Assert.Equal(0, matrix.M12);
+            Assert.Equal(0, matrix.M21);
+            Assert.Equal(0, matrix.M22);
+            Assert.Equal(0, matrix.OffsetX);
+            Assert.Equal(0, matrix.OffsetY);
+
+            Assert.False(matrix.IsIdentity);
+        }
+
+        [Theory]
+        [InlineData(-1, -2, -3, -4, -5, -6, false)]
+        [InlineData(0, 0, 0, 0, 0, 0, false)]
+        [InlineData(1, 1, 1, 1, 1, 1, false)]
+        [InlineData(1, 0, 0, 1, 0, 0, true)]
+        [InlineData(double.NaN, double.NaN, double.NaN, double.NaN, double.NaN, double.NaN, false)]
+        [InlineData(double.PositiveInfinity, double.PositiveInfinity, double.PositiveInfinity, double.PositiveInfinity, double.PositiveInfinity, double.PositiveInfinity, false)]
+        [InlineData(double.NegativeInfinity, double.NegativeInfinity, double.NegativeInfinity, double.NegativeInfinity, double.NegativeInfinity, double.NegativeInfinity, false)]
+        public void Ctor_Values(double m11, double m12, double m21, double m22, double offsetX, double offsetY, bool expectedIsIdentity)
+        {
+            var matrix = new Matrix(m11, m12, m21, m22, offsetX, offsetY);
+            Assert.Equal(m11, matrix.M11);
+            Assert.Equal(m12, matrix.M12);
+            Assert.Equal(m21, matrix.M21);
+            Assert.Equal(m22, matrix.M22);
+            Assert.Equal(offsetX, matrix.OffsetX);
+            Assert.Equal(offsetY, matrix.OffsetY);
+
+            Assert.Equal(expectedIsIdentity, matrix.IsIdentity);
+        }
+
+        [Fact]
+        public void Identity_Get_ReturnsExpected()
+        {
+            Matrix matrix = Matrix.Identity;
+            Assert.Equal(1, matrix.M11);
+            Assert.Equal(0, matrix.M12);
+            Assert.Equal(0, matrix.M21);
+            Assert.Equal(1, matrix.M22);
+            Assert.Equal(0, matrix.OffsetX);
+            Assert.Equal(0, matrix.OffsetY);
+
+            Assert.True(matrix.IsIdentity);
+        }
+
+        public static IEnumerable<object[]> Values_TestData()
+        {
+            yield return new object[] { -1 };
+            yield return new object[] { 0 };
+            yield return new object[] { 1 };
+            yield return new object[] { float.NaN };
+            yield return new object[] { float.PositiveInfinity };
+            yield return new object[] { float.NegativeInfinity };
+        }
+
+        [Theory]
+        [MemberData(nameof(Values_TestData))]
+        public void M11_Set_GetReturnsExpected(double value)
+        {
+            var matrix = new Matrix { M11 = value };
+            Assert.Equal(value, matrix.M11);
+        }
+
+        [Theory]
+        [MemberData(nameof(Values_TestData))]
+        public void M12_Set_GetReturnsExpected(double value)
+        {
+            var matrix = new Matrix { M12 = value };
+            Assert.Equal(value, matrix.M12);
+        }
+
+        [Theory]
+        [MemberData(nameof(Values_TestData))]
+        public void M21_Set_GetReturnsExpected(double value)
+        {
+            var matrix = new Matrix { M21 = value };
+            Assert.Equal(value, matrix.M21);
+        }
+
+        [Theory]
+        [MemberData(nameof(Values_TestData))]
+        public void M22_Set_GetReturnsExpected(double value)
+        {
+            var matrix = new Matrix { M22 = value };
+            Assert.Equal(value, matrix.M22);
+        }
+
+        [Theory]
+        [MemberData(nameof(Values_TestData))]
+        public void OffsetX_Set_GetReturnsExpected(double value)
+        {
+            var matrix = new Matrix { OffsetX = value };
+            Assert.Equal(value, matrix.OffsetX);
+        }
+
+        [Theory]
+        [MemberData(nameof(Values_TestData))]
+        public void OffsetY_Set_GetReturnsExpected(double value)
+        {
+            var matrix = new Matrix { OffsetY = value };
+            Assert.Equal(value, matrix.OffsetY);
+        }
+
+        [Fact]
+        public void Transform_Identity_ReturnsPoint()
+        {
+            Point transformedPoint = Matrix.Identity.Transform(new Point(1, 2));
+            Assert.Equal(new Point(1, 2), transformedPoint);
+        }
+
+        [Fact]
+        public void Transform_Point_ReturnsExpected()
+        {
+            var matrix = new Matrix(1, 2, 3, 4, 5, 6);
+            var point = new Point(1, 2);
+
+            Point transformedPoint = matrix.Transform(point);
+            Assert.Equal(new Point(12, 16), transformedPoint);
+        }
+
+        public static IEnumerable<object[]> Equals_TestData()
+        {
+            yield return new object[] { new Matrix(1, 2, 3, 4, 5, 6), new Matrix(1, 2, 3, 4, 5, 6), true };
+            yield return new object[] { new Matrix(1, 2, 3, 4, 5, 6), new Matrix(2, 2, 3, 4, 5, 6), false };
+            yield return new object[] { new Matrix(1, 2, 3, 4, 5, 6), new Matrix(1, 3, 3, 4, 5, 6), false };
+            yield return new object[] { new Matrix(1, 2, 3, 4, 5, 6), new Matrix(1, 2, 4, 4, 5, 6), false };
+            yield return new object[] { new Matrix(1, 2, 3, 4, 5, 6), new Matrix(1, 2, 3, 5, 5, 6), false };
+            yield return new object[] { new Matrix(1, 2, 3, 4, 5, 6), new Matrix(1, 2, 3, 4, 6, 6), false };
+            yield return new object[] { new Matrix(1, 2, 3, 4, 5, 6), new Matrix(1, 2, 3, 4, 5, 7), false };
+
+            yield return new object[] { Matrix.Identity, Matrix.Identity, true };
+            yield return new object[] { Matrix.Identity, new Matrix(1, 0, 0, 1, 0, 0), true };
+            yield return new object[] { Matrix.Identity, new Matrix(1, 0, 0, 0, 0, 0), false };
+
+            yield return new object[] { new Matrix(1, 2, 3, 4, 5, 6), new object(), false };
+            yield return new object[] { new Matrix(1, 2, 3, 4, 5, 6), null, false };
+        }
+
+        [Theory]
+        [MemberData(nameof(Equals_TestData))]
+        public void Equals_Object_ReturnsExpected(Matrix matrix, object other, bool expected)
+        {
+            Assert.Equal(expected, matrix.Equals(other));
+            if (other is Matrix otherMatrix)
+            {
+                Assert.Equal(expected, matrix.Equals(otherMatrix));
+                Assert.Equal(expected, matrix == otherMatrix);
+                Assert.Equal(!expected, matrix != otherMatrix);
+                Assert.Equal(expected, matrix.GetHashCode().Equals(otherMatrix.GetHashCode()));
+            }
+        }
+
+        public static IEnumerable<object[]> ToString_TestData()
+        {
+            string cultureSeparator = CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator;
+            char decimalSeparator = cultureSeparator.Length > 0 && cultureSeparator[0] == ',' ? ';' : ',';
+
+            yield return new object[] { Matrix.Identity, null, null, "Identity" };
+            yield return new object[] { Matrix.Identity, "InvalidFormat", CultureInfo.CurrentCulture, "Identity" };
+            yield return new object[] { new Matrix(1, 2, 3, 4, 5, 6), null, null, $"1{decimalSeparator}2{decimalSeparator}3{decimalSeparator}4{decimalSeparator}5{decimalSeparator}6" };
+
+            var culture = new CultureInfo("en-US");
+            culture.NumberFormat.NumberDecimalSeparator = "|";
+            yield return new object[] { new Matrix(2.2, 2.2, 2.2, 2.2, 2.2, 2.2), "abc", culture, "abc,abc,abc,abc,abc,abc" };
+            yield return new object[] { new Matrix(2.2, 2.2, 2.2, 2.2, 2.2, 2.2), "N4", culture, "2|2000,2|2000,2|2000,2|2000,2|2000,2|2000" };
+            yield return new object[] { new Matrix(2.2, 2.2, 2.2, 2.2, 2.2, 2.2), null, culture, "2|2,2|2,2|2,2|2,2|2,2|2" };
+
+            var commaCulture = new CultureInfo("en-US");
+            commaCulture.NumberFormat.NumberDecimalSeparator = ",";
+            yield return new object[] { new Matrix(2.2, 2.2, 2.2, 2.2, 2.2, 2.2), null, commaCulture, "2,2;2,2;2,2;2,2;2,2;2,2" };
+
+            yield return new object[] { new Matrix(2.2, 2.2, 2.2, 2.2, 2.2, 2.2), null, null, $"{2.2.ToString()}{decimalSeparator}{2.2.ToString()}{decimalSeparator}{2.2.ToString()}{decimalSeparator}{2.2.ToString()}{decimalSeparator}{2.2.ToString()}{decimalSeparator}{2.2.ToString()}" };
+        }
+
+        [Theory]
+        [MemberData(nameof(ToString_TestData))]
+        public void ToString_Invoke_ReturnsExpected(Matrix matrix, string format, IFormatProvider formatProvider, string expected)
+        {
+            if (format == null)
+            {
+                if (formatProvider == null)
+                {
+                    Assert.Equal(expected, matrix.ToString());
+                }
+
+                Assert.Equal(expected, matrix.ToString(formatProvider));
+            }
+
+            Assert.Equal(expected, ((IFormattable)matrix).ToString(format, formatProvider));
+        }
+    }
+}

--- a/tests/Windows/UI/Xaml/ThicknessTests.cs
+++ b/tests/Windows/UI/Xaml/ThicknessTests.cs
@@ -1,0 +1,161 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace Windows.UI.Xaml.Tests
+{
+    public class ThicknessTests
+    {
+        [Fact]
+        public void Ctor_Default()
+        {
+            var thickness = new Thickness();
+            Assert.Equal(0, thickness.Left);
+            Assert.Equal(0, thickness.Top);
+            Assert.Equal(0, thickness.Right);
+            Assert.Equal(0, thickness.Bottom);
+        }
+
+        public static IEnumerable<object[]> Values_TestData()
+        {
+            yield return new object[] { -1 };
+            yield return new object[] { 0 };
+            yield return new object[] { 1 };
+            yield return new object[] { double.MaxValue };
+            yield return new object[] { double.NaN };
+            yield return new object[] { double.PositiveInfinity };
+            yield return new object[] { double.NegativeInfinity };
+        }
+
+        [Theory]
+        [MemberData(nameof(Values_TestData))]
+        public void Ctor_Default(double uniformLength)
+        {
+            var thickness = new Thickness(uniformLength);
+            Assert.Equal(uniformLength, thickness.Left);
+            Assert.Equal(uniformLength, thickness.Top);
+            Assert.Equal(uniformLength, thickness.Right);
+            Assert.Equal(uniformLength, thickness.Bottom);
+        }
+
+        [Theory]
+        [InlineData(-1, -2, -3, -4)]
+        [InlineData(0, 0, 0, 0)]
+        [InlineData(1, 2, 3, 4)]
+        [InlineData(double.NaN, double.NaN, double.NaN, double.NaN)]
+        [InlineData(double.PositiveInfinity, double.PositiveInfinity, double.PositiveInfinity, double.PositiveInfinity)]
+        [InlineData(double.NegativeInfinity, double.NegativeInfinity, double.NegativeInfinity, double.NegativeInfinity)]
+        public void Ctor_Left_Top_Right_Bottom(double left, double top, double right, double bottom)
+        {
+            var thickness = new Thickness(left, top, right, bottom);
+            Assert.Equal(left, thickness.Left);
+            Assert.Equal(top, thickness.Top);
+            Assert.Equal(right, thickness.Right);
+            Assert.Equal(bottom, thickness.Bottom);
+        }
+
+        [Theory]
+        [MemberData(nameof(Values_TestData))]
+        public void Left_Set_GetReturnsExpected(double value)
+        {
+            var thickness = new Thickness { Left = value };
+            Assert.Equal(value, thickness.Left);
+        }
+
+        [Theory]
+        [MemberData(nameof(Values_TestData))]
+        public void Top_Set_GetReturnsExpected(double value)
+        {
+            var thickness = new Thickness { Top = value };
+            Assert.Equal(value, thickness.Top);
+        }
+
+        [Theory]
+        [MemberData(nameof(Values_TestData))]
+        public void Right_Set_GetReturnsExpected(double value)
+        {
+            var thickness = new Thickness { Right = value };
+            Assert.Equal(value, thickness.Right);
+        }
+
+        [Theory]
+        [MemberData(nameof(Values_TestData))]
+        public void Bottom_Set_GetReturnsExpected(double value)
+        {
+            var cornerRadius = new Thickness { Bottom = value };
+            Assert.Equal(value, cornerRadius.Bottom);
+        }
+
+        public static IEnumerable<object[]> Equals_TestData()
+        {
+            yield return new object[] { new Thickness(1, 2, 3, 4), new Thickness(1, 2, 3, 4), true };
+            yield return new object[] { new Thickness(1, 2, 3, 4), new Thickness(2, 2, 3, 4), false };
+            yield return new object[] { new Thickness(1, 2, 3, 4), new Thickness(1, 3, 3, 4), false };
+            yield return new object[] { new Thickness(1, 2, 3, 4), new Thickness(1, 2, 4, 4), false };
+            yield return new object[] { new Thickness(1, 2, 3, 4), new Thickness(1, 2, 3, 5), false };
+
+            yield return new object[] { new Thickness(1, 2, 3, 4), new object(), false };
+            yield return new object[] { new Thickness(1, 2, 3, 4), null, false };
+        }
+
+        [Theory]
+        [MemberData(nameof(Equals_TestData))]
+        public void Equals_Object_ReturnsExpected(Thickness thickness, object other, bool expected)
+        {
+            Assert.Equal(expected, thickness.Equals(other));
+            if (other is Thickness otherThickness)
+            {
+                Assert.Equal(expected, thickness.Equals(otherThickness));
+                Assert.Equal(expected, thickness == otherThickness);
+                Assert.Equal(!expected, thickness != otherThickness);
+                Assert.Equal(expected, thickness.GetHashCode().Equals(otherThickness.GetHashCode()));
+            }
+        }
+
+        [Fact]
+        public void ToString_Invoke_ReturnsExpected()
+        {
+            var thickness = new Thickness(1, 2.2, 3, 4);
+            Assert.Equal("1,2.2,3,4", thickness.ToString());
+        }
+
+        [Fact]
+        public void ToString_NaN_ReturnsAuto()
+        {
+            Thickness thickness = new FakeThickness
+            {
+                Left = double.NaN,
+                Top = double.NaN,
+                Right = double.NaN,
+                Bottom = double.NaN
+            }.ToActual();
+            Assert.Equal("Auto,Auto,Auto,Auto", thickness.ToString());
+        }
+
+        public struct FakeThickness
+        {
+            public double Left;
+            public double Top;
+            public double Right;
+            public double Bottom;
+
+            public Thickness ToActual()
+            {
+                ThicknessWrapper wrapper = default(ThicknessWrapper);
+                wrapper.Fake = this;
+                return wrapper.Actual;
+            }
+        }
+
+        [StructLayout(LayoutKind.Explicit)]
+        public struct ThicknessWrapper
+        {
+            [FieldOffset(0)] public Thickness Actual;
+            [FieldOffset(0)] public FakeThickness Fake;
+        }
+    }
+}


### PR DESCRIPTION
Still in draft because there are build failures.

Migrated from 3.1.

The [System.Runtime.WindowsRuntime.UI.Xaml nuget package](https://www.nuget.org/packages/System.Runtime.WindowsRuntime.UI.Xaml) has this information:

- Supports .NET Standard 2.0.
- Has public types in .NET 6.0.
- Has PNSE in .NET 6.0.

When consuming this nuget package in a console app, then printing `typeof(Windows.UI.Xaml.Media.Matrix).Assembly.CodeBase` I confirmed that:

When targeting .NET Framework 4.6.2, the installed version is used: `file:///C:/windows/Microsoft.Net/assembly/GAC_MSIL/System.Runtime.WindowsRuntime.UI.Xaml/v4.0_4.0.0.0__b77a5c561934e089/System.Runtime.WindowsRuntime.UI.Xaml.dll`

When targeting .NET 6.0, the assembly in the package is used: `bin/Debug/net6.0/runtimes/win/lib/netcoreapp3.0/System.Runtime.WindowsRuntime.UI.Xaml.dll`