### PR TITLE
Fix CI testing in Unix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ syntax: glob
 # note: there is no trailing slash so if these are symlinks (which are seen as files,
 #       instead of directories), git will still ignore them.
 .dotnet
+.mono
 .packages
 .tools
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -35,4 +35,14 @@
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.TargetFramework" PrivateAssets="all" />
   </ItemGroup>
 
+  <!-- This workaround prevents the execution of the RunTests target even when SkipTests is set to true.
+  It can be removed after this bug is fixed: https://github.com/dotnet/arcade/pull/14665 -->
+  <Target Name="_SetSkipTests" AfterTargets="_OuterGetTestsToRun">
+
+    <PropertyGroup>
+      <SkipTests Condition="'@(TestToRun)' == ''">true</SkipTests>
+    </PropertyGroup>
+
+  </Target>
+
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -38,14 +38,4 @@
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.TargetFramework" PrivateAssets="all" />
   </ItemGroup>
 
-  <!-- This workaround prevents the execution of the RunTests target even when SkipTests is set to true.
-  It can be removed after this bug is fixed: https://github.com/dotnet/arcade/pull/14665 -->
-  <Target Name="_SetSkipTests" AfterTargets="_OuterGetTestsToRun">
-
-    <PropertyGroup>
-      <SkipTests Condition="'@(TestToRun)' == ''">true</SkipTests>
-    </PropertyGroup>
-
-  </Target>
-
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -19,6 +19,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
+  <!-- The VSTest target is not bound by any conditions, needs to be overriden when we want to skip tests. -->
+  <Import Project="$(RepositoryEngineeringDir)testing\skiptests.targets" Condition="'$(IsTestProject)' == 'true' and '$(SkipTests)' == 'true'" />
+
   <ItemGroup Condition="'$(IsTestProject)' == 'true'">
     <Compile Include="$(CommonPath)tests\TestUtilities\System\AssertExtensions.cs" Link="Common\System\AssertExtensions.cs" />
     <Compile Include="$(CommonPath)tests\TestUtilities\System\PlatformDetection.cs" Link="Common\System\PlatformDetection.cs" />

--- a/eng/testing/skiptests.targets
+++ b/eng/testing/skiptests.targets
@@ -1,0 +1,9 @@
+<Project>
+
+  <!-- The VSTest target is not bound by any conditions like SkipTests:
+  https://github.com/microsoft/vstest/blob/1c07d46672669b0f7e4a367d66ab9ef9ed6cdb4b/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.targets#L30
+  This workaround prevents the execution of tests when we shouldn't, like when the TargetFramework is $(NetFrameworkMinimum) and the OS is Unix.
+  This can be removed if microsoft/vstest adds a condition to that target. -->
+  <Target Name="VSTest" />
+
+</Project>


### PR DESCRIPTION
The CI is currently attempting to wrongly execute .NET Framework tests when running in Unix due to two bugs:

1. The microsoft/vstests `VSTest` target is not bound by any conditions, so it always runs when using `dotnet test`.
2. The dotnet/arcade `RunTests` target is bound by `SkipTests` not being `true`, but is executed anyway as the Outputs depends on an item group coming from the parent target, and we don't check if the item group is empty.

This PR introduced workarounds for both cases while we get the issues in the original repos fixed and flowed here.

- RunTests PR with a fix: https://github.com/dotnet/arcade/pull/14665
- VSTest issue requesting a condition: https://github.com/microsoft/vstest/issues/4953
