### PR TITLE
Move package information to separate property group

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -34,8 +34,4 @@
     <PackageReference Include="Microsoft.DotNet.XUnitExtensions" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(UseTargetFrameworkPackage)' == 'true'">
-    <PackageReference Include="Microsoft.DotNet.Build.Tasks.TargetFramework" PrivateAssets="all" />
-  </ItemGroup>
-
 </Project>

--- a/src/Microsoft.Bcl.HashCode/src/Microsoft.Bcl.HashCode.csproj
+++ b/src/Microsoft.Bcl.HashCode/src/Microsoft.Bcl.HashCode.csproj
@@ -5,23 +5,33 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <!-- Floating package information -->
+  <PropertyGroup>
     <IsPackable>false</IsPackable>
     <VersionPrefix>1.1.1</VersionPrefix>
     <VersionPrefix Condition="'$(IsPackable)' == 'true'">1.2.0</VersionPrefix>
     <PackageValidationBaselineVersion>1.1.1</PackageValidationBaselineVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netstandard2.1'))">
-    <EnableDefaultItems>false</EnableDefaultItems>
-  </PropertyGroup>
+  <Choose>
+    <When Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netstandard2.1'))">
+      <PropertyGroup>
+        <EnableDefaultItems>false</EnableDefaultItems>
+      </PropertyGroup>
 
-  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netstandard2.1'))">
-    <Compile Include="TypeForwards.cs" />
-  </ItemGroup>
+      <ItemGroup>
+        <Compile Include="TypeForwards.cs" />
+      </ItemGroup>
+    </When>
 
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netstandard2.1'))">
-    <Compile Include="$(CommonPath)src\System\LocalAppContextSwitches.Common.cs" Link="Common\System\LocalAppContextSwitches.Common.cs" />
-    <Compile Remove="TypeForwards.cs" />
-  </ItemGroup>
+    <Otherwise>
+      <ItemGroup>
+        <Compile Include="$(CommonPath)src\System\LocalAppContextSwitches.Common.cs" Link="Common\System\LocalAppContextSwitches.Common.cs" />
+        <Compile Remove="TypeForwards.cs" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
 
 </Project>

--- a/src/Microsoft.Bcl.HashCode/src/Microsoft.Bcl.HashCode.csproj
+++ b/src/Microsoft.Bcl.HashCode/src/Microsoft.Bcl.HashCode.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <!-- Floating package information -->
+  <!-- Package servicing properties -->
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <VersionPrefix>1.1.1</VersionPrefix>

--- a/src/System.Buffers/src/System.Buffers.csproj
+++ b/src/System.Buffers/src/System.Buffers.csproj
@@ -4,14 +4,18 @@
     <TargetFrameworks>netstandard2.0;$(NetFrameworkMinimum);netcoreapp2.1</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <StrongNameKeyId>Open</StrongNameKeyId>
+    <AssemblyVersion>4.0.3.0</AssemblyVersion> <!-- NO-INCREMENT: This version is frozen for .NET Standard and .NETCoreApp because the assembly ships inbox. -->
+    <IsPlaceholderTargetFramework Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp'">true</IsPlaceholderTargetFramework>
+  </PropertyGroup>
+
+  <!-- Floating package information -->
+  <PropertyGroup>
     <IsPackable>false</IsPackable>
     <VersionPrefix>4.5.1</VersionPrefix>
     <VersionPrefix Condition="'$(IsPackable)' == 'true'">4.6.0</VersionPrefix>
-    <AssemblyVersion>4.0.3.0</AssemblyVersion> <!-- NO-INCREMENT: This version is frozen for .NET Standard and .NETCoreApp because the assembly ships inbox. -->
     <AssemblyVersion Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.0.3.0</AssemblyVersion>
     <AssemblyVersion Condition="'$(IsPackable)' == 'true' and $([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.0.4.0</AssemblyVersion>
     <PackageValidationBaselineVersion>4.5.1</PackageValidationBaselineVersion>
