### PR TITLE
Build tests in this repo

### DIFF
--- a/Build.proj
+++ b/Build.proj
@@ -2,7 +2,7 @@
 
   <ItemGroup>
     <ProjectReference Include="src/*/src/*.*proj" />
-    <ProjectReference Condition="'$(SkipTests)' == 'true'" Remove="src/*/tests/*.csproj" />
+    <ProjectReference Include="src/*/tests/*.csproj" Condition="'$(SkipTests)' != 'true'" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The Build.proj condition was wrong and resulted
in test projects never being referenced and built.

Tests didn't run in CI either (no "Tests" tab):

![image](https://github.com/user-attachments/assets/6c8bf67c-000e-4980-8653-8b0af747ab19)
