### PR TITLE
Add .NET 6.0.27 to global.json tools runtimes

### DIFF
--- a/global.json
+++ b/global.json
@@ -5,7 +5,12 @@
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "8.0.101"
+    "dotnet": "8.0.101",
+    "runtimes" : {
+      "dotnet" : [
+        "6.0.27"
+      ]
+    }
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.24113.2",


### PR DESCRIPTION
Required to get the tests of https://github.com/dotnet/maintenance-packages/pull/40 to pass.