### PR TITLE
Exclude TdsServerCertificate.pfx from CredScan

### DIFF
--- a/.config/CredScanSuppressions.json
+++ b/.config/CredScanSuppressions.json
@@ -1,0 +1,9 @@
+{
+  "tool": "Credential Scanner",
+  "suppressions": [
+    {
+      "placeholder": "PLACEHOLDER",
+      "_justification": "This is the password used for the TdsServerCertificate.pfx file in the project. It is used for testing purposes only."
+    }
+  ]
+}


### PR DESCRIPTION
Should fix the rolling build failures.