-    <IsPlaceholderTargetFramework Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp'">true</IsPlaceholderTargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/System.Buffers/src/System.Buffers.csproj
+++ b/src/System.Buffers/src/System.Buffers.csproj
@@ -8,7 +8,7 @@
     <IsPlaceholderTargetFramework Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp'">true</IsPlaceholderTargetFramework>
   </PropertyGroup>
 
-  <!-- Floating package information -->
+  <!-- Package servicing properties -->
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <VersionPrefix>4.5.1</VersionPrefix>

--- a/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
+++ b/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
@@ -13,7 +13,7 @@
       <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetPlatformIdentifier)' != 'windows'">SR.PlatformNotSupported_System_Data_SqlClient</GeneratePlatformNotSupportedAssemblyMessage>
     </PropertyGroup>
 
-    <!-- Floating package information -->
+    <!-- Package servicing properties -->
     <PropertyGroup>
       <IsPackable>false</IsPackable>
       <VersionPrefix>4.8.6</VersionPrefix>

--- a/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
+++ b/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
@@ -4,14 +4,7 @@
       <TargetFrameworks>$(NetMinimum);$(NetMinimum)-unix;$(NetMinimum)-windows;netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
       <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
       <StrongNameKeyId>Microsoft</StrongNameKeyId>
-      <IsPackable>false</IsPackable>
-      <VersionPrefix>4.8.6</VersionPrefix>
-      <VersionPrefix Condition="'$(IsPackable)' == 'true'">4.9.0</VersionPrefix>
       <AssemblyVersion>4.6.1.6</AssemblyVersion> <!-- NO-INCREMENT: This version is frozen for .NET Standard and .NETCoreApp because the assembly ships inbox. -->
-      <AssemblyVersion Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.6.1.6</AssemblyVersion>
-      <AssemblyVersion Condition="'$(IsPackable)' == 'true' and $([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.6.2.0</AssemblyVersion>
-      <PackageValidationBaselineVersion>4.8.6</PackageValidationBaselineVersion>
-      <UseTargetFrameworkPackage>true</UseTargetFrameworkPackage>
     </PropertyGroup>
 
     <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
@@ -19,5 +12,19 @@
       <TargetPlatformIdentifier>$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))</TargetPlatformIdentifier>
       <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetPlatformIdentifier)' != 'windows'">SR.PlatformNotSupported_System_Data_SqlClient</GeneratePlatformNotSupportedAssemblyMessage>
     </PropertyGroup>
+
+    <!-- Floating package information -->
+    <PropertyGroup>
+      <IsPackable>false</IsPackable>
+      <VersionPrefix>4.8.6</VersionPrefix>
+      <VersionPrefix Condition="'$(IsPackable)' == 'true'">4.9.0</VersionPrefix>
+      <AssemblyVersion Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.6.1.6</AssemblyVersion>
+      <AssemblyVersion Condition="'$(IsPackable)' == 'true' and $([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.6.2.0</AssemblyVersion>
+      <PackageValidationBaselineVersion>4.8.6</PackageValidationBaselineVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.DotNet.Build.Tasks.TargetFramework" PrivateAssets="all" />
+    </ItemGroup>
 
   </Project>

--- a/src/System.Data.SqlClient/tests/System.Data.SqlClient.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/System.Data.SqlClient.Tests.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-      <TargetFrameworks>$(NetMinimum);$(NetMinimum)-unix;$(NetMinimum)-windows;$(NetFrameworkMinimum)</TargetFrameworks>
-      <UseTargetFrameworkPackage>true</UseTargetFrameworkPackage>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>$(NetMinimum);$(NetMinimum)-unix;$(NetMinimum)-windows;$(NetFrameworkMinimum)</TargetFrameworks>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\src\System.Data.SqlClient.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\System.Data.SqlClient.csproj" />
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.TargetFramework" PrivateAssets="all" />
+  </ItemGroup>
 
 </Project>

