### PR TITLE
Move IsPackable property down to Directory.Build.props for System.Runtime.CompilerServices.Unsafe

### DIFF
--- a/src/System.Runtime.CompilerServices.Unsafe/Directory.Build.props
+++ b/src/System.Runtime.CompilerServices.Unsafe/Directory.Build.props
@@ -3,6 +3,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
 
   <PropertyGroup>
+    <IsPackable>true</IsPackable>
     <VersionPrefix>6.0.0</VersionPrefix>
     <VersionPrefix Condition="'$(IsPackable)' == 'true'">6.1.0</VersionPrefix>
   </PropertyGroup>

--- a/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.ilproj
+++ b/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.ilproj
@@ -17,9 +17,8 @@ System.Runtime.CompilerServices.Unsafe</PackageDescription>
   </PropertyGroup>
 
   <!-- Package servicing properties -->
-  <!-- VersionPrefix is defined in the parent folder's Directory.Build.props -->
+  <!-- VersionPrefix and IsPackable are defined in the parent folder's Directory.Build.props -->
   <PropertyGroup>
-    <IsPackable>true</IsPackable>
     <AssemblyVersion Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">6.0.0.0</AssemblyVersion>
     <AssemblyVersion Condition="'$(IsPackable)' == 'true' and $([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">6.0.1.0</AssemblyVersion>
     <PackageValidationBaselineVersion>4.7.1</PackageValidationBaselineVersion>


### PR DESCRIPTION
The last official build that pushed the packages to the feed, pushed version 6.0.0-preview of S.R.C.U., which is wrong: Should've been 6.1.0-preview.

We were seeing the correct package version in local builds and in the CI because in both cases, we're force-passing the /p:IsPackable=true property in the command line. But we don't do that in the official build.

I opened the fixed nupkg, then opened the two DLLs (netstandard2.0 and net462) with ILSpy, and confirmed that the correct version 6.1.0 is also stored in the metadata.