### PR TITLE
Enable System.Runtime.CompilerServices.Unsafe package generation

### DIFF
--- a/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.ilproj
+++ b/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.ilproj
@@ -19,7 +19,7 @@ System.Runtime.CompilerServices.Unsafe</PackageDescription>
   <!-- Package servicing properties -->
   <!-- VersionPrefix is defined in the parent folder's Directory.Build.props -->
   <PropertyGroup>
-    <IsPackable>false</IsPackable>
+    <IsPackable>true</IsPackable>
     <AssemblyVersion Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">6.0.0.0</AssemblyVersion>
     <AssemblyVersion Condition="'$(IsPackable)' == 'true' and $([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">6.0.1.0</AssemblyVersion>
     <PackageValidationBaselineVersion>4.7.1</PackageValidationBaselineVersion>


### PR DESCRIPTION
Missed it in https://github.com/dotnet/maintenance-packages/pull/127

Already double checked, it's the only one I missed. It happened because I used a regex to update all the `<IsPackable>` lines in csproj files, but I forgot this one uses an ilproj.