--- a/src/System.Json/src/System.Json.csproj
+++ b/src/System.Json/src/System.Json.csproj
@@ -3,6 +3,10 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
+  </PropertyGroup>
+
+  <!-- Floating package information -->
+  <PropertyGroup>
     <IsPackable>false</IsPackable>
     <VersionPrefix>4.7.1</VersionPrefix>
     <VersionPrefix Condition="'$(IsPackable)' == 'true'">4.8.0</VersionPrefix>

--- a/src/System.Json/src/System.Json.csproj
+++ b/src/System.Json/src/System.Json.csproj
@@ -5,7 +5,7 @@
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
   </PropertyGroup>
 
-  <!-- Floating package information -->
+  <!-- Package servicing properties -->
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <VersionPrefix>4.7.1</VersionPrefix>

--- a/src/System.Memory/src/System.Memory.csproj
+++ b/src/System.Memory/src/System.Memory.csproj
@@ -9,7 +9,7 @@
     <IsPlaceholderTargetFramework Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp'">true</IsPlaceholderTargetFramework>
   </PropertyGroup>
 
-  <!-- Floating package information -->
+  <!-- Package servicing properties -->
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <VersionPrefix>4.5.5</VersionPrefix>

--- a/src/System.Memory/src/System.Memory.csproj
+++ b/src/System.Memory/src/System.Memory.csproj
@@ -5,21 +5,23 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <Nullable>disable</Nullable>
+    <AssemblyVersion>4.0.1.2</AssemblyVersion><!-- NO-INCREMENT: This version is frozen for .NET Standard and .NETCoreApp because the assembly ships inbox. -->
+    <IsPlaceholderTargetFramework Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp'">true</IsPlaceholderTargetFramework>
+  </PropertyGroup>
+
+  <!-- Floating package information -->
+  <PropertyGroup>
     <IsPackable>false</IsPackable>
     <VersionPrefix>4.5.5</VersionPrefix>
     <VersionPrefix Condition="'$(IsPackable)' == 'true'">4.6.0</VersionPrefix>
-    <AssemblyVersion>4.0.1.2</AssemblyVersion><!-- NO-INCREMENT: This version is frozen for .NET Standard and .NETCoreApp because the assembly ships inbox. -->
     <AssemblyVersion Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.0.1.2</AssemblyVersion>
     <AssemblyVersion Condition="'$(IsPackable)' == 'true' and $([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.0.2.0</AssemblyVersion>
     <PackageValidationBaselineVersion>4.5.5</PackageValidationBaselineVersion>
-    <IsPlaceholderTargetFramework Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp'">true</IsPlaceholderTargetFramework>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsPlaceholderTargetFramework)' != 'true'">
     <Compile Include="$(CommonPath)src\System\Numerics\Hashing\HashHelpers.cs" Link="Common\System\Numerics\Hashing\HashHelpers.cs" />
-  </ItemGroup>
 
-  <ItemGroup Condition="'$(IsPlaceholderTargetFramework)' != 'true'">
     <ProjectReference Include="..\..\System.Buffers\src\System.Buffers.csproj" />
     <ProjectReference Include="..\..\System.Numerics.Vectors\src\System.Numerics.Vectors.csproj" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />

--- a/src/System.Net.WebSockets.WebSocketProtocol/src/System.Net.WebSockets.WebSocketProtocol.csproj
+++ b/src/System.Net.WebSockets.WebSocketProtocol/src/System.Net.WebSockets.WebSocketProtocol.csproj
@@ -5,6 +5,10 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <!-- Floating package information -->
+  <PropertyGroup>
     <IsPackable>false</IsPackable>
     <VersionPrefix>5.0.0</VersionPrefix>
     <VersionPrefix Condition="'$(IsPackable)' == 'true'">5.1.0</VersionPrefix>

--- a/src/System.Net.WebSockets.WebSocketProtocol/src/System.Net.WebSockets.WebSocketProtocol.csproj
+++ b/src/System.Net.WebSockets.WebSocketProtocol/src/System.Net.WebSockets.WebSocketProtocol.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <!-- Floating package information -->
+  <!-- Package servicing properties -->
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <VersionPrefix>5.0.0</VersionPrefix>

