### PR TITLE
Fix official build publishing

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -3,17 +3,17 @@
   <ProductDependencies>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.24158.4">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.24165.4">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>052a4b9e7a9bdb9744c86c05665f1b46e4d59b15</Sha>
+      <Sha>f311667e0587f19c3fa9553a909975662107a351</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="8.0.0-beta.24158.4">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="8.0.0-beta.24165.4">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>052a4b9e7a9bdb9744c86c05665f1b46e4d59b15</Sha>
+      <Sha>f311667e0587f19c3fa9553a909975662107a351</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="8.0.0-beta.24158.4">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="8.0.0-beta.24165.4">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>052a4b9e7a9bdb9744c86c05665f1b46e4d59b15</Sha>
+      <Sha>f311667e0587f19c3fa9553a909975662107a351</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Arcade dependencies -->
-    <MicrosoftDotNetRemoteExecutorVersion>8.0.0-beta.24158.4</MicrosoftDotNetRemoteExecutorVersion>
-    <MicrosoftDotNetXUnitExtensionsVersion>8.0.0-beta.24158.4</MicrosoftDotNetXUnitExtensionsVersion>
+    <MicrosoftDotNetRemoteExecutorVersion>8.0.0-beta.24165.4</MicrosoftDotNetRemoteExecutorVersion>
+    <MicrosoftDotNetXUnitExtensionsVersion>8.0.0-beta.24165.4</MicrosoftDotNetXUnitExtensionsVersion>
   </PropertyGroup>
 </Project>

--- a/eng/common/templates-official/job/job.yml
+++ b/eng/common/templates-official/job/job.yml
@@ -206,9 +206,11 @@ jobs:
         continueOnError: true
         condition: always()
     - ${{ if and(ne(parameters.artifacts.publish.logs, 'false'), ne(parameters.artifacts.publish.logs, '')) }}:
-      - publish: artifacts/log
-        artifact: ${{ coalesce(parameters.artifacts.publish.logs.name, 'Logs_Build_$(Agent.Os)_$(_BuildConfig)') }}
-        displayName: Publish logs
+      - task: 1ES.PublishPipelineArtifact@1
+        inputs:
+          targetPath: 'artifacts/log'
+          artifactName: ${{ coalesce(parameters.artifacts.publish.logs.name, 'Logs_Build_$(Agent.Os)_$(_BuildConfig)') }}
+        displayName: 'Publish logs'
         continueOnError: true
         condition: always()
 
@@ -253,7 +255,9 @@ jobs:
         IgnoreDirectories: ${{ parameters.componentGovernanceIgnoreDirectories }}
 
   - ${{ if eq(parameters.enableBuildRetry, 'true') }}:
-    - publish: $(Build.SourcesDirectory)\eng\common\BuildConfiguration
-      artifact: BuildConfiguration
-      displayName: Publish build retry configuration
+    - task: 1ES.PublishPipelineArtifact@1
+      inputs:
+        targetPath: '$(Build.SourcesDirectory)\eng\common\BuildConfiguration'
+        artifactName: 'BuildConfiguration'
+      displayName: 'Publish build retry configuration'
       continueOnError: true

--- a/eng/common/templates-official/job/publish-build-assets.yml
+++ b/eng/common/templates-official/job/publish-build-assets.yml
@@ -94,14 +94,16 @@ jobs:
       inputs:
         targetType: inline
         script: |
-          Add-Content -Path "$(Build.StagingDirectory)/ReleaseConfigs.txt" -Value $(BARBuildId)
-          Add-Content -Path "$(Build.StagingDirectory)/ReleaseConfigs.txt" -Value "$(DefaultChannels)"
-          Add-Content -Path "$(Build.StagingDirectory)/ReleaseConfigs.txt" -Value $(IsStableBuild)
+          New-Item -Path "$(Build.StagingDirectory)/ReleaseConfigs" -ItemType Directory -Force
+          $filePath = "$(Build.StagingDirectory)/ReleaseConfigs/ReleaseConfigs.txt"
+          Add-Content -Path $filePath -Value $(BARBuildId)
+          Add-Content -Path $filePath -Value "$(DefaultChannels)"
+          Add-Content -Path $filePath -Value $(IsStableBuild)
     
     - task: 1ES.PublishBuildArtifacts@1
       displayName: Publish ReleaseConfigs Artifact
       inputs:
-        PathtoPublish: '$(Build.StagingDirectory)/ReleaseConfigs.txt'
+        PathtoPublish: '$(Build.StagingDirectory)/ReleaseConfigs'
         PublishLocation: Container
         ArtifactName: ReleaseConfigs
 

--- a/eng/pipelines/maintenance-packages.yml
+++ b/eng/pipelines/maintenance-packages.yml
@@ -53,12 +53,11 @@ extends:
       jobs:
       - template: /eng/common/templates-official/jobs/jobs.yml@self
         parameters:
-          # log publish is broken, https://github.com/dotnet/dnceng/issues/2133
-          # artifacts:
-          #   publish:
-          #     artifacts: false
-          #     logs: true
-          #     manifests: true
+          artifacts:
+            publish:
+              artifacts: false
+              logs: true
+              manifests: true
           enableMicrobuild: true
           enablePublishUsingPipelines: true
           publishAssetsImmediately: true

--- a/global.json
+++ b/global.json
@@ -13,7 +13,7 @@
     }
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.24158.4",
+    "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.24165.4",
     "Microsoft.Build.Traversal": "3.4.0"
   }
 }


### PR DESCRIPTION
This pulls in the latest 8.0 arcade and undoes the workaround for log (and manifest publishing).  The missing manifest publishing was causing our official builds to fail.