### PR TITLE
Generate preview version of packages (excluding System.Data.SqlClient)

### DIFF
--- a/src/Microsoft.Bcl.HashCode/src/Microsoft.Bcl.HashCode.csproj
+++ b/src/Microsoft.Bcl.HashCode/src/Microsoft.Bcl.HashCode.csproj
@@ -9,7 +9,7 @@
 
   <!-- Package servicing properties -->
   <PropertyGroup>
-    <IsPackable>false</IsPackable>
+    <IsPackable>true</IsPackable>
     <VersionPrefix>1.1.1</VersionPrefix>
     <VersionPrefix Condition="'$(IsPackable)' == 'true'">6.0.0</VersionPrefix>
     <PackageValidationBaselineVersion>1.1.1</PackageValidationBaselineVersion>

--- a/src/Microsoft.IO.Redist/src/Microsoft.IO.Redist.csproj
+++ b/src/Microsoft.IO.Redist/src/Microsoft.IO.Redist.csproj
@@ -13,7 +13,7 @@
 
   <!-- Package servicing properties -->
   <PropertyGroup>
-    <IsPackable>false</IsPackable>
+    <IsPackable>true</IsPackable>
     <VersionPrefix>6.0.1</VersionPrefix>
     <VersionPrefix Condition="'$(IsPackable)' == 'true'">6.1.0</VersionPrefix>
     <AssemblyVersion>6.0.0.1</AssemblyVersion>

--- a/src/System.Buffers/src/System.Buffers.csproj
+++ b/src/System.Buffers/src/System.Buffers.csproj
@@ -10,7 +10,7 @@
 
   <!-- Package servicing properties -->
   <PropertyGroup>
-    <IsPackable>false</IsPackable>
+    <IsPackable>true</IsPackable>
     <VersionPrefix>4.5.1</VersionPrefix>
     <VersionPrefix Condition="'$(IsPackable)' == 'true'">4.6.0</VersionPrefix>
     <AssemblyVersion Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.0.3.0</AssemblyVersion>

--- a/src/System.Json/src/System.Json.csproj
+++ b/src/System.Json/src/System.Json.csproj
@@ -7,7 +7,7 @@
 
   <!-- Package servicing properties -->
   <PropertyGroup>
-    <IsPackable>false</IsPackable>
+    <IsPackable>true</IsPackable>
     <VersionPrefix>4.7.1</VersionPrefix>
     <VersionPrefix Condition="'$(IsPackable)' == 'true'">4.8.0</VersionPrefix>
     <AssemblyVersion>2.0.8.0</AssemblyVersion>

--- a/src/System.Memory/src/System.Memory.csproj
+++ b/src/System.Memory/src/System.Memory.csproj
@@ -11,7 +11,7 @@
 
   <!-- Package servicing properties -->
   <PropertyGroup>
-    <IsPackable>false</IsPackable>
+    <IsPackable>true</IsPackable>
     <VersionPrefix>4.5.5</VersionPrefix>
     <VersionPrefix Condition="'$(IsPackable)' == 'true'">4.6.0</VersionPrefix>
     <AssemblyVersion Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.0.1.2</AssemblyVersion>

--- a/src/System.Net.WebSockets.WebSocketProtocol/src/System.Net.WebSockets.WebSocketProtocol.csproj
+++ b/src/System.Net.WebSockets.WebSocketProtocol/src/System.Net.WebSockets.WebSocketProtocol.csproj
@@ -9,7 +9,7 @@
 
   <!-- Package servicing properties -->
   <PropertyGroup>
-    <IsPackable>false</IsPackable>
+    <IsPackable>true</IsPackable>
     <VersionPrefix>5.0.0</VersionPrefix>
     <VersionPrefix Condition="'$(IsPackable)' == 'true'">5.1.0</VersionPrefix>
     <PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>

--- a/src/System.Numerics.Vectors/src/System.Numerics.Vectors.csproj
+++ b/src/System.Numerics.Vectors/src/System.Numerics.Vectors.csproj
@@ -10,7 +10,7 @@
 
   <!-- Package servicing properties -->
   <PropertyGroup>
-    <IsPackable>false</IsPackable>
+    <IsPackable>true</IsPackable>
     <VersionPrefix>4.5.0</VersionPrefix>
     <VersionPrefix Condition="'$(IsPackable)' == 'true'">4.6.0</VersionPrefix>
     <AssemblyVersion Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.1.4.0</AssemblyVersion>

--- a/src/System.Reflection.DispatchProxy/src/System.Reflection.DispatchProxy.csproj
+++ b/src/System.Reflection.DispatchProxy/src/System.Reflection.DispatchProxy.csproj
@@ -10,7 +10,7 @@
 
   <!-- Package servicing properties -->
   <PropertyGroup>
-    <IsPackable>false</IsPackable>
+    <IsPackable>true</IsPackable>
     <VersionPrefix>4.7.1</VersionPrefix>
     <VersionPrefix Condition="'$(IsPackable)' == 'true'">4.8.0</VersionPrefix>
     <AssemblyVersion Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.0.6.0</AssemblyVersion>

--- a/src/System.Threading.Tasks.Extensions/src/System.Threading.Tasks.Extensions.csproj
+++ b/src/System.Threading.Tasks.Extensions/src/System.Threading.Tasks.Extensions.csproj
@@ -10,7 +10,7 @@
 
   <!-- Package servicing properties -->
   <PropertyGroup>
-    <IsPackable>false</IsPackable>
+    <IsPackable>true</IsPackable>
     <VersionPrefix>4.5.4</VersionPrefix>
     <VersionPrefix Condition="'$(IsPackable)' == 'true'">4.6.0</VersionPrefix>
     <AssemblyVersion Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.2.0.1</AssemblyVersion>

--- a/src/System.Xml.XPath.XmlDocument/src/System.Xml.XPath.XmlDocument.csproj
+++ b/src/System.Xml.XPath.XmlDocument/src/System.Xml.XPath.XmlDocument.csproj
@@ -8,7 +8,7 @@
 
   <!-- Package servicing properties -->
   <PropertyGroup>
-    <IsPackable>false</IsPackable>
+    <IsPackable>true</IsPackable>
     <VersionPrefix>4.3.0</VersionPrefix>
     <VersionPrefix Condition="'$(IsPackable)' == 'true'">4.4.0</VersionPrefix>
     <PackageValidationBaselineVersion>4.3.0</PackageValidationBaselineVersion>


### PR DESCRIPTION
System.Data.SqlClient is WIP: https://github.com/dotnet/maintenance-packages/pull/115

This change temporarily changed the PreReleaseVersionLabel and Iteration to preview1: https://github.com/dotnet/maintenance-packages/pull/123

This change fixed the branches that should publish signed artifacts and the ones that should only run tests: https://github.com/dotnet/maintenance-packages/pull/126

The darc default channels have been created for the branches that are expected to publish.

With the combination of those changes, we want to confirm the preview packages are pushed to the correct feed when they are turned on.