--- a/src/System.Numerics.Vectors/src/System.Numerics.Vectors.csproj
+++ b/src/System.Numerics.Vectors/src/System.Numerics.Vectors.csproj
@@ -4,14 +4,18 @@
     <TargetFrameworks>netcoreapp2.0;netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
+    <AssemblyVersion>4.1.4.0</AssemblyVersion><!-- NO-INCREMENT: This version is frozen for .NET Standard and .NETCoreApp because the assembly ships inbox. -->
+    <IsPlaceholderTargetFramework Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp'">true</IsPlaceholderTargetFramework>
+  </PropertyGroup>
+
+  <!-- Floating package information -->
+  <PropertyGroup>
     <IsPackable>false</IsPackable>
     <VersionPrefix>4.5.0</VersionPrefix>
     <VersionPrefix Condition="'$(IsPackable)' == 'true'">4.6.0</VersionPrefix>
-    <AssemblyVersion>4.1.4.0</AssemblyVersion><!-- NO-INCREMENT: This version is frozen for .NET Standard and .NETCoreApp because the assembly ships inbox. -->
     <AssemblyVersion Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.1.4.0</AssemblyVersion>
     <AssemblyVersion Condition="'$(IsPackable)' == 'true' and $([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.1.5.0</AssemblyVersion>
     <PackageValidationBaselineVersion>4.5.0</PackageValidationBaselineVersion>
-    <IsPlaceholderTargetFramework Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp'">true</IsPlaceholderTargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Numerics.Vectors/src/System.Numerics.Vectors.csproj
+++ b/src/System.Numerics.Vectors/src/System.Numerics.Vectors.csproj
@@ -8,7 +8,7 @@
     <IsPlaceholderTargetFramework Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp'">true</IsPlaceholderTargetFramework>
   </PropertyGroup>
 
-  <!-- Floating package information -->
+  <!-- Package servicing properties -->
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <VersionPrefix>4.5.0</VersionPrefix>

--- a/src/System.Reflection.DispatchProxy/src/System.Reflection.DispatchProxy.csproj
+++ b/src/System.Reflection.DispatchProxy/src/System.Reflection.DispatchProxy.csproj
@@ -8,7 +8,7 @@
     <IsPlaceholderTargetFramework Condition="'$(TargetFramework)' == 'netcoreapp3.1'">true</IsPlaceholderTargetFramework>
   </PropertyGroup>
 
-  <!-- Floating package information -->
+  <!-- Package servicing properties -->
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <VersionPrefix>4.7.1</VersionPrefix>

--- a/src/System.Reflection.DispatchProxy/src/System.Reflection.DispatchProxy.csproj
+++ b/src/System.Reflection.DispatchProxy/src/System.Reflection.DispatchProxy.csproj
@@ -4,14 +4,18 @@
     <TargetFrameworks>$(NetFrameworkMinimum);netstandard2.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
+    <AssemblyVersion>4.0.6.0</AssemblyVersion><!-- NO-INCREMENT: This version is frozen for .NET Standard and .NETCoreApp because the assembly ships inbox. -->
+    <IsPlaceholderTargetFramework Condition="'$(TargetFramework)' == 'netcoreapp3.1'">true</IsPlaceholderTargetFramework>
+  </PropertyGroup>
+
+  <!-- Floating package information -->
+  <PropertyGroup>
     <IsPackable>false</IsPackable>
     <VersionPrefix>4.7.1</VersionPrefix>
     <VersionPrefix Condition="'$(IsPackable)' == 'true'">4.8.0</VersionPrefix>
-    <AssemblyVersion>4.0.6.0</AssemblyVersion><!-- NO-INCREMENT: This version is frozen for .NET Standard and .NETCoreApp because the assembly ships inbox. -->
     <AssemblyVersion Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.0.6.0</AssemblyVersion>
     <AssemblyVersion Condition="'$(IsPackable)' == 'true' and $([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.0.7.0</AssemblyVersion>
     <PackageValidationBaseLineVersion>4.7.1</PackageValidationBaseLineVersion>
-    <IsPlaceholderTargetFramework Condition="'$(TargetFramework)' == 'netcoreapp3.1'">true</IsPlaceholderTargetFramework>
   </PropertyGroup>
 
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netstandard2.1'))">

--- a/src/System.Threading.Tasks.Extensions/src/System.Threading.Tasks.Extensions.csproj
+++ b/src/System.Threading.Tasks.Extensions/src/System.Threading.Tasks.Extensions.csproj
@@ -8,7 +8,7 @@
     <IsPlaceholderTargetFramework Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp'">true</IsPlaceholderTargetFramework>
   </PropertyGroup>
 
-  <!-- Floating package information -->
+  <!-- Package servicing properties -->
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <VersionPrefix>4.5.4</VersionPrefix>

--- a/src/System.Threading.Tasks.Extensions/src/System.Threading.Tasks.Extensions.csproj
+++ b/src/System.Threading.Tasks.Extensions/src/System.Threading.Tasks.Extensions.csproj
@@ -4,14 +4,18 @@
     <TargetFrameworks>$(NetFrameworkMinimum);netstandard2.0;netcoreapp2.1</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <StrongNameKeyId>Open</StrongNameKeyId>
+    <AssemblyVersion>4.2.0.1</AssemblyVersion> <!-- NO-INCREMENT: This version is frozen for .NET Standard and .NETCoreApp because the assembly ships inbox. -->
+    <IsPlaceholderTargetFramework Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp'">true</IsPlaceholderTargetFramework>
+  </PropertyGroup>
+
+  <!-- Floating package information -->
+  <PropertyGroup>
     <IsPackable>false</IsPackable>
     <VersionPrefix>4.5.4</VersionPrefix>
     <VersionPrefix Condition="'$(IsPackable)' == 'true'">4.6.0</VersionPrefix>
-    <AssemblyVersion>4.2.0.1</AssemblyVersion> <!-- NO-INCREMENT: This version is frozen for .NET Standard and .NETCoreApp because the assembly ships inbox. -->
     <AssemblyVersion Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.2.0.1</AssemblyVersion>
     <AssemblyVersion Condition="'$(IsPackable)' == 'true' and $([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.2.1.0</AssemblyVersion>
     <PackageValidationBaselineVersion>4.5.4</PackageValidationBaselineVersion>
-    <IsPlaceholderTargetFramework Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp'">true</IsPlaceholderTargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Xml.XPath.XmlDocument/src/System.Xml.XPath.XmlDocument.csproj
+++ b/src/System.Xml.XPath.XmlDocument/src/System.Xml.XPath.XmlDocument.csproj
@@ -4,6 +4,10 @@
     <TargetFrameworks>$(NetMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
+  </PropertyGroup>
+
+  <!-- Floating package information -->
+  <PropertyGroup>
     <IsPackable>false</IsPackable>
     <VersionPrefix>4.3.0</VersionPrefix>
     <VersionPrefix Condition="'$(IsPackable)' == 'true'">4.4.0</VersionPrefix>

--- a/src/System.Xml.XPath.XmlDocument/src/System.Xml.XPath.XmlDocument.csproj
+++ b/src/System.Xml.XPath.XmlDocument/src/System.Xml.XPath.XmlDocument.csproj
@@ -6,7 +6,7 @@
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
   </PropertyGroup>
 
-  <!-- Floating package information -->
+  <!-- Package servicing properties -->
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <VersionPrefix>4.3.0</VersionPrefix>


### PR DESCRIPTION
... this should help readability and make it more
obvious what needs to change when publishing a new package.

Two unrelated changes:
1. Move the Microsoft.DotNet.Build.TargetFramework package reference directly into the projects that need it to avoid indirection.
2. Use a Choose/When construct in Microsoft.Bcl. HashCode for better readability.