### PR TITLE
Bring back the intellisense xmls

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -30,6 +30,7 @@
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(IsSourceProject)' == 'true'">
+    <DocumentationFile>$(MSBuildProjectDirectory)\$(AssemblyName).xml</DocumentationFile>
     <Description Condition="'$(Description)' == ''">$(AssemblyName)</Description>
     <PackageDescription Condition="'$(PackageDescription)' == ''">$(AssemblyName)</PackageDescription>
   </PropertyGroup>
@@ -50,6 +51,9 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsSourceProject)' == 'true'">
+    <None Include="$(AssemblyName).xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <AssemblyAttribute Include="System.CLSCompliantAttribute" Condition="'$(CLSCompliant)' == 'true'">
       <_Parameter1>true</_Parameter1>
     </AssemblyAttribute>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -32,6 +32,7 @@
   <PropertyGroup Condition="'$(IsSourceProject)' == 'true'">
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <DocumentationFile>$(MSBuildProjectDirectory)\$(AssemblyName).xml</DocumentationFile>
+
     <Description Condition="'$(Description)' == ''">$(AssemblyName)</Description>
     <PackageDescription Condition="'$(PackageDescription)' == ''">$(AssemblyName)</PackageDescription>
   </PropertyGroup>
@@ -52,9 +53,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsSourceProject)' == 'true'">
-    <None Include="$(AssemblyName).xml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <None Include="$(DocumentationFile)" CopyToOutputDirectory="PreserveNewest" />
+
     <AssemblyAttribute Include="System.CLSCompliantAttribute" Condition="'$(CLSCompliant)' == 'true'">
       <_Parameter1>true</_Parameter1>
     </AssemblyAttribute>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -30,6 +30,7 @@
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(IsSourceProject)' == 'true'">
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <DocumentationFile>$(MSBuildProjectDirectory)\$(AssemblyName).xml</DocumentationFile>
     <Description Condition="'$(Description)' == ''">$(AssemblyName)</Description>
     <PackageDescription Condition="'$(PackageDescription)' == ''">$(AssemblyName)</PackageDescription>

--- a/src/Microsoft.Bcl.HashCode/src/Microsoft.Bcl.HashCode.xml
+++ b/src/Microsoft.Bcl.HashCode/src/Microsoft.Bcl.HashCode.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>Microsoft.Bcl.HashCode</name>
+    </assembly>
+    <members>
+        <member name="M:System.Numerics.BitOperations.RotateLeft(System.UInt32,System.Int32)">
+            <summary>
+            Rotates the specified value left by the specified number of bits.
+            Similar in behavior to the x86 instruction ROL.
+            </summary>
+            <param name="value">The value to rotate.</param>
+            <param name="offset">The number of bits to rotate by.
+            Any value outside the range [0..31] is treated as congruent mod 32.</param>
+            <returns>The rotated value.</returns>
+        </member>
+        <member name="M:System.Numerics.BitOperations.RotateLeft(System.UInt64,System.Int32)">
+            <summary>
+            Rotates the specified value left by the specified number of bits.
+            Similar in behavior to the x86 instruction ROL.
+            </summary>
+            <param name="value">The value to rotate.</param>
+            <param name="offset">The number of bits to rotate by.
+            Any value outside the range [0..63] is treated as congruent mod 64.</param>
+            <returns>The rotated value.</returns>
+        </member>
+        <member name="P:System.SR.HashCode_EqualityNotSupported">
+            <summary>HashCode is a mutable struct and should not be compared with other HashCodes.</summary>
+        </member>
+        <member name="P:System.SR.HashCode_HashCodeNotSupported">
+            <summary>HashCode is a mutable struct and should not be compared with other HashCodes. Use ToHashCode to retrieve the computed hash code.</summary>
+        </member>
+    </members>
+</doc>

--- a/src/Microsoft.IO.Redist/src/Microsoft.IO.Redist.csproj
+++ b/src/Microsoft.IO.Redist/src/Microsoft.IO.Redist.csproj
@@ -9,7 +9,6 @@
     <SetIsTrimmable>true</SetIsTrimmable>
     <Nullable>annotations</Nullable>
     <IncludePlatformAttributes>true</IncludePlatformAttributes>
-    <DocumentationFile>$(MSBuildThisFileDirectory)Microsoft.IO.Redist.xml</DocumentationFile>
   </PropertyGroup>
 
   <!-- Package servicing properties -->

--- a/src/System.Buffers/src/System.Buffers.xml
+++ b/src/System.Buffers/src/System.Buffers.xml
@@ -1,0 +1,173 @@
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>System.Buffers</name>
+    </assembly>
+    <members>
+        <member name="T:System.Buffers.ArrayPool`1">
+            <summary>
+            Provides a resource pool that enables reusing instances of type <see cref="T:T[]"/>. 
+            </summary>
+            <remarks>
+            <para>
+            Renting and returning buffers with an <see cref="T:System.Buffers.ArrayPool`1"/> can increase performance
+            in situations where arrays are created and destroyed frequently, resulting in significant
+            memory pressure on the garbage collector.
+            </para>
+            <para>
+            This class is thread-safe.  All members may be used by multiple threads concurrently.
+            </para>
+            </remarks>
+        </member>
+        <member name="F:System.Buffers.ArrayPool`1.s_sharedInstance">
+            <summary>The lazily-initialized shared pool instance.</summary>
+        </member>
+        <member name="P:System.Buffers.ArrayPool`1.Shared">
+            <summary>
+            Retrieves a shared <see cref="T:System.Buffers.ArrayPool`1"/> instance.
+            </summary>
+            <remarks>
+            The shared pool provides a default implementation of <see cref="T:System.Buffers.ArrayPool`1"/>
+            that's intended for general applicability.  It maintains arrays of multiple sizes, and 
+            may hand back a larger array than was actually requested, but will never hand back a smaller 
+            array than was requested. Renting a buffer from it with <see cref="M:System.Buffers.ArrayPool`1.Rent(System.Int32)"/> will result in an 
+            existing buffer being taken from the pool if an appropriate buffer is available or in a new 
+            buffer being allocated if one is not available.
+            </remarks>
+        </member>
+        <member name="M:System.Buffers.ArrayPool`1.EnsureSharedCreated">
+            <summary>Ensures that <see cref="F:System.Buffers.ArrayPool`1.s_sharedInstance"/> has been initialized to a pool and returns it.</summary>
+        </member>
+        <member name="M:System.Buffers.ArrayPool`1.Create">
+            <summary>
+            Creates a new <see cref="T:System.Buffers.ArrayPool`1"/> instance using default configuration options.
+            </summary>
+            <returns>A new <see cref="T:System.Buffers.ArrayPool`1"/> instance.</returns>
+        </member>
+        <member name="M:System.Buffers.ArrayPool`1.Create(System.Int32,System.Int32)">
+            <summary>
+            Creates a new <see cref="T:System.Buffers.ArrayPool`1"/> instance using custom configuration options.
+            </summary>
+            <param name="maxArrayLength">The maximum length of array instances that may be stored in the pool.</param>
+            <param name="maxArraysPerBucket">
+            The maximum number of array instances that may be stored in each bucket in the pool.  The pool
+            groups arrays of similar lengths into buckets for faster access.
+            </param>
+            <returns>A new <see cref="T:System.Buffers.ArrayPool`1"/> instance with the specified configuration options.</returns>
+            <remarks>
+            The created pool will group arrays into buckets, with no more than <paramref name="maxArraysPerBucket"/>
+            in each bucket and with those arrays not exceeding <paramref name="maxArrayLength"/> in length.
+            </remarks>
+        </member>
+        <member name="M:System.Buffers.ArrayPool`1.Rent(System.Int32)">
+            <summary>
+            Retrieves a buffer that is at least the requested length.
+            </summary>
+            <param name="minimumLength">The minimum length of the array needed.</param>
+            <returns>
+            An <see cref="T:T[]"/> that is at least <paramref name="minimumLength"/> in length.
+            </returns>
+            <remarks>
+            This buffer is loaned to the caller and should be returned to the same pool via 
+            <see cref="M:System.Buffers.ArrayPool`1.Return(`0[],System.Boolean)"/> so that it may be reused in subsequent usage of <see cref="M:System.Buffers.ArrayPool`1.Rent(System.Int32)"/>.  
+            It is not a fatal error to not return a rented buffer, but failure to do so may lead to 
+            decreased application performance, as the pool may need to create a new buffer to replace
+            the one lost.
+            </remarks>
+        </member>
+        <member name="M:System.Buffers.ArrayPool`1.Return(`0[],System.Boolean)">
+            <summary>
+            Returns to the pool an array that was previously obtained via <see cref="M:System.Buffers.ArrayPool`1.Rent(System.Int32)"/> on the same 
+            <see cref="T:System.Buffers.ArrayPool`1"/> instance.
+            </summary>
+            <param name="array">
+            The buffer previously obtained from <see cref="M:System.Buffers.ArrayPool`1.Rent(System.Int32)"/> to return to the pool.
+            </param>
+            <param name="clearArray">
+            If <c>true</c> and if the pool will store the buffer to enable subsequent reuse, <see cref="M:System.Buffers.ArrayPool`1.Return(`0[],System.Boolean)"/>
+            will clear <paramref name="array"/> of its contents so that a subsequent consumer via <see cref="M:System.Buffers.ArrayPool`1.Rent(System.Int32)"/> 
+            will not see the previous consumer's content.  If <c>false</c> or if the pool will release the buffer,
+            the array's contents are left unchanged.
+            </param>
+            <remarks>
+            Once a buffer has been returned to the pool, the caller gives up all ownership of the buffer 
+            and must not use it. The reference returned from a given call to <see cref="M:System.Buffers.ArrayPool`1.Rent(System.Int32)"/> must only be
+            returned via <see cref="M:System.Buffers.ArrayPool`1.Return(`0[],System.Boolean)"/> once.  The default <see cref="T:System.Buffers.ArrayPool`1"/>
+            may hold onto the returned buffer in order to rent it again, or it may release the returned buffer
+            if it's determined that the pool already has enough buffers stored.
+            </remarks>
+        </member>
+        <member name="T:System.Buffers.ArrayPoolEventSource.BufferAllocatedReason">
+            <summary>The reason for a BufferAllocated event.</summary>
+        </member>
+        <member name="F:System.Buffers.ArrayPoolEventSource.BufferAllocatedReason.Pooled">
+            <summary>The pool is allocating a buffer to be pooled in a bucket.</summary>
+        </member>
+        <member name="F:System.Buffers.ArrayPoolEventSource.BufferAllocatedReason.OverMaximumSize">
+            <summary>The requested buffer size was too large to be pooled.</summary>
+        </member>
+        <member name="F:System.Buffers.ArrayPoolEventSource.BufferAllocatedReason.PoolExhausted">
+            <summary>The pool has already allocated for pooling as many buffers of a particular size as it's allowed.</summary>
+        </member>
+        <member name="M:System.Buffers.ArrayPoolEventSource.BufferRented(System.Int32,System.Int32,System.Int32,System.Int32)">
+            <summary>
+            Event for when a buffer is rented.  This is invoked once for every successful call to Rent,
+            regardless of whether a buffer is allocated or a buffer is taken from the pool.  In a
+            perfect situation where all rented buffers are returned, we expect to see the number
+            of BufferRented events exactly match the number of BuferReturned events, with the number
+            of BufferAllocated events being less than or equal to those numbers (ideally significantly
+            less than).
+            </summary>
+        </member>
+        <member name="M:System.Buffers.ArrayPoolEventSource.BufferAllocated(System.Int32,System.Int32,System.Int32,System.Int32,System.Buffers.ArrayPoolEventSource.BufferAllocatedReason)">
+            <summary>
+            Event for when a buffer is allocated by the pool.  In an ideal situation, the number
+            of BufferAllocated events is significantly smaller than the number of BufferRented and
+            BufferReturned events.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.ArrayPoolEventSource.BufferReturned(System.Int32,System.Int32,System.Int32)">
+            <summary>
+            Event raised when a buffer is returned to the pool.  This event is raised regardless of whether
+            the returned buffer is stored or dropped.  In an ideal situation, the number of BufferReturned
+            events exactly matches the number of BufferRented events.
+            </summary>
+        </member>
+        <member name="F:System.Buffers.DefaultArrayPool`1.DefaultMaxArrayLength">
+            <summary>The default maximum length of each array in the pool (2^20).</summary>
+        </member>
+        <member name="F:System.Buffers.DefaultArrayPool`1.DefaultMaxNumberOfArraysPerBucket">
+            <summary>The default maximum number of arrays per bucket that are available for rent.</summary>
+        </member>
+        <member name="F:System.Buffers.DefaultArrayPool`1.s_emptyArray">
+            <summary>Lazily-allocated empty array used when arrays of length 0 are requested.</summary>
+        </member>
+        <member name="P:System.Buffers.DefaultArrayPool`1.Id">
+            <summary>Gets an ID for the pool to use with events.</summary>
+        </member>
+        <member name="T:System.Buffers.DefaultArrayPool`1.Bucket">
+            <summary>Provides a thread-safe bucket containing buffers that can be Rent'd and Return'd.</summary>
+        </member>
+        <member name="M:System.Buffers.DefaultArrayPool`1.Bucket.#ctor(System.Int32,System.Int32,System.Int32)">
+            <summary>
+            Creates the pool with numberOfBuffers arrays where each buffer is of bufferLength length.
+            </summary>
+        </member>
+        <member name="P:System.Buffers.DefaultArrayPool`1.Bucket.Id">
+            <summary>Gets an ID for the bucket to use with events.</summary>
+        </member>
+        <member name="M:System.Buffers.DefaultArrayPool`1.Bucket.Rent">
+            <summary>Takes an array from the bucket.  If the bucket is empty, returns null.</summary>
+        </member>
+        <member name="M:System.Buffers.DefaultArrayPool`1.Bucket.Return(`0[])">
+            <summary>
+            Attempts to return the buffer to the bucket.  If successful, the buffer will be stored
+            in the bucket and true will be returned; otherwise, the buffer won't be stored, and false
+            will be returned.
+            </summary>
+        </member>
+        <member name="P:System.SR.ArgumentException_BufferNotFromPool">
+            <summary>The buffer is not associated with this pool and may not be returned to it.</summary>
+        </member>
+    </members>
+</doc>

--- a/src/System.Data.SqlClient/src/System.Data.SqlClient.xml
+++ b/src/System.Data.SqlClient/src/System.Data.SqlClient.xml
@@ -1,0 +1,4181 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<doc>
+  <assembly>
+    <name>System.Data.SqlClient</name>
+  </assembly>
+  <members>
+    <member name="T:Microsoft.SqlServer.Server.DataAccessKind">
+      <summary>Describes the type of access to user data for a user-defined method or function.</summary>
+    </member>
+    <member name="F:Microsoft.SqlServer.Server.DataAccessKind.None">
+      <summary>The method or function does not access user data.</summary>
+    </member>
+    <member name="F:Microsoft.SqlServer.Server.DataAccessKind.Read">
+      <summary>The method or function reads user data.</summary>
+    </member>
+    <member name="T:Microsoft.SqlServer.Server.Format">
+      <summary>Used by <see cref="T:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute" /> and <see cref="T:Microsoft.SqlServer.Server.SqlUserDefinedAggregateAttribute" /> to indicate the serialization format of a user-defined type (UDT) or aggregate.</summary>
+    </member>
+    <member name="F:Microsoft.SqlServer.Server.Format.Native">
+      <summary>This serialization format uses a very simple algorithm that enables SQL Server to store an efficient representation of the UDT on disk. Types marked for <see langword="Native" /> serialization can only have value types (structs in Microsoft Visual C# and structures in Microsoft Visual Basic .NET) as members. Members of reference types (such as classes in Visual C# and Visual Basic), either user-defined or those existing in .NET class libraries (such as <see cref="T:System.String" />), are not supported.</summary>
+    </member>
+    <member name="F:Microsoft.SqlServer.Server.Format.Unknown">
+      <summary>The serialization format is unknown.</summary>
+    </member>
+    <member name="F:Microsoft.SqlServer.Server.Format.UserDefined">
+      <summary>This serialization format gives the developer full control over the binary format through the <see cref="M:Microsoft.SqlServer.Server.IBinarySerialize.Write(System.IO.BinaryWriter)" /> and <see cref="M:Microsoft.SqlServer.Server.IBinarySerialize.Read(System.IO.BinaryReader)" /> methods.</summary>
+    </member>
+    <member name="T:Microsoft.SqlServer.Server.IBinarySerialize">
+      <summary>Provides custom implementation for user-defined type (UDT) and user-defined aggregate serialization and deserialization.</summary>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.IBinarySerialize.Read(System.IO.BinaryReader)">
+      <summary>Generates a user-defined type (UDT) or user-defined aggregate from its binary form.</summary>
+      <param name="r">The <see cref="T:System.IO.BinaryReader" /> stream from which the object is deserialized.</param>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.IBinarySerialize.Write(System.IO.BinaryWriter)">
+      <summary>Converts a user-defined type (UDT) or user-defined aggregate into its binary format so that it may be persisted.</summary>
+      <param name="w">The <see cref="T:System.IO.BinaryWriter" /> stream to which the UDT or user-defined aggregate is serialized.</param>
+    </member>
+    <member name="T:Microsoft.SqlServer.Server.InvalidUdtException">
+      <summary>Thrown when SQL Server or the ADO.NET <see cref="N:System.Data.SqlClient" /> provider detects an invalid user-defined type (UDT).</summary>
+    </member>
+    <member name="T:Microsoft.SqlServer.Server.SqlDataRecord">
+      <summary>Represents a single row of data and its metadata. This class cannot be inherited.</summary>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.#ctor(Microsoft.SqlServer.Server.SqlMetaData[])">
+      <summary>Inititializes a new <see cref="T:Microsoft.SqlServer.Server.SqlDataRecord" /> instance with the schema based on the array of <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> objects passed as an argument.</summary>
+      <param name="metaData">An array of <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> objects that describe each column in the <see cref="T:Microsoft.SqlServer.Server.SqlDataRecord" />.</param>
+      <exception cref="T:System.ArgumentNullException">The <paramref name="metaData" /> is <see langword="null" />.</exception>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount">
+      <summary>Gets the number of columns in the data row. This property is read-only.</summary>
+      <returns>The number of columns in the data row as an integer.</returns>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetBoolean(System.Int32)">
+      <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Boolean" />.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <returns>The column value as a <see cref="T:System.Boolean" />.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+      <exception cref="T:System.Data.SqlTypes.SqlNullValueException">The column specified by <paramref name="ordinal" /> is null.</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetByte(System.Int32)">
+      <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Byte" />.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <returns>The column value as a <see cref="T:System.Byte" />.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+      <exception cref="T:System.Data.SqlTypes.SqlNullValueException">The column specified by <paramref name="ordinal" /> is null.</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetBytes(System.Int32,System.Int64,System.Byte[],System.Int32,System.Int32)">
+      <summary>Gets the value for the column specified by the ordinal as an array of <see cref="T:System.Byte" /> objects.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <param name="fieldOffset">The offset into the field value to start retrieving bytes.</param>
+      <param name="buffer">The target buffer to which to copy bytes.</param>
+      <param name="bufferOffset">The offset into the buffer to which to start copying bytes.</param>
+      <param name="length">The number of bytes to copy to the buffer.</param>
+      <returns>The number of bytes copied.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+      <exception cref="T:System.Data.SqlTypes.SqlNullValueException">The column specified by <paramref name="ordinal" /> is null.</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetChar(System.Int32)">
+      <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Char" />.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <returns>The column value as a <see cref="T:System.Char" />.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+      <exception cref="T:System.Data.SqlTypes.SqlNullValueException">The column specified by <paramref name="ordinal" /> is null.</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetChars(System.Int32,System.Int64,System.Char[],System.Int32,System.Int32)">
+      <summary>Gets the value for the column specified by the ordinal as an array of <see cref="T:System.Char" /> objects.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <param name="fieldOffset">The offset into the field value to start retrieving characters.</param>
+      <param name="buffer">The target buffer to copy chars to.</param>
+      <param name="bufferOffset">The offset into the buffer to start copying chars to.</param>
+      <param name="length">The number of chars to copy to the buffer.</param>
+      <returns>The number of characters copied.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+      <exception cref="T:System.Data.SqlTypes.SqlNullValueException">The column specified by <paramref name="ordinal" /> is null.</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetDataTypeName(System.Int32)">
+      <summary>Returns the name of the data type for the column specified by the ordinal argument.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <returns>A <see cref="T:System.String" /> that contains the data type of the column.</returns>
+      <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetDateTime(System.Int32)">
+      <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.DateTime" />.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <returns>The column value as a <see cref="T:System.DateTime" />.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+      <exception cref="T:System.Data.SqlTypes.SqlNullValueException">The column specified by <paramref name="ordinal" /> is null.</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetDateTimeOffset(System.Int32)">
+      <summary>Returns the specified column's data as a <see cref="T:System.DateTimeOffset" />.</summary>
+      <param name="ordinal">The zero-based column ordinal.</param>
+      <returns>The value of the specified column as a <see cref="T:System.DateTimeOffset" />.</returns>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetDecimal(System.Int32)">
+      <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Decimal" />.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <returns>The column value as a <see cref="T:System.Decimal" />.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+      <exception cref="T:System.Data.SqlTypes.SqlNullValueException">The column specified by <paramref name="ordinal" /> is null.</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetDouble(System.Int32)">
+      <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Double" />.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <returns>The column value as a <see cref="T:System.Double" />.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+      <exception cref="T:System.Data.SqlTypes.SqlNullValueException">The column specified by <paramref name="ordinal" /> is null.</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetFieldType(System.Int32)">
+      <summary>Returns a <see cref="T:System.Type" /> object representing the common language runtime (CLR) type that maps to the SQL Server type of the column specified by the <paramref name="ordinal" /> argument.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <returns>The column type as a <see cref="T:System.Type" /> object.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+      <exception cref="T:System.TypeLoadException">The column is of a user-defined type that is not available to the calling application domain.</exception>
+      <exception cref="T:System.IO.FileNotFoundException">The column is of a user-defined type that is not available to the calling application domain.</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetFloat(System.Int32)">
+      <summary>Gets the value for the column specified by the ordinal as a <see langword="float" />.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <returns>The column value as a <see langword="float" />.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+      <exception cref="T:System.Data.SqlTypes.SqlNullValueException">The column specified by <paramref name="ordinal" /> is null.</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetGuid(System.Int32)">
+      <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Guid" />.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <returns>The column value as a <see cref="T:System.Guid" />.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+      <exception cref="T:System.Data.SqlTypes.SqlNullValueException">The column specified by <paramref name="ordinal" /> is null.</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetInt16(System.Int32)">
+      <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Int16" />.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <returns>The column value as a <see cref="T:System.Int16" />.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+      <exception cref="T:System.Data.SqlTypes.SqlNullValueException">The column specified by <paramref name="ordinal" /> is null.</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetInt32(System.Int32)">
+      <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Int32" />.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <returns>The column value as a <see cref="T:System.Int32" />.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+      <exception cref="T:System.Data.SqlTypes.SqlNullValueException">The column specified by <paramref name="ordinal" /> is null.</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetInt64(System.Int32)">
+      <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Int64" />.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <returns>The column value as a <see cref="T:System.Int64" />.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+      <exception cref="T:System.Data.SqlTypes.SqlNullValueException">The column specified by <paramref name="ordinal" /> is null.</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetName(System.Int32)">
+      <summary>Returns the name of the column specified by the ordinal argument.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <returns>A <see cref="T:System.String" /> containing the column name.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetOrdinal(System.String)">
+      <summary>Returns the column ordinal specified by the column name.</summary>
+      <param name="name">The name of the column to look up.</param>
+      <returns>The zero-based ordinal of the column as an integer.</returns>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.IndexOutOfRangeException">The column name could not be found.</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetSqlBinary(System.Int32)">
+      <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlBinary" />.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <returns>The column value as a <see cref="T:System.Data.SqlTypes.SqlBinary" />.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetSqlBoolean(System.Int32)">
+      <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlBoolean" />.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <returns>The column value as a <see cref="T:System.Data.SqlTypes.SqlBoolean" />.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetSqlByte(System.Int32)">
+      <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlByte" />.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <returns>The column value as a <see cref="T:System.Data.SqlTypes.SqlByte" />.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetSqlBytes(System.Int32)">
+      <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlBytes" />.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <returns>The column value as a <see cref="T:System.Data.SqlTypes.SqlBytes" />.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetSqlChars(System.Int32)">
+      <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlChars" />.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <returns>The column value as a <see cref="T:System.Data.SqlTypes.SqlChars" />.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetSqlDateTime(System.Int32)">
+      <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlDateTime" />.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <returns>The column value as a <see cref="T:System.Data.SqlTypes.SqlDateTime" />.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetSqlDecimal(System.Int32)">
+      <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlDecimal" />.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <returns>The column value as a <see cref="T:System.Data.SqlTypes.SqlDecimal" />.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetSqlDouble(System.Int32)">
+      <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlDouble" />.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <returns>The column value as a <see cref="T:System.Data.SqlTypes.SqlDouble" />.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetSqlFieldType(System.Int32)">
+      <summary>Returns a <see cref="T:System.Type" /> object that represents the type (as a SQL Server type, defined in <see cref="N:System.Data.SqlTypes" />) that maps to the SQL Server type of the column.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <returns>The column type as a <see cref="T:System.Type" /> object.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+      <exception cref="T:System.TypeLoadException">The column is of a user-defined type that is not available to the calling application domain.</exception>
+      <exception cref="T:System.IO.FileNotFoundException">The column is of a user-defined type that is not available to the calling application domain.</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetSqlGuid(System.Int32)">
+      <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlGuid" />.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <returns>The column value as a <see cref="T:System.Data.SqlTypes.SqlGuid" />.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetSqlInt16(System.Int32)">
+      <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlInt16" />.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <returns>The column value as a <see cref="T:System.Data.SqlTypes.SqlInt16" />.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetSqlInt32(System.Int32)">
+      <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlInt32" />.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <returns>The column value as a <see cref="T:System.Data.SqlTypes.SqlInt32" />.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetSqlInt64(System.Int32)">
+      <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlInt64" />.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <returns>The column value as a <see cref="T:System.Data.SqlTypes.SqlInt64" />.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetSqlMetaData(System.Int32)">
+      <summary>Returns a <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> object, describing the metadata of the column specified by the column ordinal.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <returns>The column metadata as a <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> object.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetSqlMoney(System.Int32)">
+      <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlMoney" />.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <returns>The column value as a <see cref="T:System.Data.SqlTypes.SqlMoney" />.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetSqlSingle(System.Int32)">
+      <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlSingle" />.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <returns>The column value as a <see cref="T:System.Data.SqlTypes.SqlSingle" />.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetSqlString(System.Int32)">
+      <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlString" />.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <returns>The column value as a <see cref="T:System.Data.SqlTypes.SqlString" />.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetSqlValue(System.Int32)">
+      <summary>Returns the data value stored in the column, expressed as a SQL Server type, specified by the column ordinal.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <returns>The value of the column, expressed as a SQL Server type, as a <see cref="T:System.Object" />.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetSqlValues(System.Object[])">
+      <summary>Returns the values for all the columns in the record, expressed as SQL Server types, in an array.</summary>
+      <param name="values">The array into which to copy the values column values.</param>
+      <returns>An <see cref="T:System.Int32" /> that indicates the number of columns copied.</returns>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="values" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetSqlXml(System.Int32)">
+      <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlXml" />.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <returns>The column value as a <see cref="T:System.Data.SqlTypes.SqlXml" />.</returns>
+      <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetString(System.Int32)">
+      <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.String" />.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <returns>The column value as a <see cref="T:System.String" />.</returns>
+      <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetTimeSpan(System.Int32)">
+      <summary>Returns the specified column's data as a <see cref="T:System.TimeSpan" />.</summary>
+      <param name="ordinal">The zero-based column ordinal.</param>
+      <returns>The value of the specified column as a <see cref="T:System.TimeSpan" />.</returns>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetValue(System.Int32)">
+      <summary>Returns the common language runtime (CLR) type value for the column specified by the ordinal argument.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <returns>The CLR type value of the column specified by the ordinal.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.GetValues(System.Object[])">
+      <summary>Returns the values for all the columns in the record, expressed as common language runtime (CLR) types, in an array.</summary>
+      <param name="values">The array into which to copy the values column values.</param>
+      <returns>An <see cref="T:System.Int32" /> that indicates the number of columns copied.</returns>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="values" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.IsDBNull(System.Int32)">
+      <summary>Returns true if the column specified by the column ordinal parameter is null.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <returns>
+        <see langword="true" /> if the column is null; <see langword="false" /> otherwise.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlDataRecord.Item(System.Int32)">
+      <summary>Gets the common language runtime (CLR) type value for the column specified by the column <paramref name="ordinal" /> argument.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <returns>The CLR type value of the column specified by the <paramref name="ordinal" />.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlDataRecord.Item(System.String)">
+      <summary>Gets the common language runtime (CLR) type value for the column specified by the column <paramref name="name" /> argument.</summary>
+      <param name="name">The name of the column.</param>
+      <returns>The CLR type value of the column specified by the <paramref name="name" />.</returns>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.SetBoolean(System.Int32,System.Boolean)">
+      <summary>Sets the data stored in the column to the specified <see cref="T:System.Boolean" /> value.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <param name="value">The new value of the column.</param>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.SetByte(System.Int32,System.Byte)">
+      <summary>Sets the data stored in the column to the specified <see cref="T:System.Byte" /> value.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <param name="value">The new value of the column.</param>
+      <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.SetBytes(System.Int32,System.Int64,System.Byte[],System.Int32,System.Int32)">
+      <summary>Sets the data stored in the column to the specified array of <see cref="T:System.Byte" /> values.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <param name="fieldOffset">The offset into the field value to start copying bytes.</param>
+      <param name="buffer">The target buffer from which to copy bytes.</param>
+      <param name="bufferOffset">The offset into the buffer from which to start copying bytes.</param>
+      <param name="length">The number of bytes to copy from the buffer.</param>
+      <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.SetChar(System.Int32,System.Char)">
+      <summary>Sets the data stored in the column to the specified <see cref="T:System.Char" /> value.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <param name="value">The new value of the column.</param>
+      <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.SetChars(System.Int32,System.Int64,System.Char[],System.Int32,System.Int32)">
+      <summary>Sets the data stored in the column to the specified array of <see cref="T:System.Char" /> values.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <param name="fieldOffset">The offset into the field value to start copying characters.</param>
+      <param name="buffer">The target buffer from which to copy chars.</param>
+      <param name="bufferOffset">The offset into the buffer from which to start copying chars.</param>
+      <param name="length">The number of chars to copy from the buffer.</param>
+      <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.SetDateTime(System.Int32,System.DateTime)">
+      <summary>Sets the data stored in the column to the specified <see cref="T:System.DateTime" /> value.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <param name="value">The new value of the column.</param>
+      <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.SetDateTimeOffset(System.Int32,System.DateTimeOffset)">
+      <summary>Sets the value of the column specified to the <see cref="T:System.DateTimeOffset" /> value.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <param name="value">The new value of the column.</param>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.SetDBNull(System.Int32)">
+      <summary>Sets the value in the specified column to <see cref="T:System.DBNull" />.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.SetDecimal(System.Int32,System.Decimal)">
+      <summary>Sets the data stored in the column to the specified <see cref="T:System.Decimal" /> value.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <param name="value">The new value of the column.</param>
+      <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.SetDouble(System.Int32,System.Double)">
+      <summary>Sets the data stored in the column to the specified <see cref="T:System.Double" /> value.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <param name="value">The new value of the column.</param>
+      <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.SetFloat(System.Int32,System.Single)">
+      <summary>Sets the data stored in the column to the specified <see langword="float" /> value.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <param name="value">The new value of the column.</param>
+      <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.SetGuid(System.Int32,System.Guid)">
+      <summary>Sets the data stored in the column to the specified <see cref="T:System.Guid" /> value.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <param name="value">The new value of the column.</param>
+      <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.SetInt16(System.Int32,System.Int16)">
+      <summary>Sets the data stored in the column to the specified <see cref="T:System.Int16" /> value.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <param name="value">The new value of the column.</param>
+      <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.SetInt32(System.Int32,System.Int32)">
+      <summary>Sets the data stored in the column to the specified <see cref="T:System.Int32" /> value.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <param name="value">The new value of the column.</param>
+      <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.SetInt64(System.Int32,System.Int64)">
+      <summary>Sets the data stored in the column to the specified <see cref="T:System.Int64" /> value.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <param name="value">The new value of the column.</param>
+      <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.SetSqlBinary(System.Int32,System.Data.SqlTypes.SqlBinary)">
+      <summary>Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlBinary" /> value.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <param name="value">The new value of the column.</param>
+      <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.SetSqlBoolean(System.Int32,System.Data.SqlTypes.SqlBoolean)">
+      <summary>Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlBoolean" /> value.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <param name="value">The new value of the column.</param>
+      <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.SetSqlByte(System.Int32,System.Data.SqlTypes.SqlByte)">
+      <summary>Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlByte" /> value.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <param name="value">The new value of the column.</param>
+      <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.SetSqlBytes(System.Int32,System.Data.SqlTypes.SqlBytes)">
+      <summary>Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlBytes" /> value.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <param name="value">The new value of the column.</param>
+      <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.SetSqlChars(System.Int32,System.Data.SqlTypes.SqlChars)">
+      <summary>Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlChars" /> value.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <param name="value">The new value of the column.</param>
+      <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.SetSqlDateTime(System.Int32,System.Data.SqlTypes.SqlDateTime)">
+      <summary>Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlDateTime" /> value.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <param name="value">The new value of the column.</param>
+      <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.SetSqlDecimal(System.Int32,System.Data.SqlTypes.SqlDecimal)">
+      <summary>Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlDecimal" /> value.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <param name="value">The new value of the column.</param>
+      <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.SetSqlDouble(System.Int32,System.Data.SqlTypes.SqlDouble)">
+      <summary>Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlDouble" /> value.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <param name="value">The new value of the column.</param>
+      <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.SetSqlGuid(System.Int32,System.Data.SqlTypes.SqlGuid)">
+      <summary>Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlGuid" /> value.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <param name="value">The new value of the column.</param>
+      <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.SetSqlInt16(System.Int32,System.Data.SqlTypes.SqlInt16)">
+      <summary>Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlInt16" /> value.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <param name="value">The new value of the column.</param>
+      <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.SetSqlInt32(System.Int32,System.Data.SqlTypes.SqlInt32)">
+      <summary>Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlInt32" /> value.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <param name="value">The new value of the column.</param>
+      <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.SetSqlInt64(System.Int32,System.Data.SqlTypes.SqlInt64)">
+      <summary>Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlInt64" /> value.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <param name="value">The new value of the column.</param>
+      <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.SetSqlMoney(System.Int32,System.Data.SqlTypes.SqlMoney)">
+      <summary>Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlMoney" /> value.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <param name="value">The new value of the column.</param>
+      <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.SetSqlSingle(System.Int32,System.Data.SqlTypes.SqlSingle)">
+      <summary>Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlSingle" /> value.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <param name="value">The new value of the column.</param>
+      <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.SetSqlString(System.Int32,System.Data.SqlTypes.SqlString)">
+      <summary>Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlString" /> value.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <param name="value">The new value of the column.</param>
+      <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.SetSqlXml(System.Int32,System.Data.SqlTypes.SqlXml)">
+      <summary>Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlXml" /> value.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <param name="value">The new value of the column.</param>
+      <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.SetString(System.Int32,System.String)">
+      <summary>Sets the data stored in the column to the specified <see cref="T:System.String" /> value.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <param name="value">The new value of the column.</param>
+      <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.SetTimeSpan(System.Int32,System.TimeSpan)">
+      <summary>Sets the value of the column specified to the <see cref="T:System.TimeSpan" />.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <param name="value">The new value of the column.</param>
+      <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> passed in is a negative number.</exception>
+      <exception cref="T:System.ArgumentException">The <see cref="T:System.TimeSpan" /> value passed in is greater than 24 hours in length.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.SetValue(System.Int32,System.Object)">
+      <summary>Sets a new value, expressed as a common language runtime (CLR) type, for the column specified by the column ordinal.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <param name="value">The new value for the specified column.</param>
+      <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.SetValues(System.Object[])">
+      <summary>Sets new values for all of the columns in the <see cref="T:Microsoft.SqlServer.Server.SqlDataRecord" />. These values are expressed as common language runtime (CLR) types.</summary>
+      <param name="values">The array of new values, expressed as CLR types boxed as <see cref="T:System.Object" /> references, for the <see cref="T:Microsoft.SqlServer.Server.SqlDataRecord" /> instance.</param>
+      <returns>The number of column values set as an integer.</returns>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="values" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.ArgumentException">The size of values does not match the number of columns in the <see cref="T:Microsoft.SqlServer.Server.SqlDataRecord" /> instance.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlDataRecord.System#Data#IDataRecord#GetData(System.Int32)">
+      <summary>Not supported in this release.</summary>
+      <param name="ordinal">The zero-based ordinal of the column.</param>
+      <returns>
+        <see cref="T:System.Data.IDataReader" />
+Always throws an exception.</returns>
+      <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.SqlServer.Server.SqlDataRecord.FieldCount" />).</exception>
+    </member>
+    <member name="T:Microsoft.SqlServer.Server.SqlFacetAttribute">
+      <summary>Annotates the returned result of a user-defined type (UDT) with additional information that can be used in Transact-SQL.</summary>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlFacetAttribute.#ctor">
+      <summary>An optional attribute on a user-defined type (UDT) return type, used to annotate the returned result with additional information that can be used in Transact-SQL.</summary>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlFacetAttribute.IsFixedLength">
+      <summary>Indicates whether the return type of the user-defined type is of a fixed length.</summary>
+      <returns>
+        <see langword="true" /> if the return type is of a fixed length; otherwise <see langword="false" />.</returns>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlFacetAttribute.IsNullable">
+      <summary>Indicates whether the return type of the user-defined type can be <see langword="null" />.</summary>
+      <returns>
+        <see langword="true" /> if the return type of the user-defined type can be <see langword="null" />; otherwise <see langword="false" />.</returns>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlFacetAttribute.MaxSize">
+      <summary>The maximum size, in logical units, of the underlying field type of the user-defined type.</summary>
+      <returns>An <see cref="T:System.Int32" /> representing the maximum size, in logical units, of the underlying field type.</returns>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlFacetAttribute.Precision">
+      <summary>The precision of the return type of the user-defined type.</summary>
+      <returns>An <see cref="T:System.Int32" /> representing the precision of the return type.</returns>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlFacetAttribute.Scale">
+      <summary>The scale of the return type of the user-defined type.</summary>
+      <returns>An <see cref="T:System.Int32" /> representing the scale of the return type.</returns>
+    </member>
+    <member name="T:Microsoft.SqlServer.Server.SqlFunctionAttribute">
+      <summary>Used to mark a method definition of a user-defined aggregate as a function in SQL Server. The properties on the attribute reflect the physical characteristics used when the type is registered with SQL Server.</summary>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlFunctionAttribute.#ctor">
+      <summary>An optional attribute on a user-defined aggregate, used to indicate that the method should be registered in SQL Server as a function. Also used to set the <see cref="P:Microsoft.SqlServer.Server.SqlFunctionAttribute.DataAccess" />, <see cref="P:Microsoft.SqlServer.Server.SqlFunctionAttribute.FillRowMethodName" />, <see cref="P:Microsoft.SqlServer.Server.SqlFunctionAttribute.IsDeterministic" />, <see cref="P:Microsoft.SqlServer.Server.SqlFunctionAttribute.IsPrecise" />, <see cref="P:Microsoft.SqlServer.Server.SqlFunctionAttribute.Name" />, <see cref="P:Microsoft.SqlServer.Server.SqlFunctionAttribute.SystemDataAccess" />, and <see cref="P:Microsoft.SqlServer.Server.SqlFunctionAttribute.TableDefinition" /> properties of the function attribute.</summary>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlFunctionAttribute.DataAccess">
+      <summary>Indicates whether the function involves access to user data stored in the local instance of SQL Server.</summary>
+      <returns>
+        <see cref="T:Microsoft.SqlServer.Server.DataAccessKind" />.<see langword="None" />: Does not access data. <see cref="T:Microsoft.SqlServer.Server.DataAccessKind" />.<see langword="Read" />: Only reads user data.</returns>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlFunctionAttribute.FillRowMethodName">
+      <summary>The name of a method in the same class which is used to fill a row of data in the table returned by the table-valued function.</summary>
+      <returns>A <see cref="T:System.String" /> value representing the name of a method in the same class which is used to fill a row of data in the table returned by the table-valued function.</returns>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlFunctionAttribute.IsDeterministic">
+      <summary>Indicates whether the user-defined function is deterministic.</summary>
+      <returns>
+        <see langword="true" /> if the function is deterministic; otherwise <see langword="false" />.</returns>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlFunctionAttribute.IsPrecise">
+      <summary>Indicates whether the function involves imprecise computations, such as floating point operations.</summary>
+      <returns>
+        <see langword="true" /> if the function involves precise computations; otherwise <see langword="false" />.</returns>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlFunctionAttribute.Name">
+      <summary>The name under which the function should be registered in SQL Server.</summary>
+      <returns>A <see cref="T:System.String" /> value representing the name under which the function should be registered.</returns>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlFunctionAttribute.SystemDataAccess">
+      <summary>Indicates whether the function requires access to data stored in the system catalogs or virtual system tables of SQL Server.</summary>
+      <returns>
+        <see cref="T:Microsoft.SqlServer.Server.DataAccessKind" />.<see langword="None" />: Does not access system data. <see cref="T:Microsoft.SqlServer.Server.DataAccessKind" />.<see langword="Read" />: Only reads system data.</returns>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlFunctionAttribute.TableDefinition">
+      <summary>A string that represents the table definition of the results, if the method is used as a table-valued function (TVF).</summary>
+      <returns>A <see cref="T:System.String" /> value representing the table definition of the results.</returns>
+    </member>
+    <member name="T:Microsoft.SqlServer.Server.SqlMetaData">
+      <summary>Specifies and retrieves metadata information from parameters and columns of <see cref="T:Microsoft.SqlServer.Server.SqlDataRecord" /> objects. This class cannot be inherited.</summary>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.#ctor(System.String,System.Data.SqlDbType)">
+      <summary>Initializes a new instance of the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> class with the specified column name and type.</summary>
+      <param name="name">The name of the column.</param>
+      <param name="dbType">The SQL Server type of the parameter or column.</param>
+      <exception cref="T:System.ArgumentNullException">The <paramref name="Name" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.ArgumentException">A <see langword="SqlDbType" /> that is not allowed was passed to the constructor as <paramref name="dbType" />.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.#ctor(System.String,System.Data.SqlDbType,System.Boolean,System.Boolean,System.Data.SqlClient.SortOrder,System.Int32)">
+      <summary>Initializes a new instance of the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> class with the specified column name, and default server. This form of the constructor supports table-valued parameters by allowing you to specify if the column is unique in the table-valued parameter, the sort order for the column, and the ordinal of the sort column.</summary>
+      <param name="name">The name of the column.</param>
+      <param name="dbType">The SQL Server type of the parameter or column.</param>
+      <param name="useServerDefault">Specifies whether this column should use the default server value.</param>
+      <param name="isUniqueKey">Specifies if the column in the table-valued parameter is unique.</param>
+      <param name="columnSortOrder">Specifies the sort order for a column.</param>
+      <param name="sortOrdinal">Specifies the ordinal of the sort column.</param>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.#ctor(System.String,System.Data.SqlDbType,System.Byte,System.Byte)">
+      <summary>Initializes a new instance of the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> class with the specified column name, type, precision, and scale.</summary>
+      <param name="name">The name of the parameter or column.</param>
+      <param name="dbType">The SQL Server type of the parameter or column.</param>
+      <param name="precision">The precision of the parameter or column.</param>
+      <param name="scale">The scale of the parameter or column.</param>
+      <exception cref="T:System.ArgumentNullException">The <paramref name="Name" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.ArgumentException">A <see langword="SqlDbType" /> that is not allowed was passed to the constructor as <paramref name="dbType" />, or <paramref name="scale" /> was greater than <paramref name="precision" />.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.#ctor(System.String,System.Data.SqlDbType,System.Byte,System.Byte,System.Boolean,System.Boolean,System.Data.SqlClient.SortOrder,System.Int32)">
+      <summary>Initializes a new instance of the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> class with the specified column name, type, precision, scale, and server default. This form of the constructor supports table-valued parameters by allowing you to specify if the column is unique in the table-valued parameter, the sort order for the column, and the ordinal of the sort column.</summary>
+      <param name="name">The name of the column.</param>
+      <param name="dbType">The SQL Server type of the parameter or column.</param>
+      <param name="precision">The precision of the parameter or column.</param>
+      <param name="scale">The scale of the parameter or column.</param>
+      <param name="useServerDefault">Specifies whether this column should use the default server value.</param>
+      <param name="isUniqueKey">Specifies if the column in the table-valued parameter is unique.</param>
+      <param name="columnSortOrder">Specifies the sort order for a column.</param>
+      <param name="sortOrdinal">Specifies the ordinal of the sort column.</param>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.#ctor(System.String,System.Data.SqlDbType,System.Int64)">
+      <summary>Initializes a new instance of the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> class with the specified column name, type, and maximum length.</summary>
+      <param name="name">The name of the column.</param>
+      <param name="dbType">The SQL Server type of the parameter or column.</param>
+      <param name="maxLength">The maximum length of the specified type.</param>
+      <exception cref="T:System.ArgumentNullException">The <paramref name="Name" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.ArgumentException">A SqlDbType that is not allowed was passed to the constructor as <paramref name="dbType" />.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.#ctor(System.String,System.Data.SqlDbType,System.Int64,System.Boolean,System.Boolean,System.Data.SqlClient.SortOrder,System.Int32)">
+      <summary>Initializes a new instance of the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> class with the specified column name, type, maximum length, and server default. This form of the constructor supports table-valued parameters by allowing you to specify if the column is unique in the table-valued parameter, the sort order for the column, and the ordinal of the sort column.</summary>
+      <param name="name">The name of the column.</param>
+      <param name="dbType">The SQL Server type of the parameter or column.</param>
+      <param name="maxLength">The maximum length of the specified type.</param>
+      <param name="useServerDefault">Specifies whether this column should use the default server value.</param>
+      <param name="isUniqueKey">Specifies if the column in the table-valued parameter is unique.</param>
+      <param name="columnSortOrder">Specifies the sort order for a column.</param>
+      <param name="sortOrdinal">Specifies the ordinal of the sort column.</param>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.#ctor(System.String,System.Data.SqlDbType,System.Int64,System.Byte,System.Byte,System.Int64,System.Data.SqlTypes.SqlCompareOptions,System.Type)">
+      <summary>Initializes a new instance of the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> class with the specified column name, type, maximum length, precision, scale, locale ID, compare options, and user-defined type (UDT).</summary>
+      <param name="name">The name of the column.</param>
+      <param name="dbType">The SQL Server type of the parameter or column.</param>
+      <param name="maxLength">The maximum length of the specified type.</param>
+      <param name="precision">The precision of the parameter or column.</param>
+      <param name="scale">The scale of the parameter or column.</param>
+      <param name="locale">The locale ID of the parameter or column.</param>
+      <param name="compareOptions">The comparison rules of the parameter or column.</param>
+      <param name="userDefinedType">A <see cref="T:System.Type" /> instance that points to the UDT.</param>
+      <exception cref="T:System.ArgumentNullException">The <paramref name="Name" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.ArgumentException">A <see langword="SqlDbType" /> that is not allowed was passed to the constructor as <paramref name="dbType" />, or <paramref name="userDefinedType" /> points to a type that does not have <see cref="T:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute" /> declared.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.#ctor(System.String,System.Data.SqlDbType,System.Int64,System.Byte,System.Byte,System.Int64,System.Data.SqlTypes.SqlCompareOptions,System.Type,System.Boolean,System.Boolean,System.Data.SqlClient.SortOrder,System.Int32)">
+      <summary>Initializes a new instance of the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> class with the specified column name, type, maximum length, precision, scale, locale ID, compare options, and user-defined type (UDT). This form of the constructor supports table-valued parameters by allowing you to specify if the column is unique in the table-valued parameter, the sort order for the column, and the ordinal of the sort column.</summary>
+      <param name="name">The name of the column.</param>
+      <param name="dbType">The SQL Server type of the parameter or column.</param>
+      <param name="maxLength">The maximum length of the specified type.</param>
+      <param name="precision">The precision of the parameter or column.</param>
+      <param name="scale">The scale of the parameter or column.</param>
+      <param name="localeId">The locale ID of the parameter or column.</param>
+      <param name="compareOptions">The comparison rules of the parameter or column.</param>
+      <param name="userDefinedType">A <see cref="T:System.Type" /> instance that points to the UDT.</param>
+      <param name="useServerDefault">Specifies whether this column should use the default server value.</param>
+      <param name="isUniqueKey">Specifies if the column in the table-valued parameter is unique.</param>
+      <param name="columnSortOrder">Specifies the sort order for a column.</param>
+      <param name="sortOrdinal">Specifies the ordinal of the sort column.</param>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.#ctor(System.String,System.Data.SqlDbType,System.Int64,System.Int64,System.Data.SqlTypes.SqlCompareOptions)">
+      <summary>Initializes a new instance of the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> class with the specified column name, type, maximum length, locale, and compare options.</summary>
+      <param name="name">The name of the parameter or column.</param>
+      <param name="dbType">The SQL Server type of the parameter or column.</param>
+      <param name="maxLength">The maximum length of the specified type.</param>
+      <param name="locale">The locale ID of the parameter or column.</param>
+      <param name="compareOptions">The comparison rules of the parameter or column.</param>
+      <exception cref="T:System.ArgumentNullException">The <paramref name="Name" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.ArgumentException">A SqlDbType that is not allowed was passed to the constructor as <paramref name="dbType" />.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.#ctor(System.String,System.Data.SqlDbType,System.Int64,System.Int64,System.Data.SqlTypes.SqlCompareOptions,System.Boolean,System.Boolean,System.Data.SqlClient.SortOrder,System.Int32)">
+      <summary>Initializes a new instance of the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> class with the specified column name, type, maximum length, locale, compare options, and server default. This form of the constructor supports table-valued parameters by allowing you to specify if the column is unique in the table-valued parameter, the sort order for the column, and the ordinal of the sort column.</summary>
+      <param name="name">The name of the column.</param>
+      <param name="dbType">The SQL Server type of the parameter or column.</param>
+      <param name="maxLength">The maximum length of the specified type.</param>
+      <param name="locale">The locale ID of the parameter or column.</param>
+      <param name="compareOptions">The comparison rules of the parameter or column.</param>
+      <param name="useServerDefault">Specifies whether this column should use the default server value.</param>
+      <param name="isUniqueKey">Specifies if the column in the table-valued parameter is unique.</param>
+      <param name="columnSortOrder">Specifies the sort order for a column.</param>
+      <param name="sortOrdinal">Specifies the ordinal of the sort column.</param>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.#ctor(System.String,System.Data.SqlDbType,System.String,System.String,System.String)">
+      <summary>Initializes a new instance of the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> class with the specified column name, type, database name, owning schema, and object name.</summary>
+      <param name="name">The name of the column.</param>
+      <param name="dbType">The SQL Server type of the parameter or column.</param>
+      <param name="database">The database name of the XML schema collection of a typed XML instance.</param>
+      <param name="owningSchema">The relational schema name of the XML schema collection of a typed XML instance.</param>
+      <param name="objectName">The name of the XML schema collection of a typed XML instance.</param>
+      <exception cref="T:System.ArgumentNullException">The <paramref name="Name" /> is <see langword="null" />, or <paramref name="objectName" /> is <see langword="null" /> when <paramref name="database" /> and <paramref name="owningSchema" /> are non-<see langword="null" />.</exception>
+      <exception cref="T:System.ArgumentException">A SqlDbType that is not allowed was passed to the constructor as <paramref name="dbType" />.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.#ctor(System.String,System.Data.SqlDbType,System.String,System.String,System.String,System.Boolean,System.Boolean,System.Data.SqlClient.SortOrder,System.Int32)">
+      <summary>Initializes a new instance of the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> class with the specified column name, database name, owning schema, object name, and default server. This form of the constructor supports table-valued parameters by allowing you to specify if the column is unique in the table-valued parameter, the sort order for the column, and the ordinal of the sort column.</summary>
+      <param name="name">The name of the column.</param>
+      <param name="dbType">The SQL Server type of the parameter or column.</param>
+      <param name="database">The database name of the XML schema collection of a typed XML instance.</param>
+      <param name="owningSchema">The relational schema name of the XML schema collection of a typed XML instance.</param>
+      <param name="objectName">The name of the XML schema collection of a typed XML instance.</param>
+      <param name="useServerDefault">Specifies whether this column should use the default server value.</param>
+      <param name="isUniqueKey">Specifies if the column in the table-valued parameter is unique.</param>
+      <param name="columnSortOrder">Specifies the sort order for a column.</param>
+      <param name="sortOrdinal">Specifies the ordinal of the sort column.</param>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.#ctor(System.String,System.Data.SqlDbType,System.Type)">
+      <summary>Initializes a new instance of the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> class with the specified column name, type, and user-defined type (UDT).</summary>
+      <param name="name">The name of the column.</param>
+      <param name="dbType">The SQL Server type of the parameter or column.</param>
+      <param name="userDefinedType">A <see cref="T:System.Type" /> instance that points to the UDT.</param>
+      <exception cref="T:System.ArgumentNullException">The <paramref name="Name" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.ArgumentException">A SqlDbType that is not allowed was passed to the constructor as <paramref name="dbType" />, or <paramref name="userDefinedType" /> points to a type that does not have <see cref="T:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute" /> declared.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.#ctor(System.String,System.Data.SqlDbType,System.Type,System.String)">
+      <summary>Initializes a new instance of the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> class with the specified column name, user-defined type (UDT), and SQLServer type.</summary>
+      <param name="name">The name of the column.</param>
+      <param name="dbType">The SQL Server type of the parameter or column.</param>
+      <param name="userDefinedType">A <see cref="T:System.Type" /> instance that points to the UDT.</param>
+      <param name="serverTypeName">The SQL Server type name for <paramref name="userDefinedType" />.</param>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.#ctor(System.String,System.Data.SqlDbType,System.Type,System.String,System.Boolean,System.Boolean,System.Data.SqlClient.SortOrder,System.Int32)">
+      <summary>Initializes a new instance of the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> class with the specified column name, type, user-defined type, SQL Server type, and server default. This form of the constructor supports table-valued parameters by allowing you to specify if the column is unique in the table-valued parameter, the sort order for the column, and the ordinal of the sort column.</summary>
+      <param name="name">The name of the column.</param>
+      <param name="dbType">The SQL Server type of the parameter or column.</param>
+      <param name="userDefinedType">A <see cref="T:System.Type" /> instance that points to the UDT.</param>
+      <param name="serverTypeName">The SQL Server type name for <paramref name="userDefinedType" />.</param>
+      <param name="useServerDefault">Specifies whether this column should use the default server value.</param>
+      <param name="isUniqueKey">Specifies if the column in the table-valued parameter is unique.</param>
+      <param name="columnSortOrder">Specifies the sort order for a column.</param>
+      <param name="sortOrdinal">Specifies the ordinal of the sort column.</param>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.Adjust(System.Boolean)">
+      <summary>Validates the specified <see cref="T:System.Boolean" /> value against the metadata, and adjusts the value if necessary.</summary>
+      <param name="value">The value to validate against the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> instance.</param>
+      <returns>The adjusted value as a <see cref="T:System.Boolean" />.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="Value" /> does not match the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.Adjust(System.Byte)">
+      <summary>Validates the specified <see cref="T:System.Byte" /> value against the metadata, and adjusts the value if necessary.</summary>
+      <param name="value">The value to validate against the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> instance.</param>
+      <returns>The adjusted value as a <see cref="T:System.Byte" />.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="Value" /> does not match the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.Adjust(System.Byte[])">
+      <summary>Validates the specified array of <see cref="T:System.Byte" /> values against the metadata, and adjusts the value if necessary.</summary>
+      <param name="value">The value to validate against the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> instance.</param>
+      <returns>The adjusted value as an array of <see cref="T:System.Byte" /> values.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="Value" /> does not match the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.Adjust(System.Char)">
+      <summary>Validates the specified <see cref="T:System.Char" /> value against the metadata, and adjusts the value if necessary.</summary>
+      <param name="value">The value to validate against the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> instance.</param>
+      <returns>The adjusted value as a <see cref="T:System.Char" />.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="Value" /> does not match the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.Adjust(System.Char[])">
+      <summary>Validates the specified array of <see cref="T:System.Char" /> values against the metadata, and adjusts the value if necessary.</summary>
+      <param name="value">The value to validate against the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> instance.</param>
+      <returns>The adjusted value as an array <see cref="T:System.Char" /> values.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="Value" /> does not match the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.Adjust(System.Data.SqlTypes.SqlBinary)">
+      <summary>Validates the specified <see cref="T:System.Data.SqlTypes.SqlBinary" /> value against the metadata, and adjusts the value if necessary.</summary>
+      <param name="value">The value to validate against the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> instance.</param>
+      <returns>The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlBinary" />.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="Value" /> does not match the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.Adjust(System.Data.SqlTypes.SqlBoolean)">
+      <summary>Validates the specified <see cref="T:System.Data.SqlTypes.SqlBoolean" /> value against the metadata, and adjusts the value if necessary.</summary>
+      <param name="value">The value to validate against the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> instance.</param>
+      <returns>The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlBoolean" />.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="Value" /> does not match the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.Adjust(System.Data.SqlTypes.SqlByte)">
+      <summary>Validates the specified <see cref="T:System.Data.SqlTypes.SqlByte" /> value against the metadata, and adjusts the value if necessary.</summary>
+      <param name="value">The value to validate against the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> instance.</param>
+      <returns>The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlByte" />.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="Value" /> does not match the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.Adjust(System.Data.SqlTypes.SqlBytes)">
+      <summary>Validates the specified <see cref="T:System.Data.SqlTypes.SqlBytes" /> value against the metadata, and adjusts the value if necessary.</summary>
+      <param name="value">The value to validate against the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> instance.</param>
+      <returns>The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlBytes" />.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="Value" /> does not match the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.Adjust(System.Data.SqlTypes.SqlChars)">
+      <summary>Validates the specified <see cref="T:System.Data.SqlTypes.SqlChars" /> value against the metadata, and adjusts the value if necessary.</summary>
+      <param name="value">The value to validate against the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> instance.</param>
+      <returns>The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlChars" />.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="Value" /> does not match the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.Adjust(System.Data.SqlTypes.SqlDateTime)">
+      <summary>Validates the specified <see cref="T:System.Data.SqlTypes.SqlDateTime" /> value against the metadata, and adjusts the value if necessary.</summary>
+      <param name="value">The value to validate against the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> instance.</param>
+      <returns>The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlDateTime" />.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="Value" /> does not match the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.Adjust(System.Data.SqlTypes.SqlDecimal)">
+      <summary>Validates the specified <see cref="T:System.Data.SqlTypes.SqlDecimal" /> value against the metadata, and adjusts the value if necessary.</summary>
+      <param name="value">The value to validate against the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> instance.</param>
+      <returns>The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlDecimal" />.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="Value" /> does not match the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.Adjust(System.Data.SqlTypes.SqlDouble)">
+      <summary>Validates the specified <see cref="T:System.Data.SqlTypes.SqlDouble" /> value against the metadata, and adjusts the value if necessary.</summary>
+      <param name="value">The value to validate against the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> instance.</param>
+      <returns>The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlDouble" />.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="Value" /> does not match the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.Adjust(System.Data.SqlTypes.SqlGuid)">
+      <summary>Validates the specified <see cref="T:System.Data.SqlTypes.SqlGuid" /> value against the metadata, and adjusts the value if necessary.</summary>
+      <param name="value">The value to validate against the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> instance.</param>
+      <returns>The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlGuid" />.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="Value" /> does not match the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.Adjust(System.Data.SqlTypes.SqlInt16)">
+      <summary>Validates the specified <see cref="T:System.Data.SqlTypes.SqlInt16" /> value against the metadata, and adjusts the value if necessary.</summary>
+      <param name="value">The value to validate against the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> instance.</param>
+      <returns>The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlInt16" />.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="Value" /> does not match the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.Adjust(System.Data.SqlTypes.SqlInt32)">
+      <summary>Validates the specified <see cref="T:System.Data.SqlTypes.SqlInt32" /> value against the metadata, and adjusts the value if necessary.</summary>
+      <param name="value">The value to validate against the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> instance.</param>
+      <returns>The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlInt32" />.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="Value" /> does not match the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.Adjust(System.Data.SqlTypes.SqlInt64)">
+      <summary>Validates the specified <see cref="T:System.Data.SqlTypes.SqlInt64" /> value against the metadata, and adjusts the value if necessary.</summary>
+      <param name="value">The value to validate against the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> instance.</param>
+      <returns>The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlInt64" />.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="Value" /> does not match the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.Adjust(System.Data.SqlTypes.SqlMoney)">
+      <summary>Validates the specified <see cref="T:System.Data.SqlTypes.SqlMoney" /> value against the metadata, and adjusts the value if necessary.</summary>
+      <param name="value">The value to validate against the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> instance.</param>
+      <returns>The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlMoney" />.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="Value" /> does not match the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.Adjust(System.Data.SqlTypes.SqlSingle)">
+      <summary>Validates the specified <see cref="T:System.Data.SqlTypes.SqlSingle" /> value against the metadata, and adjusts the value if necessary.</summary>
+      <param name="value">The value to validate against the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> instance.</param>
+      <returns>The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlSingle" />.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="Value" /> does not match the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.Adjust(System.Data.SqlTypes.SqlString)">
+      <summary>Validates the specified <see cref="T:System.Data.SqlTypes.SqlString" /> value against the metadata, and adjusts the value if necessary.</summary>
+      <param name="value">The value to validate against the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> instance.</param>
+      <returns>The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlString" />.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="Value" /> does not match the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.Adjust(System.Data.SqlTypes.SqlXml)">
+      <summary>Validates the specified <see cref="T:System.Data.SqlTypes.SqlXml" /> value against the metadata, and adjusts the value if necessary.</summary>
+      <param name="value">The value to validate against the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> instance.</param>
+      <returns>The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlXml" />.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="Value" /> does not match the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.Adjust(System.DateTime)">
+      <summary>Validates the specified <see cref="T:System.DateTime" /> value against the metadata, and adjusts the value if necessary.</summary>
+      <param name="value">The value to validate against the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> instance.</param>
+      <returns>The adjusted value as a <see cref="T:System.DateTime" />.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="Value" /> does not match the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.Adjust(System.DateTimeOffset)">
+      <summary>Validates the specified <see cref="T:System.DateTimeOffset" /> value against the metadata, and adjusts the value if necessary.</summary>
+      <param name="value">The value to validate against the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> instance.</param>
+      <returns>The adjusted value as an array of <see cref="T:System.DateTimeOffset" /> values.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="Value" /> does not match the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.Adjust(System.Decimal)">
+      <summary>Validates the specified <see cref="T:System.Decimal" /> value against the metadata, and adjusts the value if necessary.</summary>
+      <param name="value">The value to validate against the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> instance.</param>
+      <returns>The adjusted value as a <see cref="T:System.Decimal" />.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="Value" /> does not match the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.Adjust(System.Double)">
+      <summary>Validates the specified <see cref="T:System.Double" /> value against the metadata, and adjusts the value if necessary.</summary>
+      <param name="value">The value to validate against the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> instance.</param>
+      <returns>The adjusted value as a <see cref="T:System.Double" />.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="Value" /> does not match the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.Adjust(System.Guid)">
+      <summary>Validates the specified <see cref="T:System.Guid" /> value against the metadata, and adjusts the value if necessary.</summary>
+      <param name="value">The value to validate against the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> instance.</param>
+      <returns>The adjusted value as a <see cref="T:System.Guid" />.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="Value" /> does not match the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.Adjust(System.Int16)">
+      <summary>Validates the specified <see cref="T:System.Int16" /> value against the metadata, and adjusts the value if necessary.</summary>
+      <param name="value">The value to validate against the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> instance.</param>
+      <returns>The adjusted value as a <see cref="T:System.Int16" />.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="Value" /> does not match the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.Adjust(System.Int32)">
+      <summary>Validates the specified <see cref="T:System.Int32" /> value against the metadata, and adjusts the value if necessary.</summary>
+      <param name="value">The value to validate against the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> instance.</param>
+      <returns>The adjusted value as a <see cref="T:System.Int32" />.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="Value" /> does not match the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.Adjust(System.Int64)">
+      <summary>Validates the specified <see cref="T:System.Int64" /> value against the metadata, and adjusts the value if necessary.</summary>
+      <param name="value">The value to validate against the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> instance.</param>
+      <returns>The adjusted value as a <see cref="T:System.Int64" />.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="Value" /> does not match the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.Adjust(System.Object)">
+      <summary>Validates the specified <see cref="T:System.Object" /> value against the metadata, and adjusts the value if necessary.</summary>
+      <param name="value">The value to validate against the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> instance.</param>
+      <returns>The adjusted value as a <see cref="T:System.Object" />.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="Value" /> does not match the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.Adjust(System.Single)">
+      <summary>Validates the specified <see cref="T:System.Single" /> value against the metadata, and adjusts the value if necessary.</summary>
+      <param name="value">The value to validate against the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> instance.</param>
+      <returns>The adjusted value as a <see cref="T:System.Single" />.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="Value" /> does not match the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.Adjust(System.String)">
+      <summary>Validates the specified <see cref="T:System.String" /> value against the metadata, and adjusts the value if necessary.</summary>
+      <param name="value">The value to validate against the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> instance.</param>
+      <returns>The adjusted value as a <see cref="T:System.String" />.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="Value" /> does not match the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.Adjust(System.TimeSpan)">
+      <summary>Validates the specified <see cref="T:System.TimeSpan" /> value against the metadata, and adjusts the value if necessary.</summary>
+      <param name="value">The value to validate against the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> instance.</param>
+      <returns>The adjusted value as an array of <see cref="T:System.TimeSpan" /> values.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="Value" /> does not match the <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlMetaData.CompareOptions">
+      <summary>Gets the comparison rules used for the column or parameter.</summary>
+      <returns>The comparison rules used for the column or parameter as a <see cref="T:System.Data.SqlTypes.SqlCompareOptions" />.</returns>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlMetaData.DbType">
+      <summary>Gets the data type of the column or parameter.</summary>
+      <returns>The data type of the column or parameter as a <see cref="T:System.Data.DbType" />.</returns>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMetaData.InferFromValue(System.Object,System.String)">
+      <summary>Infers the metadata from the specified object and returns it as a <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> instance.</summary>
+      <param name="value">The object used from which the metadata is inferred.</param>
+      <param name="name">The name assigned to the returned <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> instance.</param>
+      <returns>The inferred metadata as a <see cref="T:Microsoft.SqlServer.Server.SqlMetaData" /> instance.</returns>
+      <exception cref="T:System.ArgumentNullException">The <paramref name="value" /> is <see langword="null" />.</exception>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlMetaData.IsUniqueKey">
+      <summary>Indicates if the column in the table-valued parameter is unique.</summary>
+      <returns>A <see langword="Boolean" /> value.</returns>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlMetaData.LocaleId">
+      <summary>Gets the locale ID of the column or parameter.</summary>
+      <returns>The locale ID of the column or parameter as a <see cref="T:System.Int64" />.</returns>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlMetaData.Max">
+      <summary>Gets the length of <see langword="text" />, <see langword="ntext" />, and <see langword="image" /> data types.</summary>
+      <returns>The length of <see langword="text" />, <see langword="ntext" />, and <see langword="image" /> data types.</returns>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlMetaData.MaxLength">
+      <summary>Gets the maximum length of the column or parameter.</summary>
+      <returns>The maximum length of the column or parameter as a <see cref="T:System.Int64" />.</returns>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlMetaData.Name">
+      <summary>Gets the name of the column or parameter.</summary>
+      <returns>The name of the column or parameter as a <see cref="T:System.String" />.</returns>
+      <exception cref="T:System.InvalidOperationException">The <paramref name="Name" /> specified in the constructor is longer than 128 characters.</exception>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlMetaData.Precision">
+      <summary>Gets the precision of the column or parameter.</summary>
+      <returns>The precision of the column or parameter as a <see cref="T:System.Byte" />.</returns>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlMetaData.Scale">
+      <summary>Gets the scale of the column or parameter.</summary>
+      <returns>The scale of the column or parameter.</returns>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlMetaData.SortOrder">
+      <summary>Returns the sort order for a column.</summary>
+      <returns>A <see cref="T:System.Data.SqlClient.SortOrder" /> object.</returns>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlMetaData.SortOrdinal">
+      <summary>Returns the ordinal of the sort column.</summary>
+      <returns>The ordinal of the sort column.</returns>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlMetaData.SqlDbType">
+      <summary>Gets the data type of the column or parameter.</summary>
+      <returns>The data type of the column or parameter as a <see cref="T:System.Data.DbType" />.</returns>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlMetaData.Type">
+      <summary>Gets the common language runtime (CLR) type of a user-defined type (UDT).</summary>
+      <returns>The CLR type name of a user-defined type as a <see cref="T:System.Type" />.</returns>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlMetaData.TypeName">
+      <summary>Gets the three-part name of the user-defined type (UDT) or the SQL Server type represented by the instance.</summary>
+      <returns>The name of the UDT or SQL Server type as a <see cref="T:System.String" />.</returns>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlMetaData.UseServerDefault">
+      <summary>Reports whether this column should use the default server value.</summary>
+      <returns>A <see langword="Boolean" /> value.</returns>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlMetaData.XmlSchemaCollectionDatabase">
+      <summary>Gets the name of the database where the schema collection for this XML instance is located.</summary>
+      <returns>The name of the database where the schema collection for this XML instance is located as a <see cref="T:System.String" />.</returns>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlMetaData.XmlSchemaCollectionName">
+      <summary>Gets the name of the schema collection for this XML instance.</summary>
+      <returns>The name of the schema collection for this XML instance as a <see cref="T:System.String" />.</returns>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlMetaData.XmlSchemaCollectionOwningSchema">
+      <summary>Gets the owning relational schema where the schema collection for this XML instance is located.</summary>
+      <returns>The owning relational schema where the schema collection for this XML instance is located as a <see cref="T:System.String" />.</returns>
+    </member>
+    <member name="T:Microsoft.SqlServer.Server.SqlMethodAttribute">
+      <summary>Indicates the determinism and data access properties of a method or property on a user-defined type (UDT). The properties on the attribute reflect the physical characteristics that are used when the type is registered with SQL Server.</summary>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlMethodAttribute.#ctor">
+      <summary>An attribute on a user-defined type (UDT), used to indicate the determinism and data access properties of a method or a property on a UDT.</summary>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlMethodAttribute.InvokeIfReceiverIsNull">
+      <summary>Indicates whether SQL Server should invoke the method on null instances.</summary>
+      <returns>
+        <see langword="true" /> if SQL Server should invoke the method on null instances; otherwise, <see langword="false" />. If the method cannot be invoked (because of an attribute on the method), the SQL Server <see langword="DbNull" /> is returned.</returns>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlMethodAttribute.IsMutator">
+      <summary>Indicates whether a method on a user-defined type (UDT) is a mutator.</summary>
+      <returns>
+        <see langword="true" /> if the method is a mutator; otherwise <see langword="false" />.</returns>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlMethodAttribute.OnNullCall">
+      <summary>Indicates whether the method on a user-defined type (UDT) is called when <see langword="null" /> input arguments are specified in the method invocation.</summary>
+      <returns>
+        <see langword="true" /> if the method is called when <see langword="null" /> input arguments are specified in the method invocation; <see langword="false" /> if the method returns a <see langword="null" /> value when any of its input parameters are <see langword="null" />. If the method cannot be invoked (because of an attribute on the method), the SQL Server <see langword="DbNull" /> is returned.</returns>
+    </member>
+    <member name="T:Microsoft.SqlServer.Server.SqlUserDefinedAggregateAttribute">
+      <summary>Indicates that the type should be registered as a user-defined aggregate. The properties on the attribute reflect the physical attributes used when the type is registered with SQL Server. This class cannot be inherited.</summary>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlUserDefinedAggregateAttribute.#ctor(Microsoft.SqlServer.Server.Format)">
+      <summary>A required attribute on a user-defined aggregate, used to indicate that the given type is a user-defined aggregate and the storage format of the user-defined aggregate.</summary>
+      <param name="format">One of the <see cref="T:Microsoft.SqlServer.Server.Format" /> values representing the serialization format of the aggregate.</param>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlUserDefinedAggregateAttribute.Format">
+      <summary>The serialization format as a <see cref="T:Microsoft.SqlServer.Server.Format" />.</summary>
+      <returns>A <see cref="T:Microsoft.SqlServer.Server.Format" /> representing the serialization format.</returns>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlUserDefinedAggregateAttribute.IsInvariantToDuplicates">
+      <summary>Indicates whether the aggregate is invariant to duplicates.</summary>
+      <returns>
+        <see langword="true" /> if the aggregate is invariant to duplicates; otherwise <see langword="false" />.</returns>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlUserDefinedAggregateAttribute.IsInvariantToNulls">
+      <summary>Indicates whether the aggregate is invariant to nulls.</summary>
+      <returns>
+        <see langword="true" /> if the aggregate is invariant to nulls; otherwise <see langword="false" />.</returns>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlUserDefinedAggregateAttribute.IsInvariantToOrder">
+      <summary>Indicates whether the aggregate is invariant to order.</summary>
+      <returns>
+        <see langword="true" /> if the aggregate is invariant to order; otherwise <see langword="false" />.</returns>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlUserDefinedAggregateAttribute.IsNullIfEmpty">
+      <summary>Indicates whether the aggregate returns <see langword="null" /> if no values have been accumulated.</summary>
+      <returns>
+        <see langword="true" /> if the aggregate returns <see langword="null" /> if no values have been accumulated; otherwise <see langword="false" />.</returns>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlUserDefinedAggregateAttribute.MaxByteSize">
+      <summary>The maximum size, in bytes, of the aggregate instance.</summary>
+      <returns>An <see cref="T:System.Int32" /> value representing the maximum size of the aggregate instance.</returns>
+    </member>
+    <member name="F:Microsoft.SqlServer.Server.SqlUserDefinedAggregateAttribute.MaxByteSizeValue">
+      <summary>The maximum size, in bytes, required to store the state of this aggregate instance during computation.</summary>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlUserDefinedAggregateAttribute.Name">
+      <summary>The name of the aggregate.</summary>
+      <returns>A <see cref="T:System.String" /> value representing the name of the aggregate.</returns>
+    </member>
+    <member name="T:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute">
+      <summary>Used to mark a type definition in an assembly as a user-defined type (UDT) in SQL Server. The properties on the attribute reflect the physical characteristics used when the type is registered with SQL Server. This class cannot be inherited.</summary>
+    </member>
+    <member name="M:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute.#ctor(Microsoft.SqlServer.Server.Format)">
+      <summary>A required attribute on a user-defined type (UDT), used to confirm that the given type is a UDT and to indicate the storage format of the UDT.</summary>
+      <param name="format">One of the <see cref="T:Microsoft.SqlServer.Server.Format" /> values representing the serialization format of the type.</param>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute.Format">
+      <summary>The serialization format as a <see cref="T:Microsoft.SqlServer.Server.Format" />.</summary>
+      <returns>A <see cref="T:Microsoft.SqlServer.Server.Format" /> value representing the serialization format.</returns>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute.IsByteOrdered">
+      <summary>Indicates whether the user-defined type is byte ordered.</summary>
+      <returns>
+        <see langword="true" /> if the user-defined type is byte ordered; otherwise <see langword="false" />.</returns>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute.IsFixedLength">
+      <summary>Indicates whether all instances of this user-defined type are the same length.</summary>
+      <returns>
+        <see langword="true" /> if all instances of this type are the same length; otherwise <see langword="false" />.</returns>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute.MaxByteSize">
+      <summary>The maximum size of the instance, in bytes.</summary>
+      <returns>An <see cref="T:System.Int32" /> value representing the maximum size of the instance.</returns>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute.Name">
+      <summary>The SQL Server name of the user-defined type.</summary>
+      <returns>A <see cref="T:System.String" /> value representing the SQL Server name of the user-defined type.</returns>
+    </member>
+    <member name="P:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute.ValidationMethodName">
+      <summary>The name of the method used to validate instances of the user-defined type.</summary>
+      <returns>A <see cref="T:System.String" /> representing the name of the method used to validate instances of the user-defined type.</returns>
+    </member>
+    <member name="T:Microsoft.SqlServer.Server.SystemDataAccessKind">
+      <summary>Describes the type of access to system data for a user-defined method or function.</summary>
+    </member>
+    <member name="F:Microsoft.SqlServer.Server.SystemDataAccessKind.None">
+      <summary>The method or function does not access system data.</summary>
+    </member>
+    <member name="F:Microsoft.SqlServer.Server.SystemDataAccessKind.Read">
+      <summary>The method or function reads system data.</summary>
+    </member>
+    <member name="T:System.Data.OperationAbortedException">
+      <summary>This exception is thrown when an ongoing operation is aborted by the user.</summary>
+    </member>
+    <member name="T:System.Data.Sql.SqlNotificationRequest">
+      <summary>Represents a request for notification for a given command.</summary>
+    </member>
+    <member name="M:System.Data.Sql.SqlNotificationRequest.#ctor">
+      <summary>Creates a new instance of the <see cref="T:System.Data.Sql.SqlNotificationRequest" /> class with default values.</summary>
+    </member>
+    <member name="M:System.Data.Sql.SqlNotificationRequest.#ctor(System.String,System.String,System.Int32)">
+      <summary>Creates a new instance of the <see cref="T:System.Data.Sql.SqlNotificationRequest" /> class with a user-defined string that identifies a particular notification request, the name of a predefined SQL Server 2005 Service Broker service name, and the time-out period, measured in seconds.</summary>
+      <param name="userData">A string that contains an application-specific identifier for this notification. It is not used by the notifications infrastructure, but it allows you to associate notifications with the application state. The value indicated in this parameter is included in the Service Broker queue message.</param>
+      <param name="options">A string that contains the Service Broker service name where notification messages are posted, and it must include a database name or a Service Broker instance GUID that restricts the scope of the service name lookup to a particular database.
+For more information about the format of the <paramref name="options" /> parameter, see <see cref="P:System.Data.Sql.SqlNotificationRequest.Options" />.</param>
+      <param name="timeout">The time, in seconds, to wait for a notification message.</param>
+      <exception cref="T:System.ArgumentNullException">The value of the <paramref name="options" /> parameter is NULL.</exception>
+      <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="options" /> or <paramref name="userData" /> parameter is longer than <see langword="uint16.MaxValue" /> or the value in the <paramref name="timeout" /> parameter is less than zero.</exception>
+    </member>
+    <member name="P:System.Data.Sql.SqlNotificationRequest.Options">
+      <summary>Gets or sets the SQL Server Service Broker service name where notification messages are posted.</summary>
+      <returns>
+        <see langword="string" /> that contains the SQL Server 2005 Service Broker service name where notification messages are posted and the database or service broker instance GUID to scope the server name lookup.</returns>
+      <exception cref="T:System.ArgumentNullException">The value is NULL.</exception>
+      <exception cref="T:System.ArgumentException">The value is longer than <see langword="uint16.MaxValue" />.</exception>
+    </member>
+    <member name="P:System.Data.Sql.SqlNotificationRequest.Timeout">
+      <summary>Gets or sets a value that specifies how long SQL Server waits for a change to occur before the operation times out.</summary>
+      <returns>A signed integer value that specifies, in seconds, how long SQL Server waits for a change to occur before the operation times out.</returns>
+      <exception cref="T:System.ArgumentOutOfRangeException">The value is less than zero.</exception>
+    </member>
+    <member name="P:System.Data.Sql.SqlNotificationRequest.UserData">
+      <summary>Gets or sets an application-specific identifier for this notification.</summary>
+      <returns>A <see langword="string" /> value of the application-specific identifier for this notification.</returns>
+      <exception cref="T:System.ArgumentException">The value is longer than <see langword="uint16.MaxValue" />.</exception>
+    </member>
+    <member name="T:System.Data.SqlClient.ApplicationIntent">
+      <summary>Specifies a value for <see cref="P:System.Data.SqlClient.SqlConnectionStringBuilder.ApplicationIntent" />. Possible values are <see langword="ReadWrite" /> and <see langword="ReadOnly" />.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.ApplicationIntent.ReadOnly">
+      <summary>The application workload type when connecting to a server is read only.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.ApplicationIntent.ReadWrite">
+      <summary>The application workload type when connecting to a server is read write.</summary>
+    </member>
+    <member name="T:System.Data.SqlClient.OnChangeEventHandler">
+      <summary>Handles the <see cref="E:System.Data.SqlClient.SqlDependency.OnChange" /> event that is fired when a notification is received for any of the commands associated with a <see cref="T:System.Data.SqlClient.SqlDependency" /> object.</summary>
+      <param name="sender">The source of the event.</param>
+      <param name="e">A <see cref="T:System.Data.SqlClient.SqlNotificationEventArgs" /> object that contains the event data.</param>
+    </member>
+    <member name="T:System.Data.SqlClient.PoolBlockingPeriod">
+      <summary>Specifies a value for the <see cref="P:System.Data.SqlClient.SqlConnectionStringBuilder.PoolBlockingPeriod" /> property.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.PoolBlockingPeriod.AlwaysBlock">
+      <summary>Blocking period ON for all SQL servers including Azure SQL servers.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.PoolBlockingPeriod.Auto">
+      <summary>Blocking period OFF for Azure SQL servers, but ON for all other SQL servers.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.PoolBlockingPeriod.NeverBlock">
+      <summary>Blocking period OFF for all SQL servers including Azure SQL servers.</summary>
+    </member>
+    <member name="T:System.Data.SqlClient.SortOrder">
+      <summary>Specifies how rows of data are sorted.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SortOrder.Ascending">
+      <summary>Rows are sorted in ascending order.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SortOrder.Descending">
+      <summary>Rows are sorted in descending order.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SortOrder.Unspecified">
+      <summary>The default. No sort order is specified.</summary>
+    </member>
+    <member name="T:System.Data.SqlClient.SqlBulkCopy">
+      <summary>Lets you efficiently bulk load a SQL Server table with data from another source.</summary>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlBulkCopy.#ctor(System.Data.SqlClient.SqlConnection)">
+      <summary>Initializes a new instance of the <see cref="T:System.Data.SqlClient.SqlBulkCopy" /> class using the specified open instance of <see cref="T:System.Data.SqlClient.SqlConnection" />.</summary>
+      <param name="connection">The already open <see cref="T:System.Data.SqlClient.SqlConnection" /> instance that will be used to perform the bulk copy operation. If your connection string does not use <see langword="Integrated Security = true" />, you can use <see cref="T:System.Data.SqlClient.SqlCredential" /> to pass the user ID and password more securely than by specifying the user ID and password as text in the connection string.</param>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlBulkCopy.#ctor(System.Data.SqlClient.SqlConnection,System.Data.SqlClient.SqlBulkCopyOptions,System.Data.SqlClient.SqlTransaction)">
+      <summary>Initializes a new instance of the <see cref="T:System.Data.SqlClient.SqlBulkCopy" /> class using the supplied existing open instance of <see cref="T:System.Data.SqlClient.SqlConnection" />. The <see cref="T:System.Data.SqlClient.SqlBulkCopy" /> instance behaves according to options supplied in the <paramref name="copyOptions" /> parameter. If a non-null <see cref="T:System.Data.SqlClient.SqlTransaction" /> is supplied, the copy operations will be performed within that transaction.</summary>
+      <param name="connection">The already open <see cref="T:System.Data.SqlClient.SqlConnection" /> instance that will be used to perform the bulk copy. If your connection string does not use <see langword="Integrated Security = true" />, you can use <see cref="T:System.Data.SqlClient.SqlCredential" /> to pass the user ID and password more securely than by specifying the user ID and password as text in the connection string.</param>
+      <param name="copyOptions">A combination of values from the <see cref="T:System.Data.SqlClient.SqlBulkCopyOptions" /> enumeration that determines which data source rows are copied to the destination table.</param>
+      <param name="externalTransaction">An existing <see cref="T:System.Data.SqlClient.SqlTransaction" /> instance under which the bulk copy will occur.</param>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlBulkCopy.#ctor(System.String)">
+      <summary>Initializes and opens a new instance of <see cref="T:System.Data.SqlClient.SqlConnection" /> based on the supplied <paramref name="connectionString" />. The constructor uses the <see cref="T:System.Data.SqlClient.SqlConnection" /> to initialize a new instance of the <see cref="T:System.Data.SqlClient.SqlBulkCopy" /> class.</summary>
+      <param name="connectionString">The string defining the connection that will be opened for use by the <see cref="T:System.Data.SqlClient.SqlBulkCopy" /> instance. If your connection string does not use <see langword="Integrated Security = true" />, you can use <see cref="M:System.Data.SqlClient.SqlBulkCopy.#ctor(System.Data.SqlClient.SqlConnection)" /> or <see cref="M:System.Data.SqlClient.SqlBulkCopy.#ctor(System.Data.SqlClient.SqlConnection,System.Data.SqlClient.SqlBulkCopyOptions,System.Data.SqlClient.SqlTransaction)" /> and <see cref="T:System.Data.SqlClient.SqlCredential" /> to pass the user ID and password more securely than by specifying the user ID and password as text in the connection string.</param>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlBulkCopy.#ctor(System.String,System.Data.SqlClient.SqlBulkCopyOptions)">
+      <summary>Initializes and opens a new instance of <see cref="T:System.Data.SqlClient.SqlConnection" /> based on the supplied <paramref name="connectionString" />. The constructor uses that <see cref="T:System.Data.SqlClient.SqlConnection" /> to initialize a new instance of the <see cref="T:System.Data.SqlClient.SqlBulkCopy" /> class. The <see cref="T:System.Data.SqlClient.SqlConnection" /> instance behaves according to options supplied in the <paramref name="copyOptions" /> parameter.</summary>
+      <param name="connectionString">The string defining the connection that will be opened for use by the <see cref="T:System.Data.SqlClient.SqlBulkCopy" /> instance. If your connection string does not use <see langword="Integrated Security = true" />, you can use <see cref="M:System.Data.SqlClient.SqlBulkCopy.#ctor(System.Data.SqlClient.SqlConnection)" /> or <see cref="M:System.Data.SqlClient.SqlBulkCopy.#ctor(System.Data.SqlClient.SqlConnection,System.Data.SqlClient.SqlBulkCopyOptions,System.Data.SqlClient.SqlTransaction)" /> and <see cref="T:System.Data.SqlClient.SqlCredential" /> to pass the user ID and password more securely than by specifying the user ID and password as text in the connection string.</param>
+      <param name="copyOptions">A combination of values from the <see cref="T:System.Data.SqlClient.SqlBulkCopyOptions" /> enumeration that determines which data source rows are copied to the destination table.</param>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlBulkCopy.BatchSize">
+      <summary>Number of rows in each batch. At the end of each batch, the rows in the batch are sent to the server.</summary>
+      <returns>The integer value of the <see cref="P:System.Data.SqlClient.SqlBulkCopy.BatchSize" /> property, or zero if no value has been set.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlBulkCopy.BulkCopyTimeout">
+      <summary>Number of seconds for the operation to complete before it times out.</summary>
+      <returns>The integer value of the <see cref="P:System.Data.SqlClient.SqlBulkCopy.BulkCopyTimeout" /> property. The default is 30 seconds. A value of 0 indicates no limit; the bulk copy will wait indefinitely.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlBulkCopy.Close">
+      <summary>Closes the <see cref="T:System.Data.SqlClient.SqlBulkCopy" /> instance.</summary>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlBulkCopy.ColumnMappings">
+      <summary>Returns a collection of <see cref="T:System.Data.SqlClient.SqlBulkCopyColumnMapping" /> items. Column mappings define the relationships between columns in the data source and columns in the destination.</summary>
+      <returns>A collection of column mappings. By default, it is an empty collection.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlBulkCopy.DestinationTableName">
+      <summary>Name of the destination table on the server.</summary>
+      <returns>The string value of the <see cref="P:System.Data.SqlClient.SqlBulkCopy.DestinationTableName" /> property, or null if none as been supplied.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlBulkCopy.EnableStreaming">
+      <summary>Enables or disables a <see cref="T:System.Data.SqlClient.SqlBulkCopy" /> object to stream data from an <see cref="T:System.Data.IDataReader" /> object.</summary>
+      <returns>
+        <see langword="true" /> if a <see cref="T:System.Data.SqlClient.SqlBulkCopy" /> object can stream data from an <see cref="T:System.Data.IDataReader" /> object; otherwise, false. The default is <see langword="false" />.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlBulkCopy.NotifyAfter">
+      <summary>Defines the number of rows to be processed before generating a notification event.</summary>
+      <returns>The integer value of the <see cref="P:System.Data.SqlClient.SqlBulkCopy.NotifyAfter" /> property, or zero if the property has not been set.</returns>
+    </member>
+    <member name="E:System.Data.SqlClient.SqlBulkCopy.SqlRowsCopied">
+      <summary>Occurs every time that the number of rows specified by the <see cref="P:System.Data.SqlClient.SqlBulkCopy.NotifyAfter" /> property have been processed.</summary>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlBulkCopy.System#IDisposable#Dispose">
+      <summary>Releases all resources used by the current instance of the <see cref="T:System.Data.SqlClient.SqlBulkCopy" /> class.</summary>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlBulkCopy.WriteToServer(System.Data.Common.DbDataReader)">
+      <summary>Copies all rows from the supplied <see cref="T:System.Data.Common.DbDataReader" /> array to a destination table specified by the <see cref="P:System.Data.SqlClient.SqlBulkCopy.DestinationTableName" /> property of the <see cref="T:System.Data.SqlClient.SqlBulkCopy" /> object.</summary>
+      <param name="reader">A <see cref="T:System.Data.Common.DbDataReader" /> whose rows will be copied to the destination table.</param>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlBulkCopy.WriteToServer(System.Data.DataRow[])">
+      <summary>Copies all rows from the supplied <see cref="T:System.Data.DataRow" /> array to a destination table specified by the <see cref="P:System.Data.SqlClient.SqlBulkCopy.DestinationTableName" /> property of the <see cref="T:System.Data.SqlClient.SqlBulkCopy" /> object.</summary>
+      <param name="rows">An array of <see cref="T:System.Data.DataRow" /> objects that will be copied to the destination table.</param>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlBulkCopy.WriteToServer(System.Data.DataTable)">
+      <summary>Copies all rows in the supplied <see cref="T:System.Data.DataTable" /> to a destination table specified by the <see cref="P:System.Data.SqlClient.SqlBulkCopy.DestinationTableName" /> property of the <see cref="T:System.Data.SqlClient.SqlBulkCopy" /> object.</summary>
+      <param name="table">A <see cref="T:System.Data.DataTable" /> whose rows will be copied to the destination table.</param>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlBulkCopy.WriteToServer(System.Data.DataTable,System.Data.DataRowState)">
+      <summary>Copies only rows that match the supplied row state in the supplied <see cref="T:System.Data.DataTable" /> to a destination table specified by the <see cref="P:System.Data.SqlClient.SqlBulkCopy.DestinationTableName" /> property of the <see cref="T:System.Data.SqlClient.SqlBulkCopy" /> object.</summary>
+      <param name="table">A <see cref="T:System.Data.DataTable" /> whose rows will be copied to the destination table.</param>
+      <param name="rowState">A value from the <see cref="T:System.Data.DataRowState" /> enumeration. Only rows matching the row state are copied to the destination.</param>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlBulkCopy.WriteToServer(System.Data.IDataReader)">
+      <summary>Copies all rows in the supplied <see cref="T:System.Data.IDataReader" /> to a destination table specified by the <see cref="P:System.Data.SqlClient.SqlBulkCopy.DestinationTableName" /> property of the <see cref="T:System.Data.SqlClient.SqlBulkCopy" /> object.</summary>
+      <param name="reader">A <see cref="T:System.Data.IDataReader" /> whose rows will be copied to the destination table.</param>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlBulkCopy.WriteToServerAsync(System.Data.Common.DbDataReader)">
+      <summary>The asynchronous version of <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServer(System.Data.Common.DbDataReader)" />, which copies all rows from the supplied <see cref="T:System.Data.Common.DbDataReader" /> array to a destination table specified by the <see cref="P:System.Data.SqlClient.SqlBulkCopy.DestinationTableName" /> property of the <see cref="T:System.Data.SqlClient.SqlBulkCopy" /> object.</summary>
+      <param name="reader">A <see cref="T:System.Data.Common.DbDataReader" /> whose rows will be copied to the destination table.</param>
+      <returns>A task representing the asynchronous operation.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlBulkCopy.WriteToServerAsync(System.Data.Common.DbDataReader,System.Threading.CancellationToken)">
+      <summary>The asynchronous version of <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServer(System.Data.Common.DbDataReader)" />, which copies all rows from the supplied <see cref="T:System.Data.Common.DbDataReader" /> array to a destination table specified by the <see cref="P:System.Data.SqlClient.SqlBulkCopy.DestinationTableName" /> property of the <see cref="T:System.Data.SqlClient.SqlBulkCopy" /> object.</summary>
+      <param name="reader">A <see cref="T:System.Data.Common.DbDataReader" /> whose rows will be copied to the destination table.</param>
+      <param name="cancellationToken">The cancellation instruction. A <see cref="P:System.Threading.CancellationToken.None" /> value in this parameter makes this method equivalent to <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServerAsync(System.Data.Common.DbDataReader)" />.</param>
+      <returns>Returns <see cref="T:System.Threading.Tasks.Task" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlBulkCopy.WriteToServerAsync(System.Data.DataRow[])">
+      <summary>The asynchronous version of <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServer(System.Data.DataRow[])" />, which copies all rows from the supplied <see cref="T:System.Data.DataRow" /> array to a destination table specified by the <see cref="P:System.Data.SqlClient.SqlBulkCopy.DestinationTableName" /> property of the <see cref="T:System.Data.SqlClient.SqlBulkCopy" /> object.</summary>
+      <param name="rows">An array of <see cref="T:System.Data.DataRow" /> objects that will be copied to the destination table.</param>
+      <returns>A task representing the asynchronous operation.</returns>
+      <exception cref="T:System.InvalidOperationException">Calling <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServerAsync(System.Data.DataRow[])" /> multiple times for the same instance before task completion.
+Calling <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServerAsync(System.Data.DataRow[])" /> and <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServer(System.Data.DataRow[])" /> for the same instance before task completion.
+The connection drops or is closed during <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServerAsync(System.Data.DataRow[])" /> execution.
+Returned in the task object, the <see cref="T:System.Data.SqlClient.SqlBulkCopy" /> object was closed during the method execution.
+Returned in the task object, there was a connection pool timeout.
+Returned in the task object, the <see cref="T:System.Data.SqlClient.SqlConnection" /> object is closed before method execution.
+<see langword="Context Connection=true" /> is specified in the connection string.</exception>
+      <exception cref="T:System.Data.SqlClient.SqlException">Returned in the task object, any error returned by SQL Server that occurred while opening the connection.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlBulkCopy.WriteToServerAsync(System.Data.DataRow[],System.Threading.CancellationToken)">
+      <summary>The asynchronous version of <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServer(System.Data.DataRow[])" />, which copies all rows from the supplied <see cref="T:System.Data.DataRow" /> array to a destination table specified by the <see cref="P:System.Data.SqlClient.SqlBulkCopy.DestinationTableName" /> property of the <see cref="T:System.Data.SqlClient.SqlBulkCopy" /> object.
+The cancellation token can be used to request that the operation be abandoned before the command timeout elapses.  Exceptions will be reported via the returned Task object.</summary>
+      <param name="rows">An array of <see cref="T:System.Data.DataRow" /> objects that will be copied to the destination table.</param>
+      <param name="cancellationToken">The cancellation instruction. A <see cref="P:System.Threading.CancellationToken.None" /> value in this parameter makes this method equivalent to <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServerAsync(System.Data.DataTable)" />.</param>
+      <returns>A task representing the asynchronous operation.</returns>
+      <exception cref="T:System.InvalidOperationException">Calling <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServerAsync(System.Data.DataRow[])" /> multiple times for the same instance before task completion.
+Calling <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServerAsync(System.Data.DataRow[])" /> and <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServer(System.Data.DataRow[])" /> for the same instance before task completion.
+The connection drops or is closed during <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServerAsync(System.Data.DataRow[])" /> execution.
+Returned in the task object, the <see cref="T:System.Data.SqlClient.SqlBulkCopy" /> object was closed during the method execution.
+Returned in the task object, there was a connection pool timeout.
+Returned in the task object, the <see cref="T:System.Data.SqlClient.SqlConnection" /> object is closed before method execution.
+<see langword="Context Connection=true" /> is specified in the connection string.</exception>
+      <exception cref="T:System.Data.SqlClient.SqlException">Returned in the task object, any error returned by SQL Server that occurred while opening the connection.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlBulkCopy.WriteToServerAsync(System.Data.DataTable)">
+      <summary>The asynchronous version of <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServer(System.Data.DataTable)" />, which copies all rows in the supplied <see cref="T:System.Data.DataTable" /> to a destination table specified by the <see cref="P:System.Data.SqlClient.SqlBulkCopy.DestinationTableName" /> property of the <see cref="T:System.Data.SqlClient.SqlBulkCopy" /> object.</summary>
+      <param name="table">A <see cref="T:System.Data.DataTable" /> whose rows will be copied to the destination table.</param>
+      <returns>A task representing the asynchronous operation.</returns>
+      <exception cref="T:System.InvalidOperationException">Calling <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServerAsync(System.Data.DataTable)" /> multiple times for the same instance before task completion.
+Calling <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServerAsync(System.Data.DataTable)" /> and <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServer(System.Data.DataTable)" /> for the same instance before task completion.
+The connection drops or is closed during <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServerAsync(System.Data.DataTable)" /> execution.
+Returned in the task object, the <see cref="T:System.Data.SqlClient.SqlBulkCopy" /> object was closed during the method execution.
+Returned in the task object, there was a connection pool timeout.
+Returned in the task object, the <see cref="T:System.Data.SqlClient.SqlConnection" /> object is closed before method execution.
+<see langword="Context Connection=true" /> is specified in the connection string.</exception>
+      <exception cref="T:System.Data.SqlClient.SqlException">Returned in the task object, any error returned by SQL Server that occurred while opening the connection.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlBulkCopy.WriteToServerAsync(System.Data.DataTable,System.Data.DataRowState)">
+      <summary>The asynchronous version of <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServer(System.Data.DataTable,System.Data.DataRowState)" />, which copies only rows that match the supplied row state in the supplied <see cref="T:System.Data.DataTable" /> to a destination table specified by the <see cref="P:System.Data.SqlClient.SqlBulkCopy.DestinationTableName" /> property of the <see cref="T:System.Data.SqlClient.SqlBulkCopy" /> object.</summary>
+      <param name="table">A <see cref="T:System.Data.DataTable" /> whose rows will be copied to the destination table.</param>
+      <param name="rowState">A value from the <see cref="T:System.Data.DataRowState" /> enumeration. Only rows matching the row state are copied to the destination.</param>
+      <returns>A task representing the asynchronous operation.</returns>
+      <exception cref="T:System.InvalidOperationException">Calling <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServerAsync(System.Data.DataTable,System.Data.DataRowState)" /> multiple times for the same instance before task completion.
+Calling <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServerAsync(System.Data.DataTable,System.Data.DataRowState)" /> and <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServer(System.Data.DataTable,System.Data.DataRowState)" /> for the same instance before task completion.
+The connection drops or is closed during <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServerAsync(System.Data.DataTable,System.Data.DataRowState)" /> execution.
+Returned in the task object, the <see cref="T:System.Data.SqlClient.SqlBulkCopy" /> object was closed during the method execution.
+Returned in the task object, there was a connection pool timeout.
+Returned in the task object, the <see cref="T:System.Data.SqlClient.SqlConnection" /> object is closed before method execution.
+<see langword="Context Connection=true" /> is specified in the connection string.</exception>
+      <exception cref="T:System.Data.SqlClient.SqlException">Returned in the task object, any error returned by SQL Server that occurred while opening the connection.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlBulkCopy.WriteToServerAsync(System.Data.DataTable,System.Data.DataRowState,System.Threading.CancellationToken)">
+      <summary>The asynchronous version of <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServer(System.Data.DataTable,System.Data.DataRowState)" />, which copies only rows that match the supplied row state in the supplied <see cref="T:System.Data.DataTable" /> to a destination table specified by the <see cref="P:System.Data.SqlClient.SqlBulkCopy.DestinationTableName" /> property of the <see cref="T:System.Data.SqlClient.SqlBulkCopy" /> object.
+The cancellation token can be used to request that the operation be abandoned before the command timeout elapses.  Exceptions will be reported via the returned Task object.</summary>
+      <param name="table">A <see cref="T:System.Data.DataTable" /> whose rows will be copied to the destination table.</param>
+      <param name="rowState">A value from the <see cref="T:System.Data.DataRowState" /> enumeration. Only rows matching the row state are copied to the destination.</param>
+      <param name="cancellationToken">The cancellation instruction. A <see cref="P:System.Threading.CancellationToken.None" /> value in this parameter makes this method equivalent to <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServerAsync(System.Data.DataTable)" />.</param>
+      <returns>A task representing the asynchronous operation.</returns>
+      <exception cref="T:System.InvalidOperationException">Calling <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServerAsync(System.Data.DataTable,System.Data.DataRowState)" /> multiple times for the same instance before task completion.
+Calling <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServerAsync(System.Data.DataTable,System.Data.DataRowState)" /> and <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServer(System.Data.DataTable,System.Data.DataRowState)" /> for the same instance before task completion.
+The connection drops or is closed during <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServerAsync(System.Data.DataTable,System.Data.DataRowState)" /> execution.
+Returned in the task object, the <see cref="T:System.Data.SqlClient.SqlBulkCopy" /> object was closed during the method execution.
+Returned in the task object, there was a connection pool timeout.
+Returned in the task object, the <see cref="T:System.Data.SqlClient.SqlConnection" /> object is closed before method execution.
+<see langword="Context Connection=true" /> is specified in the connection string.</exception>
+      <exception cref="T:System.Data.SqlClient.SqlException">Returned in the task object, any error returned by SQL Server that occurred while opening the connection.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlBulkCopy.WriteToServerAsync(System.Data.DataTable,System.Threading.CancellationToken)">
+      <summary>The asynchronous version of <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServer(System.Data.DataTable)" />, which copies all rows in the supplied <see cref="T:System.Data.DataTable" /> to a destination table specified by the <see cref="P:System.Data.SqlClient.SqlBulkCopy.DestinationTableName" /> property of the <see cref="T:System.Data.SqlClient.SqlBulkCopy" /> object.
+The cancellation token can be used to request that the operation be abandoned before the command timeout elapses.  Exceptions will be reported via the returned Task object.</summary>
+      <param name="table">A <see cref="T:System.Data.DataTable" /> whose rows will be copied to the destination table.</param>
+      <param name="cancellationToken">The cancellation instruction. A <see cref="P:System.Threading.CancellationToken.None" /> value in this parameter makes this method equivalent to <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServerAsync(System.Data.DataTable)" />.</param>
+      <returns>A task representing the asynchronous operation.</returns>
+      <exception cref="T:System.InvalidOperationException">Calling <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServerAsync(System.Data.DataTable)" /> multiple times for the same instance before task completion.
+Calling <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServerAsync(System.Data.DataTable)" /> and <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServer(System.Data.DataTable)" /> for the same instance before task completion.
+The connection drops or is closed during <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServerAsync(System.Data.DataTable)" /> execution.
+Returned in the task object, the <see cref="T:System.Data.SqlClient.SqlBulkCopy" /> object was closed during the method execution.
+Returned in the task object, there was a connection pool timeout.
+Returned in the task object, the <see cref="T:System.Data.SqlClient.SqlConnection" /> object is closed before method execution.
+<see langword="Context Connection=true" /> is specified in the connection string.</exception>
+      <exception cref="T:System.Data.SqlClient.SqlException">Returned in the task object, any error returned by SQL Server that occurred while opening the connection.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlBulkCopy.WriteToServerAsync(System.Data.IDataReader)">
+      <summary>The asynchronous version of <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServer(System.Data.IDataReader)" />, which copies all rows in the supplied <see cref="T:System.Data.IDataReader" /> to a destination table specified by the <see cref="P:System.Data.SqlClient.SqlBulkCopy.DestinationTableName" /> property of the <see cref="T:System.Data.SqlClient.SqlBulkCopy" /> object.</summary>
+      <param name="reader">A <see cref="T:System.Data.IDataReader" /> whose rows will be copied to the destination table.</param>
+      <returns>A task representing the asynchronous operation.</returns>
+      <exception cref="T:System.InvalidOperationException">Calling <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServerAsync(System.Data.IDataReader)" /> multiple times for the same instance before task completion.
+Calling <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServerAsync(System.Data.IDataReader)" /> and <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServer(System.Data.IDataReader)" /> for the same instance before task completion.
+The connection drops or is closed during <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServerAsync(System.Data.IDataReader)" /> execution.
+Returned in the task object, the <see cref="T:System.Data.SqlClient.SqlBulkCopy" /> object was closed during the method execution.
+Returned in the task object, there was a connection pool timeout.
+Returned in the task object, the <see cref="T:System.Data.SqlClient.SqlConnection" /> object is closed before method execution.
+The <see cref="T:System.Data.IDataReader" /> was closed before the completed <see cref="T:System.Threading.Tasks.Task" /> returned.
+The <see cref="T:System.Data.IDataReader" />'s associated connection was closed before the completed <see cref="T:System.Threading.Tasks.Task" /> returned.
+<see langword="Context Connection=true" /> is specified in the connection string.</exception>
+      <exception cref="T:System.Data.SqlClient.SqlException">Returned in the task object, any error returned by SQL Server that occurred while opening the connection.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlBulkCopy.WriteToServerAsync(System.Data.IDataReader,System.Threading.CancellationToken)">
+      <summary>The asynchronous version of <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServer(System.Data.IDataReader)" />, which copies all rows in the supplied <see cref="T:System.Data.IDataReader" /> to a destination table specified by the <see cref="P:System.Data.SqlClient.SqlBulkCopy.DestinationTableName" /> property of the <see cref="T:System.Data.SqlClient.SqlBulkCopy" /> object.
+The cancellation token can be used to request that the operation be abandoned before the command timeout elapses.  Exceptions will be reported via the returned Task object.</summary>
+      <param name="reader">A <see cref="T:System.Data.IDataReader" /> whose rows will be copied to the destination table.</param>
+      <param name="cancellationToken">The cancellation instruction. A <see cref="P:System.Threading.CancellationToken.None" /> value in this parameter makes this method equivalent to <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServerAsync(System.Data.DataTable)" />.</param>
+      <returns>A task representing the asynchronous operation.</returns>
+      <exception cref="T:System.InvalidOperationException">Calling <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServerAsync(System.Data.IDataReader)" /> multiple times for the same instance before task completion.
+Calling <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServerAsync(System.Data.IDataReader)" /> and <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServer(System.Data.IDataReader)" /> for the same instance before task completion.
+The connection drops or is closed during <see cref="M:System.Data.SqlClient.SqlBulkCopy.WriteToServerAsync(System.Data.IDataReader)" /> execution.
+Returned in the task object, the <see cref="T:System.Data.SqlClient.SqlBulkCopy" /> object was closed during the method execution.
+Returned in the task object, there was a connection pool timeout.
+Returned in the task object, the <see cref="T:System.Data.SqlClient.SqlConnection" /> object is closed before method execution.
+The <see cref="T:System.Data.IDataReader" /> was closed before the completed <see cref="T:System.Threading.Tasks.Task" /> returned.
+The <see cref="T:System.Data.IDataReader" />'s associated connection was closed before the completed <see cref="T:System.Threading.Tasks.Task" /> returned.
+<see langword="Context Connection=true" /> is specified in the connection string.</exception>
+      <exception cref="T:System.Data.SqlClient.SqlException">Returned in the task object, any error returned by SQL Server that occurred while opening the connection.</exception>
+    </member>
+    <member name="T:System.Data.SqlClient.SqlBulkCopyColumnMapping">
+      <summary>Defines the mapping between a column in a <see cref="T:System.Data.SqlClient.SqlBulkCopy" /> instance's data source and a column in the instance's destination table.</summary>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlBulkCopyColumnMapping.#ctor">
+      <summary>Parameterless constructor that initializes a new <see cref="T:System.Data.SqlClient.SqlBulkCopyColumnMapping" /> object.</summary>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlBulkCopyColumnMapping.#ctor(System.Int32,System.Int32)">
+      <summary>Creates a new column mapping, using column ordinals to refer to source and destination columns.</summary>
+      <param name="sourceColumnOrdinal">The ordinal position of the source column within the data source.</param>
+      <param name="destinationOrdinal">The ordinal position of the destination column within the destination table.</param>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlBulkCopyColumnMapping.#ctor(System.Int32,System.String)">
+      <summary>Creates a new column mapping, using a column ordinal to refer to the source column and a column name for the target column.</summary>
+      <param name="sourceColumnOrdinal">The ordinal position of the source column within the data source.</param>
+      <param name="destinationColumn">The name of the destination column within the destination table.</param>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlBulkCopyColumnMapping.#ctor(System.String,System.Int32)">
+      <summary>Creates a new column mapping, using a column name to refer to the source column and a column ordinal for the target column.</summary>
+      <param name="sourceColumn">The name of the source column within the data source.</param>
+      <param name="destinationOrdinal">The ordinal position of the destination column within the destination table.</param>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlBulkCopyColumnMapping.#ctor(System.String,System.String)">
+      <summary>Creates a new column mapping, using column names to refer to source and destination columns.</summary>
+      <param name="sourceColumn">The name of the source column within the data source.</param>
+      <param name="destinationColumn">The name of the destination column within the destination table.</param>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlBulkCopyColumnMapping.DestinationColumn">
+      <summary>Name of the column being mapped in the destination database table.</summary>
+      <returns>The string value of the <see cref="P:System.Data.SqlClient.SqlBulkCopyColumnMapping.DestinationColumn" /> property.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlBulkCopyColumnMapping.DestinationOrdinal">
+      <summary>Ordinal value of the destination column within the destination table.</summary>
+      <returns>The integer value of the <see cref="P:System.Data.SqlClient.SqlBulkCopyColumnMapping.DestinationOrdinal" /> property, or -1 if the property has not been set.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlBulkCopyColumnMapping.SourceColumn">
+      <summary>Name of the column being mapped in the data source.</summary>
+      <returns>The string value of the <see cref="P:System.Data.SqlClient.SqlBulkCopyColumnMapping.SourceColumn" /> property.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlBulkCopyColumnMapping.SourceOrdinal">
+      <summary>The ordinal position of the source column within the data source.</summary>
+      <returns>The integer value of the <see cref="P:System.Data.SqlClient.SqlBulkCopyColumnMapping.SourceOrdinal" /> property.</returns>
+    </member>
+    <member name="T:System.Data.SqlClient.SqlBulkCopyColumnMappingCollection">
+      <summary>Collection of <see cref="T:System.Data.SqlClient.SqlBulkCopyColumnMapping" /> objects that inherits from <see cref="T:System.Collections.CollectionBase" />.</summary>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlBulkCopyColumnMappingCollection.Add(System.Data.SqlClient.SqlBulkCopyColumnMapping)">
+      <summary>Adds the specified mapping to the <see cref="T:System.Data.SqlClient.SqlBulkCopyColumnMappingCollection" />.</summary>
+      <param name="bulkCopyColumnMapping">The <see cref="T:System.Data.SqlClient.SqlBulkCopyColumnMapping" /> object that describes the mapping to be added to the collection.</param>
+      <returns>A <see cref="T:System.Data.SqlClient.SqlBulkCopyColumnMapping" /> object.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlBulkCopyColumnMappingCollection.Add(System.Int32,System.Int32)">
+      <summary>Creates a new <see cref="T:System.Data.SqlClient.SqlBulkCopyColumnMapping" /> and adds it to the collection, using ordinals to specify both source and destination columns.</summary>
+      <param name="sourceColumnIndex">The ordinal position of the source column within the data source.</param>
+      <param name="destinationColumnIndex">The ordinal position of the destination column within the destination table.</param>
+      <returns>A column mapping.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlBulkCopyColumnMappingCollection.Add(System.Int32,System.String)">
+      <summary>Creates a new <see cref="T:System.Data.SqlClient.SqlBulkCopyColumnMapping" /> and adds it to the collection, using an ordinal for the source column and a string for the destination column.</summary>
+      <param name="sourceColumnIndex">The ordinal position of the source column within the data source.</param>
+      <param name="destinationColumn">The name of the destination column within the destination table.</param>
+      <returns>A column mapping.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlBulkCopyColumnMappingCollection.Add(System.String,System.Int32)">
+      <summary>Creates a new <see cref="T:System.Data.SqlClient.SqlBulkCopyColumnMapping" /> and adds it to the collection, using a column name to describe the source column and an ordinal to specify the destination column.</summary>
+      <param name="sourceColumn">The name of the source column within the data source.</param>
+      <param name="destinationColumnIndex">The ordinal position of the destination column within the destination table.</param>
+      <returns>A column mapping.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlBulkCopyColumnMappingCollection.Add(System.String,System.String)">
+      <summary>Creates a new <see cref="T:System.Data.SqlClient.SqlBulkCopyColumnMapping" /> and adds it to the collection, using column names to specify both source and destination columns.</summary>
+      <param name="sourceColumn">The name of the source column within the data source.</param>
+      <param name="destinationColumn">The name of the destination column within the destination table.</param>
+      <returns>A column mapping.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlBulkCopyColumnMappingCollection.Clear">
+      <summary>Clears the contents of the collection.</summary>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlBulkCopyColumnMappingCollection.Contains(System.Data.SqlClient.SqlBulkCopyColumnMapping)">
+      <summary>Gets a value indicating whether a specified <see cref="T:System.Data.SqlClient.SqlBulkCopyColumnMapping" /> object exists in the collection.</summary>
+      <param name="value">A valid <see cref="T:System.Data.SqlClient.SqlBulkCopyColumnMapping" /> object.</param>
+      <returns>
+        <see langword="true" /> if the specified mapping exists in the collection; otherwise <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlBulkCopyColumnMappingCollection.CopyTo(System.Data.SqlClient.SqlBulkCopyColumnMapping[],System.Int32)">
+      <summary>Copies the elements of the <see cref="T:System.Data.SqlClient.SqlBulkCopyColumnMappingCollection" /> to an array of <see cref="T:System.Data.SqlClient.SqlBulkCopyColumnMapping" /> items, starting at a particular index.</summary>
+      <param name="array">The one-dimensional <see cref="T:System.Data.SqlClient.SqlBulkCopyColumnMapping" /> array that is the destination of the elements copied from <see cref="T:System.Data.SqlClient.SqlBulkCopyColumnMappingCollection" />. The array must have zero-based indexing.</param>
+      <param name="index">The zero-based index in <paramref name="array" /> at which copying begins.</param>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlBulkCopyColumnMappingCollection.IndexOf(System.Data.SqlClient.SqlBulkCopyColumnMapping)">
+      <summary>Gets the index of the specified <see cref="T:System.Data.SqlClient.SqlBulkCopyColumnMapping" /> object.</summary>
+      <param name="value">The <see cref="T:System.Data.SqlClient.SqlBulkCopyColumnMapping" /> object for which to search.</param>
+      <returns>The zero-based index of the column mapping, or -1 if the column mapping is not found in the collection.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlBulkCopyColumnMappingCollection.Insert(System.Int32,System.Data.SqlClient.SqlBulkCopyColumnMapping)">
+      <summary>Insert a new <see cref="T:System.Data.SqlClient.SqlBulkCopyColumnMapping" /> at the index specified.</summary>
+      <param name="index">Integer value of the location within the <see cref="T:System.Data.SqlClient.SqlBulkCopyColumnMappingCollection" /> at which to insert the new <see cref="T:System.Data.SqlClient.SqlBulkCopyColumnMapping" />.</param>
+      <param name="value">
+        <see cref="T:System.Data.SqlClient.SqlBulkCopyColumnMapping" /> object to be inserted in the collection.</param>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlBulkCopyColumnMappingCollection.Item(System.Int32)">
+      <summary>Gets the <see cref="T:System.Data.SqlClient.SqlBulkCopyColumnMapping" /> object at the specified index.</summary>
+      <param name="index">The zero-based index of the <see cref="T:System.Data.SqlClient.SqlBulkCopyColumnMapping" /> to find.</param>
+      <returns>A <see cref="T:System.Data.SqlClient.SqlBulkCopyColumnMapping" /> object.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlBulkCopyColumnMappingCollection.Remove(System.Data.SqlClient.SqlBulkCopyColumnMapping)">
+      <summary>Removes the specified <see cref="T:System.Data.SqlClient.SqlBulkCopyColumnMapping" /> element from the <see cref="T:System.Data.SqlClient.SqlBulkCopyColumnMappingCollection" />.</summary>
+      <param name="value">
+        <see cref="T:System.Data.SqlClient.SqlBulkCopyColumnMapping" /> object to be removed from the collection.</param>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlBulkCopyColumnMappingCollection.RemoveAt(System.Int32)">
+      <summary>Removes the mapping at the specified index from the collection.</summary>
+      <param name="index">The zero-based index of the <see cref="T:System.Data.SqlClient.SqlBulkCopyColumnMapping" /> object to be removed from the collection.</param>
+    </member>
+    <member name="T:System.Data.SqlClient.SqlBulkCopyOptions">
+      <summary>Bitwise flag that specifies one or more options to use with an instance of <see cref="T:System.Data.SqlClient.SqlBulkCopy" />.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlBulkCopyOptions.CheckConstraints">
+      <summary>Check constraints while data is being inserted. By default, constraints are not checked.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlBulkCopyOptions.Default">
+      <summary>Use the default values for all options.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlBulkCopyOptions.FireTriggers">
+      <summary>When specified, cause the server to fire the insert triggers for the rows being inserted into the database.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlBulkCopyOptions.KeepIdentity">
+      <summary>Preserve source identity values. When not specified, identity values are assigned by the destination.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlBulkCopyOptions.KeepNulls">
+      <summary>Preserve null values in the destination table regardless of the settings for default values. When not specified, null values are replaced by default values where applicable.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlBulkCopyOptions.TableLock">
+      <summary>Obtain a bulk update lock for the duration of the bulk copy operation. When not specified, row locks are used.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlBulkCopyOptions.UseInternalTransaction">
+      <summary>When specified, each batch of the bulk-copy operation will occur within a transaction. If you indicate this option and also provide a <see cref="T:System.Data.SqlClient.SqlTransaction" /> object to the constructor, an <see cref="T:System.ArgumentException" /> occurs.</summary>
+    </member>
+    <member name="T:System.Data.SqlClient.SqlClientFactory">
+      <summary>Represents a set of methods for creating instances of the <see cref="N:System.Data.SqlClient" /> provider's implementation of the data source classes.</summary>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlClientFactory.CreateCommand">
+      <summary>Returns a strongly typed <see cref="T:System.Data.Common.DbCommand" /> instance.</summary>
+      <returns>A new strongly typed instance of <see cref="T:System.Data.Common.DbCommand" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlClientFactory.CreateCommandBuilder">
+      <summary>Returns a strongly typed <see cref="T:System.Data.Common.DbCommandBuilder" /> instance.</summary>
+      <returns>A new strongly typed instance of <see cref="T:System.Data.Common.DbCommandBuilder" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlClientFactory.CreateConnection">
+      <summary>Returns a strongly typed <see cref="T:System.Data.Common.DbConnection" /> instance.</summary>
+      <returns>A new strongly typed instance of <see cref="T:System.Data.Common.DbConnection" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlClientFactory.CreateConnectionStringBuilder">
+      <summary>Returns a strongly typed <see cref="T:System.Data.Common.DbConnectionStringBuilder" /> instance.</summary>
+      <returns>A new strongly typed instance of <see cref="T:System.Data.Common.DbConnectionStringBuilder" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlClientFactory.CreateDataAdapter">
+      <summary>Returns a strongly typed <see cref="T:System.Data.Common.DbDataAdapter" /> instance.</summary>
+      <returns>A new strongly typed instance of <see cref="T:System.Data.Common.DbDataAdapter" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlClientFactory.CreateParameter">
+      <summary>Returns a strongly typed <see cref="T:System.Data.Common.DbParameter" /> instance.</summary>
+      <returns>A new strongly typed instance of <see cref="T:System.Data.Common.DbParameter" />.</returns>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlClientFactory.Instance">
+      <summary>Gets an instance of the <see cref="T:System.Data.SqlClient.SqlClientFactory" />. This can be used to retrieve strongly typed data objects.</summary>
+    </member>
+    <member name="T:System.Data.SqlClient.SqlClientMetaDataCollectionNames">
+      <summary>Provides a list of constants for use with the GetSchema method to retrieve metadata collections.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlClientMetaDataCollectionNames.Columns">
+      <summary>A constant for use with the GetSchema method that represents the Columns collection.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlClientMetaDataCollectionNames.Databases">
+      <summary>A constant for use with the GetSchema method that represents the Databases collection.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlClientMetaDataCollectionNames.ForeignKeys">
+      <summary>A constant for use with the GetSchema method that represents the ForeignKeys collection.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlClientMetaDataCollectionNames.IndexColumns">
+      <summary>A constant for use with the GetSchema method that represents the IndexColumns collection.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlClientMetaDataCollectionNames.Indexes">
+      <summary>A constant for use with the GetSchema method that represents the Indexes collection.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlClientMetaDataCollectionNames.Parameters">
+      <summary>A constant for use with the GetSchema method that represents the Parameters collection.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlClientMetaDataCollectionNames.ProcedureColumns">
+      <summary>A constant for use with the GetSchema method that represents the ProcedureColumns collection.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlClientMetaDataCollectionNames.Procedures">
+      <summary>A constant for use with the GetSchema method that represents the Procedures collection.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlClientMetaDataCollectionNames.Tables">
+      <summary>A constant for use with the GetSchema method that represents the Tables collection.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlClientMetaDataCollectionNames.UserDefinedTypes">
+      <summary>A constant for use with the GetSchema method that represents the UserDefinedTypes collection.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlClientMetaDataCollectionNames.Users">
+      <summary>A constant for use with the GetSchema method that represents the Users collection.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlClientMetaDataCollectionNames.ViewColumns">
+      <summary>A constant for use with the GetSchema method that represents the ViewColumns collection.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlClientMetaDataCollectionNames.Views">
+      <summary>A constant for use with the GetSchema method that represents the Views collection.</summary>
+    </member>
+    <member name="T:System.Data.SqlClient.SqlCommand">
+      <summary>Represents a Transact-SQL statement or stored procedure to execute against a SQL Server database. This class cannot be inherited.</summary>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommand.#ctor">
+      <summary>Initializes a new instance of the <see cref="T:System.Data.SqlClient.SqlCommand" /> class.</summary>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommand.#ctor(System.String)">
+      <summary>Initializes a new instance of the <see cref="T:System.Data.SqlClient.SqlCommand" /> class with the text of the query.</summary>
+      <param name="cmdText">The text of the query.</param>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommand.#ctor(System.String,System.Data.SqlClient.SqlConnection)">
+      <summary>Initializes a new instance of the <see cref="T:System.Data.SqlClient.SqlCommand" /> class with the text of the query and a <see cref="T:System.Data.SqlClient.SqlConnection" />.</summary>
+      <param name="cmdText">The text of the query.</param>
+      <param name="connection">A <see cref="T:System.Data.SqlClient.SqlConnection" /> that represents the connection to an instance of SQL Server.</param>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommand.#ctor(System.String,System.Data.SqlClient.SqlConnection,System.Data.SqlClient.SqlTransaction)">
+      <summary>Initializes a new instance of the <see cref="T:System.Data.SqlClient.SqlCommand" /> class with the text of the query, a <see cref="T:System.Data.SqlClient.SqlConnection" />, and the <see cref="T:System.Data.SqlClient.SqlTransaction" />.</summary>
+      <param name="cmdText">The text of the query.</param>
+      <param name="connection">A <see cref="T:System.Data.SqlClient.SqlConnection" /> that represents the connection to an instance of SQL Server.</param>
+      <param name="transaction">The <see cref="T:System.Data.SqlClient.SqlTransaction" /> in which the <see cref="T:System.Data.SqlClient.SqlCommand" /> executes.</param>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommand.BeginExecuteNonQuery">
+      <summary>Initiates the asynchronous execution of the Transact-SQL statement or stored procedure that is described by this <see cref="T:System.Data.SqlClient.SqlCommand" />.</summary>
+      <returns>An <see cref="T:System.IAsyncResult" /> that can be used to poll or wait for results, or both; this value is also needed when invoking <see cref="M:System.Data.SqlClient.SqlCommand.EndExecuteNonQuery(System.IAsyncResult)" />, which returns the number of affected rows.</returns>
+      <exception cref="T:System.InvalidCastException">A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Binary or VarBinary was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.Stream" />. For more information about streaming, see SqlClient Streaming Support.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Char, NChar, NVarChar, VarChar, or  Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.TextReader" />.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.Xml.XmlReader" />.</exception>
+      <exception cref="T:System.Data.SqlClient.SqlException">Any error that occurred while executing the command text.
+-or-
+A timeout occurred during a streaming operation. For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.InvalidOperationException">The name/value pair "Asynchronous Processing=true" was not included within the connection string defining the connection for this <see cref="T:System.Data.SqlClient.SqlCommand" />.
+-or-
+The <see cref="T:System.Data.SqlClient.SqlConnection" /> closed or dropped during a streaming operation. For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.IO.IOException">An error occurred in a <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object was closed during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommand.BeginExecuteNonQuery(System.AsyncCallback,System.Object)">
+      <summary>Initiates the asynchronous execution of the Transact-SQL statement or stored procedure that is described by this <see cref="T:System.Data.SqlClient.SqlCommand" />, given a callback procedure and state information.</summary>
+      <param name="callback">An <see cref="T:System.AsyncCallback" /> delegate that is invoked when the command's execution has completed. Pass <see langword="null" /> (<see langword="Nothing" /> in Microsoft Visual Basic) to indicate that no callback is required.</param>
+      <param name="stateObject">A user-defined state object that is passed to the callback procedure. Retrieve this object from within the callback procedure using the <see cref="P:System.IAsyncResult.AsyncState" /> property.</param>
+      <returns>An <see cref="T:System.IAsyncResult" /> that can be used to poll or wait for results, or both; this value is also needed when invoking <see cref="M:System.Data.SqlClient.SqlCommand.EndExecuteNonQuery(System.IAsyncResult)" />, which returns the number of affected rows.</returns>
+      <exception cref="T:System.InvalidCastException">A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Binary or VarBinary was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.Stream" />. For more information about streaming, see SqlClient Streaming Support.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Char, NChar, NVarChar, VarChar, or  Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.TextReader" />.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.Xml.XmlReader" />.</exception>
+      <exception cref="T:System.Data.SqlClient.SqlException">Any error that occurred while executing the command text.
+-or-
+A timeout occurred during a streaming operation. For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.InvalidOperationException">The name/value pair "Asynchronous Processing=true" was not included within the connection string defining the connection for this <see cref="T:System.Data.SqlClient.SqlCommand" />.
+-or-
+The <see cref="T:System.Data.SqlClient.SqlConnection" /> closed or dropped during a streaming operation. For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.IO.IOException">An error occurred in a <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object was closed during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommand.BeginExecuteReader">
+      <summary>Initiates the asynchronous execution of the Transact-SQL statement or stored procedure that is described by this <see cref="T:System.Data.SqlClient.SqlCommand" />, and retrieves one or more result sets from the server.</summary>
+      <returns>An <see cref="T:System.IAsyncResult" /> that can be used to poll or wait for results, or both; this value is also needed when invoking <see cref="M:System.Data.SqlClient.SqlCommand.EndExecuteReader(System.IAsyncResult)" />, which returns a <see cref="T:System.Data.SqlClient.SqlDataReader" /> instance that can be used to retrieve the returned rows.</returns>
+      <exception cref="T:System.InvalidCastException">A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Binary or VarBinary was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.Stream" />. For more information about streaming, see SqlClient Streaming Support.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Char, NChar, NVarChar, VarChar, or  Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.TextReader" />.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.Xml.XmlReader" />.</exception>
+      <exception cref="T:System.Data.SqlClient.SqlException">Any error that occurred while executing the command text.
+-or-
+A timeout occurred during a streaming operation. For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.InvalidOperationException">The name/value pair "Asynchronous Processing=true" was not included within the connection string defining the connection for this <see cref="T:System.Data.SqlClient.SqlCommand" />.
+-or-
+The <see cref="T:System.Data.SqlClient.SqlConnection" /> closed or dropped during a streaming operation. For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.IO.IOException">An error occurred in a <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object was closed during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommand.BeginExecuteReader(System.AsyncCallback,System.Object)">
+      <summary>Initiates the asynchronous execution of the Transact-SQL statement or stored procedure that is described by this <see cref="T:System.Data.SqlClient.SqlCommand" /> and retrieves one or more result sets from the server, given a callback procedure and state information.</summary>
+      <param name="callback">An <see cref="T:System.AsyncCallback" /> delegate that is invoked when the command's execution has completed. Pass <see langword="null" /> (<see langword="Nothing" /> in Microsoft Visual Basic) to indicate that no callback is required.</param>
+      <param name="stateObject">A user-defined state object that is passed to the callback procedure. Retrieve this object from within the callback procedure using the <see cref="P:System.IAsyncResult.AsyncState" /> property.</param>
+      <returns>An <see cref="T:System.IAsyncResult" /> that can be used to poll, wait for results, or both; this value is also needed when invoking <see cref="M:System.Data.SqlClient.SqlCommand.EndExecuteReader(System.IAsyncResult)" />, which returns a <see cref="T:System.Data.SqlClient.SqlDataReader" /> instance which can be used to retrieve the returned rows.</returns>
+      <exception cref="T:System.InvalidCastException">A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Binary or VarBinary was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.Stream" />. For more information about streaming, see SqlClient Streaming Support.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Char, NChar, NVarChar, VarChar, or  Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.TextReader" />.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.Xml.XmlReader" />.</exception>
+      <exception cref="T:System.Data.SqlClient.SqlException">Any error that occurred while executing the command text.
+-or-
+A timeout occurred during a streaming operation. For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.InvalidOperationException">The name/value pair "Asynchronous Processing=true" was not included within the connection string defining the connection for this <see cref="T:System.Data.SqlClient.SqlCommand" />.
+-or-
+The <see cref="T:System.Data.SqlClient.SqlConnection" /> closed or dropped during a streaming operation. For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.IO.IOException">An error occurred in a <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object was closed during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommand.BeginExecuteReader(System.AsyncCallback,System.Object,System.Data.CommandBehavior)">
+      <summary>Initiates the asynchronous execution of the Transact-SQL statement or stored procedure that is described by this <see cref="T:System.Data.SqlClient.SqlCommand" />, using one of the <see langword="CommandBehavior" /> values, and retrieving one or more result sets from the server, given a callback procedure and state information.</summary>
+      <param name="callback">An <see cref="T:System.AsyncCallback" /> delegate that is invoked when the command's execution has completed. Pass <see langword="null" /> (<see langword="Nothing" /> in Microsoft Visual Basic) to indicate that no callback is required.</param>
+      <param name="stateObject">A user-defined state object that is passed to the callback procedure. Retrieve this object from within the callback procedure using the <see cref="P:System.IAsyncResult.AsyncState" /> property.</param>
+      <param name="behavior">One of the <see cref="T:System.Data.CommandBehavior" /> values, indicating options for statement execution and data retrieval.</param>
+      <returns>An <see cref="T:System.IAsyncResult" /> that can be used to poll or wait for results, or both; this value is also needed when invoking <see cref="M:System.Data.SqlClient.SqlCommand.EndExecuteReader(System.IAsyncResult)" />, which returns a <see cref="T:System.Data.SqlClient.SqlDataReader" /> instance which can be used to retrieve the returned rows.</returns>
+      <exception cref="T:System.InvalidCastException">A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Binary or VarBinary was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.Stream" />. For more information about streaming, see SqlClient Streaming Support.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Char, NChar, NVarChar, VarChar, or  Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.TextReader" />.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.Xml.XmlReader" />.</exception>
+      <exception cref="T:System.Data.SqlClient.SqlException">Any error that occurred while executing the command text.
+-or-
+A timeout occurred during a streaming operation. For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.InvalidOperationException">The name/value pair "Asynchronous Processing=true" was not included within the connection string defining the connection for this <see cref="T:System.Data.SqlClient.SqlCommand" />.
+-or-
+The <see cref="T:System.Data.SqlClient.SqlConnection" /> closed or dropped during a streaming operation. For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.IO.IOException">An error occurred in a <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object was closed during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommand.BeginExecuteReader(System.Data.CommandBehavior)">
+      <summary>Initiates the asynchronous execution of the Transact-SQL statement or stored procedure that is described by this <see cref="T:System.Data.SqlClient.SqlCommand" /> using one of the <see cref="T:System.Data.CommandBehavior" /> values.</summary>
+      <param name="behavior">One of the <see cref="T:System.Data.CommandBehavior" /> values, indicating options for statement execution and data retrieval.</param>
+      <returns>An <see cref="T:System.IAsyncResult" /> that can be used to poll, wait for results, or both; this value is also needed when invoking <see cref="M:System.Data.SqlClient.SqlCommand.EndExecuteReader(System.IAsyncResult)" />, which returns a <see cref="T:System.Data.SqlClient.SqlDataReader" /> instance that can be used to retrieve the returned rows.</returns>
+      <exception cref="T:System.InvalidCastException">A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Binary or VarBinary was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.Stream" />. For more information about streaming, see SqlClient Streaming Support.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Char, NChar, NVarChar, VarChar, or  Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.TextReader" />.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.Xml.XmlReader" />.</exception>
+      <exception cref="T:System.Data.SqlClient.SqlException">Any error that occurred while executing the command text.
+-or-
+A timeout occurred during a streaming operation. For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.InvalidOperationException">The name/value pair "Asynchronous Processing=true" was not included within the connection string defining the connection for this <see cref="T:System.Data.SqlClient.SqlCommand" />.
+-or-
+The <see cref="T:System.Data.SqlClient.SqlConnection" /> closed or dropped during a streaming operation. For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.IO.IOException">An error occurred in a <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object was closed during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommand.BeginExecuteXmlReader">
+      <summary>Initiates the asynchronous execution of the Transact-SQL statement or stored procedure that is described by this <see cref="T:System.Data.SqlClient.SqlCommand" /> and returns results as an <see cref="T:System.Xml.XmlReader" /> object.</summary>
+      <returns>An <see cref="T:System.IAsyncResult" /> that can be used to poll or wait for results, or both; this value is also needed when invoking <see langword="EndExecuteXmlReader" />, which returns a single XML value.</returns>
+      <exception cref="T:System.InvalidCastException">A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Binary or VarBinary was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.Stream" />. For more information about streaming, see SqlClient Streaming Support.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Char, NChar, NVarChar, VarChar, or  Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.TextReader" />.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.Xml.XmlReader" />.</exception>
+      <exception cref="T:System.Data.SqlClient.SqlException">Any error that occurred while executing the command text.
+-or-
+A timeout occurred during a streaming operation. For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.InvalidOperationException">The name/value pair "Asynchronous Processing=true" was not included within the connection string defining the connection for this <see cref="T:System.Data.SqlClient.SqlCommand" />.
+-or-
+The <see cref="T:System.Data.SqlClient.SqlConnection" /> closed or dropped during a streaming operation. For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.IO.IOException">An error occurred in a <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object was closed during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommand.BeginExecuteXmlReader(System.AsyncCallback,System.Object)">
+      <summary>Initiates the asynchronous execution of the Transact-SQL statement or stored procedure that is described by this <see cref="T:System.Data.SqlClient.SqlCommand" /> and returns results as an <see cref="T:System.Xml.XmlReader" /> object, using a callback procedure.</summary>
+      <param name="callback">An <see cref="T:System.AsyncCallback" /> delegate that is invoked when the command's execution has completed. Pass <see langword="null" /> (<see langword="Nothing" /> in Microsoft Visual Basic) to indicate that no callback is required.</param>
+      <param name="stateObject">A user-defined state object that is passed to the callback procedure. Retrieve this object from within the callback procedure using the <see cref="P:System.IAsyncResult.AsyncState" /> property.</param>
+      <returns>An <see cref="T:System.IAsyncResult" /> that can be used to poll, wait for results, or both; this value is also needed when the <see cref="M:System.Data.SqlClient.SqlCommand.EndExecuteXmlReader(System.IAsyncResult)" /> is called, which returns the results of the command as XML.</returns>
+      <exception cref="T:System.InvalidCastException">A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Binary or VarBinary was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.Stream" />. For more information about streaming, see SqlClient Streaming Support.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Char, NChar, NVarChar, VarChar, or  Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.TextReader" />.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.Xml.XmlReader" />.</exception>
+      <exception cref="T:System.Data.SqlClient.SqlException">Any error that occurred while executing the command text.
+-or-
+A timeout occurred during a streaming operation. For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.InvalidOperationException">The name/value pair "Asynchronous Processing=true" was not included within the connection string defining the connection for this <see cref="T:System.Data.SqlClient.SqlCommand" />.
+-or-
+The <see cref="T:System.Data.SqlClient.SqlConnection" /> closed or dropped during a streaming operation. For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.IO.IOException">An error occurred in a <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object was closed during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommand.Cancel">
+      <summary>Tries to cancel the execution of a <see cref="T:System.Data.SqlClient.SqlCommand" />.</summary>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommand.Clone">
+      <summary>Creates a new <see cref="T:System.Data.SqlClient.SqlCommand" /> object that is a copy of the current instance.</summary>
+      <returns>A new <see cref="T:System.Data.SqlClient.SqlCommand" /> object that is a copy of this instance.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlCommand.CommandText">
+      <summary>Gets or sets the Transact-SQL statement, table name or stored procedure to execute at the data source.</summary>
+      <returns>The Transact-SQL statement or stored procedure to execute. The default is an empty string.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlCommand.CommandTimeout">
+      <summary>Gets or sets the wait time before terminating the attempt to execute a command and generating an error.</summary>
+      <returns>The time in seconds to wait for the command to execute. The default is 30 seconds.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlCommand.CommandType">
+      <summary>Gets or sets a value indicating how the <see cref="P:System.Data.SqlClient.SqlCommand.CommandText" /> property is to be interpreted.</summary>
+      <returns>One of the <see cref="T:System.Data.CommandType" /> values. The default is <see langword="Text" />.</returns>
+      <exception cref="T:System.ArgumentException">The value was not a valid <see cref="T:System.Data.CommandType" />.</exception>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlCommand.Connection">
+      <summary>Gets or sets the <see cref="T:System.Data.SqlClient.SqlConnection" /> used by this instance of the <see cref="T:System.Data.SqlClient.SqlCommand" />.</summary>
+      <returns>The connection to a data source. The default value is <see langword="null" />.</returns>
+      <exception cref="T:System.InvalidOperationException">The <see cref="P:System.Data.SqlClient.SqlCommand.Connection" /> property was changed while the command was enlisted in a transaction.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommand.CreateParameter">
+      <summary>Creates a new instance of a <see cref="T:System.Data.SqlClient.SqlParameter" /> object.</summary>
+      <returns>A <see cref="T:System.Data.SqlClient.SqlParameter" /> object.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlCommand.DesignTimeVisible">
+      <summary>Gets or sets a value indicating whether the command object should be visible in a Windows Form Designer control.</summary>
+      <returns>A value indicating whether the command object should be visible in a control. The default is <see langword="true" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommand.EndExecuteNonQuery(System.IAsyncResult)">
+      <summary>Finishes asynchronous execution of a Transact-SQL statement.</summary>
+      <param name="asyncResult">The <see cref="T:System.IAsyncResult" /> returned by the call to <see cref="M:System.Data.SqlClient.SqlCommand.BeginExecuteNonQuery" />.</param>
+      <returns>The number of rows affected (the same behavior as <see cref="M:System.Data.SqlClient.SqlCommand.ExecuteNonQuery" />).</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="asyncResult" /> parameter is null (<see langword="Nothing" /> in Microsoft Visual Basic)</exception>
+      <exception cref="T:System.InvalidOperationException">
+        <see cref="M:System.Data.SqlClient.SqlCommand.EndExecuteNonQuery(System.IAsyncResult)" /> was called more than once for a single command execution, or the method was mismatched against its execution method (for example, the code called <see cref="M:System.Data.SqlClient.SqlCommand.EndExecuteNonQuery(System.IAsyncResult)" /> to complete execution of a call to <see cref="M:System.Data.SqlClient.SqlCommand.BeginExecuteXmlReader" />.</exception>
+      <exception cref="T:System.Data.SqlClient.SqlException">The amount of time specified in <see cref="P:System.Data.SqlClient.SqlCommand.CommandTimeout" /> elapsed and the asynchronous operation specified with <see cref="Overload:System.Data.SqlClient.SqlCommand.BeginExecuteNonQuery" /> is not complete.
+-or-
+In some situations, <see cref="T:System.IAsyncResult" /> can be set to <see langword="IsCompleted" /> incorrectly. If this occurs and <see cref="M:System.Data.SqlClient.SqlCommand.EndExecuteNonQuery(System.IAsyncResult)" /> is called, EndExecuteNonQuery could raise a SqlException error if the amount of time specified in <see cref="P:System.Data.SqlClient.SqlCommand.CommandTimeout" /> elapsed and the asynchronous operation specified with <see cref="Overload:System.Data.SqlClient.SqlCommand.BeginExecuteNonQuery" /> is not complete. To correct this situation, you should either increase the value of CommandTimeout or reduce the work being done by the asynchronous operation.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommand.EndExecuteReader(System.IAsyncResult)">
+      <summary>Finishes asynchronous execution of a Transact-SQL statement, returning the requested <see cref="T:System.Data.SqlClient.SqlDataReader" />.</summary>
+      <param name="asyncResult">The <see cref="T:System.IAsyncResult" /> returned by the call to <see cref="M:System.Data.SqlClient.SqlCommand.BeginExecuteReader" />.</param>
+      <returns>A <see cref="T:System.Data.SqlClient.SqlDataReader" /> object that can be used to retrieve the requested rows.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="asyncResult" /> parameter is null (<see langword="Nothing" /> in Microsoft Visual Basic)</exception>
+      <exception cref="T:System.InvalidOperationException">
+        <see cref="M:System.Data.SqlClient.SqlCommand.EndExecuteReader(System.IAsyncResult)" /> was called more than once for a single command execution, or the method was mismatched against its execution method (for example, the code called <see cref="M:System.Data.SqlClient.SqlCommand.EndExecuteReader(System.IAsyncResult)" /> to complete execution of a call to <see cref="M:System.Data.SqlClient.SqlCommand.BeginExecuteXmlReader" />.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommand.EndExecuteXmlReader(System.IAsyncResult)">
+      <summary>Finishes asynchronous execution of a Transact-SQL statement, returning the requested data as XML.</summary>
+      <param name="asyncResult">The <see cref="T:System.IAsyncResult" /> returned by the call to <see cref="M:System.Data.SqlClient.SqlCommand.BeginExecuteXmlReader" />.</param>
+      <returns>An <see cref="T:System.Xml.XmlReader" /> object that can be used to fetch the resulting XML data.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="asyncResult" /> parameter is null (<see langword="Nothing" /> in Microsoft Visual Basic)</exception>
+      <exception cref="T:System.InvalidOperationException">
+        <see cref="M:System.Data.SqlClient.SqlCommand.EndExecuteXmlReader(System.IAsyncResult)" /> was called more than once for a single command execution, or the method was mismatched against its execution method (for example, the code called <see cref="M:System.Data.SqlClient.SqlCommand.EndExecuteXmlReader(System.IAsyncResult)" /> to complete execution of a call to <see cref="M:System.Data.SqlClient.SqlCommand.BeginExecuteNonQuery" />.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommand.ExecuteNonQuery">
+      <summary>Executes a Transact-SQL statement against the connection and returns the number of rows affected.</summary>
+      <returns>The number of rows affected.</returns>
+      <exception cref="T:System.InvalidCastException">A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Binary or VarBinary was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.Stream" />. For more information about streaming, see SqlClient Streaming Support.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Char, NChar, NVarChar, VarChar, or  Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.TextReader" />.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.Xml.XmlReader" />.</exception>
+      <exception cref="T:System.Data.SqlClient.SqlException">An exception occurred while executing the command against a locked row. This exception is not generated when you are using Microsoft .NET Framework version 1.0.
+-or-
+A timeout occurred during a streaming operation. For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.IO.IOException">An error occurred in a <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Data.SqlClient.SqlConnection" /> closed or dropped during a streaming operation. For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object was closed during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommand.ExecuteNonQueryAsync(System.Threading.CancellationToken)">
+      <summary>An asynchronous version of <see cref="M:System.Data.SqlClient.SqlCommand.ExecuteNonQuery" />, which executes a Transact-SQL statement against the connection and returns the number of rows affected. The cancellation token can be used to request that the operation be abandoned before the command timeout elapses.  Exceptions will be reported via the returned Task object.</summary>
+      <param name="cancellationToken">The cancellation instruction.</param>
+      <returns>A task representing the asynchronous operation.</returns>
+      <exception cref="T:System.InvalidCastException">A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Binary or VarBinary was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.Stream" />. For more information about streaming, see SqlClient Streaming Support.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Char, NChar, NVarChar, VarChar, or  Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.TextReader" />.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.Xml.XmlReader" />.</exception>
+      <exception cref="T:System.InvalidOperationException">Calling <see cref="M:System.Data.SqlClient.SqlCommand.ExecuteNonQueryAsync(System.Threading.CancellationToken)" /> more than once for the same instance before task completion.
+-or-
+The <see cref="T:System.Data.SqlClient.SqlConnection" /> closed or dropped during a streaming operation. For more information about streaming, see SqlClient Streaming Support.
+-or-
+<see langword="Context Connection=true" /> is specified in the connection string.</exception>
+      <exception cref="T:System.Data.SqlClient.SqlException">SQL Server returned an error while executing the command text.
+-or-
+A timeout occurred during a streaming operation. For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.IO.IOException">An error occurred in a <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object was closed during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommand.ExecuteReader">
+      <summary>Sends the <see cref="P:System.Data.SqlClient.SqlCommand.CommandText" /> to the <see cref="P:System.Data.SqlClient.SqlCommand.Connection" /> and builds a <see cref="T:System.Data.SqlClient.SqlDataReader" />.</summary>
+      <returns>A <see cref="T:System.Data.SqlClient.SqlDataReader" /> object.</returns>
+      <exception cref="T:System.InvalidCastException">A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Binary or VarBinary was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.Stream" />. For more information about streaming, see SqlClient Streaming Support.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Char, NChar, NVarChar, VarChar, or  Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.TextReader" />.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.Xml.XmlReader" />.</exception>
+      <exception cref="T:System.Data.SqlClient.SqlException">An exception occurred while executing the command against a locked row. This exception is not generated when you are using Microsoft .NET Framework version 1.0.
+-or-
+A timeout occurred during a streaming operation. For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.InvalidOperationException">The current state of the connection is closed. <see cref="M:System.Data.SqlClient.SqlCommand.ExecuteReader" /> requires an open <see cref="T:System.Data.SqlClient.SqlConnection" />.
+-or-
+The <see cref="T:System.Data.SqlClient.SqlConnection" /> closed or dropped during a streaming operation. For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.IO.IOException">An error occurred in a <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object was closed during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommand.ExecuteReader(System.Data.CommandBehavior)">
+      <summary>Sends the <see cref="P:System.Data.SqlClient.SqlCommand.CommandText" /> to the <see cref="P:System.Data.SqlClient.SqlCommand.Connection" />, and builds a <see cref="T:System.Data.SqlClient.SqlDataReader" /> using one of the <see cref="T:System.Data.CommandBehavior" /> values.</summary>
+      <param name="behavior">One of the <see cref="T:System.Data.CommandBehavior" /> values.</param>
+      <returns>A <see cref="T:System.Data.SqlClient.SqlDataReader" /> object.</returns>
+      <exception cref="T:System.InvalidCastException">A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Binary or VarBinary was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.Stream" />. For more information about streaming, see SqlClient Streaming Support.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Char, NChar, NVarChar, VarChar, or  Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.TextReader" />.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.Xml.XmlReader" />.</exception>
+      <exception cref="T:System.Data.SqlClient.SqlException">A timeout occurred during a streaming operation. For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.IO.IOException">An error occurred in a <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Data.SqlClient.SqlConnection" /> closed or dropped during a streaming operation. For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object was closed during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommand.ExecuteReaderAsync">
+      <summary>An asynchronous version of <see cref="M:System.Data.SqlClient.SqlCommand.ExecuteReader" />, which sends the <see cref="P:System.Data.SqlClient.SqlCommand.CommandText" /> to the <see cref="P:System.Data.SqlClient.SqlCommand.Connection" /> and builds a <see cref="T:System.Data.SqlClient.SqlDataReader" />. Exceptions will be reported via the returned Task object.</summary>
+      <returns>A task representing the asynchronous operation.</returns>
+      <exception cref="T:System.InvalidCastException">A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Binary or VarBinary was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.Stream" />. For more information about streaming, see SqlClient Streaming Support.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Char, NChar, NVarChar, VarChar, or  Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.TextReader" />.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.Xml.XmlReader" />.</exception>
+      <exception cref="T:System.ArgumentException">An invalid <see cref="T:System.Data.CommandBehavior" /> value.</exception>
+      <exception cref="T:System.InvalidOperationException">Calling <see cref="M:System.Data.SqlClient.SqlCommand.ExecuteReaderAsync" /> more than once for the same instance before task completion.
+-or-
+The <see cref="T:System.Data.SqlClient.SqlConnection" /> closed or dropped during a streaming operation. For more information about streaming, see SqlClient Streaming Support.
+-or-
+<see langword="Context Connection=true" /> is specified in the connection string.</exception>
+      <exception cref="T:System.Data.SqlClient.SqlException">SQL Server returned an error while executing the command text.
+-or-
+A timeout occurred during a streaming operation. For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.IO.IOException">An error occurred in a <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object was closed during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommand.ExecuteReaderAsync(System.Data.CommandBehavior)">
+      <summary>An asynchronous version of <see cref="M:System.Data.SqlClient.SqlCommand.ExecuteReader(System.Data.CommandBehavior)" />, which sends the <see cref="P:System.Data.SqlClient.SqlCommand.CommandText" /> to the <see cref="P:System.Data.SqlClient.SqlCommand.Connection" />, and builds a <see cref="T:System.Data.SqlClient.SqlDataReader" />. Exceptions will be reported via the returned Task object.</summary>
+      <param name="behavior">Options for statement execution and data retrieval.  When is set to <see langword="Default" />, <see cref="M:System.Data.SqlClient.SqlDataReader.ReadAsync(System.Threading.CancellationToken)" /> reads the entire row before returning a complete Task.</param>
+      <returns>A task representing the asynchronous operation.</returns>
+      <exception cref="T:System.InvalidCastException">A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Binary or VarBinary was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.Stream" />. For more information about streaming, see SqlClient Streaming Support.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Char, NChar, NVarChar, VarChar, or  Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.TextReader" />.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.Xml.XmlReader" />.</exception>
+      <exception cref="T:System.ArgumentException">An invalid <see cref="T:System.Data.CommandBehavior" /> value.</exception>
+      <exception cref="T:System.InvalidOperationException">Calling <see cref="M:System.Data.SqlClient.SqlCommand.ExecuteReaderAsync(System.Data.CommandBehavior)" /> more than once for the same instance before task completion.
+-or-
+The <see cref="T:System.Data.SqlClient.SqlConnection" /> closed or dropped during a streaming operation. For more information about streaming, see SqlClient Streaming Support.
+-or-
+<see langword="Context Connection=true" /> is specified in the connection string.</exception>
+      <exception cref="T:System.Data.SqlClient.SqlException">SQL Server returned an error while executing the command text.
+-or-
+A timeout occurred during a streaming operation. For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.IO.IOException">An error occurred in a <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object was closed during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommand.ExecuteReaderAsync(System.Data.CommandBehavior,System.Threading.CancellationToken)">
+      <summary>An asynchronous version of <see cref="M:System.Data.SqlClient.SqlCommand.ExecuteReader(System.Data.CommandBehavior)" />, which sends the <see cref="P:System.Data.SqlClient.SqlCommand.CommandText" /> to the <see cref="P:System.Data.SqlClient.SqlCommand.Connection" />, and builds a <see cref="T:System.Data.SqlClient.SqlDataReader" />
+The cancellation token can be used to request that the operation be abandoned before the command timeout elapses.  Exceptions will be reported via the returned Task object.</summary>
+      <param name="behavior">Options for statement execution and data retrieval.  When is set to <see langword="Default" />, <see cref="M:System.Data.SqlClient.SqlDataReader.ReadAsync(System.Threading.CancellationToken)" /> reads the entire row before returning a complete Task.</param>
+      <param name="cancellationToken">The cancellation instruction.</param>
+      <returns>A task representing the asynchronous operation.</returns>
+      <exception cref="T:System.InvalidCastException">A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Binary or VarBinary was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.Stream" />. For more information about streaming, see SqlClient Streaming Support.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Char, NChar, NVarChar, VarChar, or  Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.TextReader" />.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.Xml.XmlReader" />.</exception>
+      <exception cref="T:System.ArgumentException">An invalid <see cref="T:System.Data.CommandBehavior" /> value.</exception>
+      <exception cref="T:System.InvalidOperationException">Calling <see cref="M:System.Data.SqlClient.SqlCommand.ExecuteReaderAsync(System.Data.CommandBehavior,System.Threading.CancellationToken)" /> more than once for the same instance before task completion.
+-or-
+The <see cref="T:System.Data.SqlClient.SqlConnection" /> closed or dropped during a streaming operation. For more information about streaming, see SqlClient Streaming Support.
+-or-
+<see langword="Context Connection=true" /> is specified in the connection string.</exception>
+      <exception cref="T:System.Data.SqlClient.SqlException">SQL Server returned an error while executing the command text.
+-or-
+A timeout occurred during a streaming operation. For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.IO.IOException">An error occurred in a <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object was closed during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommand.ExecuteReaderAsync(System.Threading.CancellationToken)">
+      <summary>An asynchronous version of <see cref="M:System.Data.SqlClient.SqlCommand.ExecuteReader" />, which sends the <see cref="P:System.Data.SqlClient.SqlCommand.CommandText" /> to the <see cref="P:System.Data.SqlClient.SqlCommand.Connection" /> and builds a <see cref="T:System.Data.SqlClient.SqlDataReader" />.
+The cancellation token can be used to request that the operation be abandoned before the command timeout elapses.  Exceptions will be reported via the returned Task object.</summary>
+      <param name="cancellationToken">The cancellation instruction.</param>
+      <returns>A task representing the asynchronous operation.</returns>
+      <exception cref="T:System.InvalidCastException">A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Binary or VarBinary was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.Stream" />. For more information about streaming, see SqlClient Streaming Support.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Char, NChar, NVarChar, VarChar, or  Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.TextReader" />.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.Xml.XmlReader" />.</exception>
+      <exception cref="T:System.ArgumentException">An invalid <see cref="T:System.Data.CommandBehavior" /> value.</exception>
+      <exception cref="T:System.InvalidOperationException">Calling <see cref="M:System.Data.SqlClient.SqlCommand.ExecuteReaderAsync(System.Data.CommandBehavior,System.Threading.CancellationToken)" /> more than once for the same instance before task completion.
+-or-
+The <see cref="T:System.Data.SqlClient.SqlConnection" /> closed or dropped during a streaming operation. For more information about streaming, see SqlClient Streaming Support.
+-or-
+<see langword="Context Connection=true" /> is specified in the connection string.</exception>
+      <exception cref="T:System.Data.SqlClient.SqlException">SQL Server returned an error while executing the command text.
+-or-
+A timeout occurred during a streaming operation. For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.IO.IOException">An error occurred in a <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object was closed during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommand.ExecuteScalar">
+      <summary>Executes the query, and returns the first column of the first row in the result set returned by the query. Additional columns or rows are ignored.</summary>
+      <returns>The first column of the first row in the result set, or a null reference (<see langword="Nothing" /> in Visual Basic) if the result set is empty. Returns a maximum of 2033 characters.</returns>
+      <exception cref="T:System.InvalidCastException">A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Binary or VarBinary was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.Stream" />. For more information about streaming, see SqlClient Streaming Support.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Char, NChar, NVarChar, VarChar, or  Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.TextReader" />.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.Xml.XmlReader" />.</exception>
+      <exception cref="T:System.Data.SqlClient.SqlException">An exception occurred while executing the command against a locked row. This exception is not generated when you are using Microsoft .NET Framework version 1.0.
+-or-
+A timeout occurred during a streaming operation. For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Data.SqlClient.SqlConnection" /> closed or dropped during a streaming operation. For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.IO.IOException">An error occurred in a <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object was closed during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommand.ExecuteScalarAsync(System.Threading.CancellationToken)">
+      <summary>An asynchronous version of <see cref="M:System.Data.SqlClient.SqlCommand.ExecuteScalar" />, which executes the query asynchronously and returns the first column of the first row in the result set returned by the query. Additional columns or rows are ignored.
+The cancellation token can be used to request that the operation be abandoned before the command timeout elapses. Exceptions will be reported via the returned Task object.</summary>
+      <param name="cancellationToken">The cancellation instruction.</param>
+      <returns>A task representing the asynchronous operation.</returns>
+      <exception cref="T:System.InvalidCastException">A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Binary or VarBinary was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.Stream" />. For more information about streaming, see SqlClient Streaming Support.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Char, NChar, NVarChar, VarChar, or  Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.TextReader" />.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.Xml.XmlReader" />.</exception>
+      <exception cref="T:System.InvalidOperationException">Calling <see cref="M:System.Data.SqlClient.SqlCommand.ExecuteScalarAsync(System.Threading.CancellationToken)" /> more than once for the same instance before task completion.
+-or-
+The <see cref="T:System.Data.SqlClient.SqlConnection" /> closed or dropped during a streaming operation. For more information about streaming, see SqlClient Streaming Support.
+-or-
+<see langword="Context Connection=true" /> is specified in the connection string.</exception>
+      <exception cref="T:System.Data.SqlClient.SqlException">SQL Server returned an error while executing the command text.
+-or-
+A timeout occurred during a streaming operation. For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.IO.IOException">An error occurred in a <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object was closed during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommand.ExecuteXmlReader">
+      <summary>Sends the <see cref="P:System.Data.SqlClient.SqlCommand.CommandText" /> to the <see cref="P:System.Data.SqlClient.SqlCommand.Connection" /> and builds an <see cref="T:System.Xml.XmlReader" /> object.</summary>
+      <returns>An <see cref="T:System.Xml.XmlReader" /> object.</returns>
+      <exception cref="T:System.InvalidCastException">A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Binary or VarBinary was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.Stream" />. For more information about streaming, see SqlClient Streaming Support.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Char, NChar, NVarChar, VarChar, or  Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.TextReader" />.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.Xml.XmlReader" />.</exception>
+      <exception cref="T:System.Data.SqlClient.SqlException">An exception occurred while executing the command against a locked row. This exception is not generated when you are using Microsoft .NET Framework version 1.0.
+-or-
+A timeout occurred during a streaming operation. For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Data.SqlClient.SqlConnection" /> closed or dropped during a streaming operation. For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.IO.IOException">An error occurred in a <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object was closed during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommand.ExecuteXmlReaderAsync">
+      <summary>An asynchronous version of <see cref="M:System.Data.SqlClient.SqlCommand.ExecuteXmlReader" />, which sends the <see cref="P:System.Data.SqlClient.SqlCommand.CommandText" /> to the <see cref="P:System.Data.SqlClient.SqlCommand.Connection" /> and builds an <see cref="T:System.Xml.XmlReader" /> object.
+Exceptions will be reported via the returned Task object.</summary>
+      <returns>A task representing the asynchronous operation.</returns>
+      <exception cref="T:System.InvalidCastException">A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Binary or VarBinary was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.Stream" />. For more information about streaming, see SqlClient Streaming Support.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Char, NChar, NVarChar, VarChar, or  Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.TextReader" />.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.Xml.XmlReader" />.</exception>
+      <exception cref="T:System.InvalidOperationException">Calling <see cref="M:System.Data.SqlClient.SqlCommand.ExecuteScalarAsync(System.Threading.CancellationToken)" /> more than once for the same instance before task completion.
+-or-
+The <see cref="T:System.Data.SqlClient.SqlConnection" /> closed or dropped during a streaming operation. For more information about streaming, see SqlClient Streaming Support.
+-or-
+<see langword="Context Connection=true" /> is specified in the connection string.</exception>
+      <exception cref="T:System.Data.SqlClient.SqlException">SQL Server returned an error while executing the command text.
+-or-
+A timeout occurred during a streaming operation. For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.IO.IOException">An error occurred in a <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object was closed during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommand.ExecuteXmlReaderAsync(System.Threading.CancellationToken)">
+      <summary>An asynchronous version of <see cref="M:System.Data.SqlClient.SqlCommand.ExecuteXmlReader" />, which sends the <see cref="P:System.Data.SqlClient.SqlCommand.CommandText" /> to the <see cref="P:System.Data.SqlClient.SqlCommand.Connection" /> and builds an <see cref="T:System.Xml.XmlReader" /> object.
+The cancellation token can be used to request that the operation be abandoned before the command timeout elapses.  Exceptions will be reported via the returned Task object.</summary>
+      <param name="cancellationToken">The cancellation instruction.</param>
+      <returns>A task representing the asynchronous operation.</returns>
+      <exception cref="T:System.InvalidCastException">A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Binary or VarBinary was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.Stream" />. For more information about streaming, see SqlClient Streaming Support.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Char, NChar, NVarChar, VarChar, or  Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.IO.TextReader" />.
+-or-
+A <see cref="P:System.Data.SqlClient.SqlParameter.SqlDbType" /> other than Xml was used when <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> was set to <see cref="T:System.Xml.XmlReader" />.</exception>
+      <exception cref="T:System.InvalidOperationException">Calling <see cref="M:System.Data.SqlClient.SqlCommand.ExecuteScalarAsync(System.Threading.CancellationToken)" /> more than once for the same instance before task completion.
+-or-
+The <see cref="T:System.Data.SqlClient.SqlConnection" /> closed or dropped during a streaming operation. For more information about streaming, see SqlClient Streaming Support.
+-or-
+<see langword="Context Connection=true" /> is specified in the connection string.</exception>
+      <exception cref="T:System.Data.SqlClient.SqlException">SQL Server returned an error while executing the command text.
+-or-
+A timeout occurred during a streaming operation. For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.IO.IOException">An error occurred in a <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+      <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.IO.Stream" />, <see cref="T:System.Xml.XmlReader" /> or <see cref="T:System.IO.TextReader" /> object was closed during a streaming operation.  For more information about streaming, see SqlClient Streaming Support.</exception>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlCommand.Notification">
+      <summary>Gets or sets a value that specifies the <see cref="T:System.Data.Sql.SqlNotificationRequest" /> object bound to this command.</summary>
+      <returns>When set to null (default), no notification should be requested.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlCommand.Parameters">
+      <summary>Gets the <see cref="T:System.Data.SqlClient.SqlParameterCollection" />.</summary>
+      <returns>The parameters of the Transact-SQL statement or stored procedure. The default is an empty collection.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommand.Prepare">
+      <summary>Creates a prepared version of the command on an instance of SQL Server.</summary>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommand.ResetCommandTimeout">
+      <summary>Resets the <see cref="P:System.Data.SqlClient.SqlCommand.CommandTimeout" /> property to its default value.</summary>
+    </member>
+    <member name="E:System.Data.SqlClient.SqlCommand.StatementCompleted">
+      <summary>Occurs when the execution of a Transact-SQL statement completes.</summary>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommand.System#ICloneable#Clone">
+      <summary>Creates a new <see cref="T:System.Data.SqlClient.SqlCommand" /> object that is a copy of the current instance.</summary>
+      <returns>A new <see cref="T:System.Data.SqlClient.SqlCommand" /> object that is a copy of this instance.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlCommand.Transaction">
+      <summary>Gets or sets the <see cref="T:System.Data.SqlClient.SqlTransaction" /> within which the <see cref="T:System.Data.SqlClient.SqlCommand" /> executes.</summary>
+      <returns>The <see cref="T:System.Data.SqlClient.SqlTransaction" />. The default value is <see langword="null" />.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlCommand.UpdatedRowSource">
+      <summary>Gets or sets how command results are applied to the <see cref="T:System.Data.DataRow" /> when used by the Update method of the <see cref="T:System.Data.Common.DbDataAdapter" />.</summary>
+      <returns>One of the <see cref="T:System.Data.UpdateRowSource" /> values.</returns>
+    </member>
+    <member name="T:System.Data.SqlClient.SqlCommandBuilder">
+      <summary>Automatically generates single-table commands that are used to reconcile changes made to a <see cref="T:System.Data.DataSet" /> with the associated SQL Server database. This class cannot be inherited.</summary>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommandBuilder.#ctor">
+      <summary>Initializes a new instance of the <see cref="T:System.Data.SqlClient.SqlCommandBuilder" /> class.</summary>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommandBuilder.#ctor(System.Data.SqlClient.SqlDataAdapter)">
+      <summary>Initializes a new instance of the <see cref="T:System.Data.SqlClient.SqlCommandBuilder" /> class with the associated <see cref="T:System.Data.SqlClient.SqlDataAdapter" /> object.</summary>
+      <param name="adapter">The name of the <see cref="T:System.Data.SqlClient.SqlDataAdapter" />.</param>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlCommandBuilder.CatalogLocation">
+      <summary>Sets or gets the <see cref="T:System.Data.Common.CatalogLocation" /> for an instance of the <see cref="T:System.Data.SqlClient.SqlCommandBuilder" /> class.</summary>
+      <returns>A <see cref="T:System.Data.Common.CatalogLocation" /> object.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlCommandBuilder.CatalogSeparator">
+      <summary>Sets or gets a string used as the catalog separator for an instance of the <see cref="T:System.Data.SqlClient.SqlCommandBuilder" /> class.</summary>
+      <returns>A string that indicates the catalog separator for use with an instance of the <see cref="T:System.Data.SqlClient.SqlCommandBuilder" /> class.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlCommandBuilder.DataAdapter">
+      <summary>Gets or sets a <see cref="T:System.Data.SqlClient.SqlDataAdapter" /> object for which Transact-SQL statements are automatically generated.</summary>
+      <returns>A <see cref="T:System.Data.SqlClient.SqlDataAdapter" /> object.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommandBuilder.DeriveParameters(System.Data.SqlClient.SqlCommand)">
+      <summary>Retrieves parameter information from the stored procedure specified in the <see cref="T:System.Data.SqlClient.SqlCommand" /> and populates the <see cref="P:System.Data.SqlClient.SqlCommand.Parameters" /> collection of the specified <see cref="T:System.Data.SqlClient.SqlCommand" /> object.</summary>
+      <param name="command">The <see cref="T:System.Data.SqlClient.SqlCommand" /> referencing the stored procedure from which the parameter information is to be derived. The derived parameters are added to the <see cref="P:System.Data.SqlClient.SqlCommand.Parameters" /> collection of the <see cref="T:System.Data.SqlClient.SqlCommand" />.</param>
+      <exception cref="T:System.InvalidOperationException">The command text is not a valid stored procedure name.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommandBuilder.GetDeleteCommand">
+      <summary>Gets the automatically generated <see cref="T:System.Data.SqlClient.SqlCommand" /> object required to perform deletions on the database.</summary>
+      <returns>The automatically generated <see cref="T:System.Data.SqlClient.SqlCommand" /> object required to perform deletions.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommandBuilder.GetDeleteCommand(System.Boolean)">
+      <summary>Gets the automatically generated <see cref="T:System.Data.SqlClient.SqlCommand" /> object that is required to perform deletions on the database.</summary>
+      <param name="useColumnsForParameterNames">If <see langword="true" />, generate parameter names matching column names if possible. If <see langword="false" />, generate <c>@p1</c>, <c>@p2</c>, and so on.</param>
+      <returns>The automatically generated <see cref="T:System.Data.SqlClient.SqlCommand" /> object that is required to perform deletions.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommandBuilder.GetInsertCommand">
+      <summary>Gets the automatically generated <see cref="T:System.Data.SqlClient.SqlCommand" /> object required to perform insertions on the database.</summary>
+      <returns>The automatically generated <see cref="T:System.Data.SqlClient.SqlCommand" /> object required to perform insertions.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommandBuilder.GetInsertCommand(System.Boolean)">
+      <summary>Gets the automatically generated <see cref="T:System.Data.SqlClient.SqlCommand" /> object that is required to perform insertions on the database.</summary>
+      <param name="useColumnsForParameterNames">If <see langword="true" />, generate parameter names matching column names if possible. If <see langword="false" />, generate <c>@p1</c>, <c>@p2</c>, and so on.</param>
+      <returns>The automatically generated <see cref="T:System.Data.SqlClient.SqlCommand" /> object that is required to perform insertions.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommandBuilder.GetUpdateCommand">
+      <summary>Gets the automatically generated <see cref="T:System.Data.SqlClient.SqlCommand" /> object required to perform updates on the database.</summary>
+      <returns>The automatically generated <see cref="T:System.Data.SqlClient.SqlCommand" /> object that is required to perform updates.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommandBuilder.GetUpdateCommand(System.Boolean)">
+      <summary>Gets the automatically generated <see cref="T:System.Data.SqlClient.SqlCommand" /> object required to perform updates on the database.</summary>
+      <param name="useColumnsForParameterNames">If <see langword="true" />, generate parameter names matching column names if possible. If <see langword="false" />, generate <c>@p1</c>, <c>@p2</c>, and so on.</param>
+      <returns>The automatically generated <see cref="T:System.Data.SqlClient.SqlCommand" /> object required to perform updates.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommandBuilder.QuoteIdentifier(System.String)">
+      <summary>Given an unquoted identifier in the correct catalog case, returns the correct quoted form of that identifier. This includes correctly escaping any embedded quotes in the identifier.</summary>
+      <param name="unquotedIdentifier">The original unquoted identifier.</param>
+      <returns>The quoted version of the identifier. Embedded quotes within the identifier are correctly escaped.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlCommandBuilder.QuotePrefix">
+      <summary>Gets or sets the starting character or characters to use when specifying SQL Server database objects, such as tables or columns, whose names contain characters such as spaces or reserved tokens.</summary>
+      <returns>The starting character or characters to use. The default is an empty string.</returns>
+      <exception cref="T:System.InvalidOperationException">This property cannot be changed after an INSERT, UPDATE, or DELETE command has been generated.</exception>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlCommandBuilder.QuoteSuffix">
+      <summary>Gets or sets the ending character or characters to use when specifying SQL Server database objects, such as tables or columns, whose names contain characters such as spaces or reserved tokens.</summary>
+      <returns>The ending character or characters to use. The default is an empty string.</returns>
+      <exception cref="T:System.InvalidOperationException">This property cannot be changed after an insert, update, or delete command has been generated.</exception>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlCommandBuilder.SchemaSeparator">
+      <summary>Gets or sets the character to be used for the separator between the schema identifier and any other identifiers.</summary>
+      <returns>The character to be used as the schema separator.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCommandBuilder.UnquoteIdentifier(System.String)">
+      <summary>Given a quoted identifier, returns the correct unquoted form of that identifier. This includes correctly unescaping any embedded quotes in the identifier.</summary>
+      <param name="quotedIdentifier">The identifier that will have its embedded quotes removed.</param>
+      <returns>The unquoted identifier, with embedded quotes properly unescaped.</returns>
+    </member>
+    <member name="T:System.Data.SqlClient.SqlConnection">
+      <summary>Represents a connection to a SQL Server database. This class cannot be inherited.</summary>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlConnection.#ctor">
+      <summary>Initializes a new instance of the <see cref="T:System.Data.SqlClient.SqlConnection" /> class.</summary>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlConnection.#ctor(System.String)">
+      <summary>Initializes a new instance of the <see cref="T:System.Data.SqlClient.SqlConnection" /> class when given a string that contains the connection string.</summary>
+      <param name="connectionString">The connection used to open the SQL Server database.</param>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlConnection.#ctor(System.String,System.Data.SqlClient.SqlCredential)">
+      <summary>Initializes a new instance of the <see cref="T:System.Data.SqlClient.SqlConnection" /> class given a connection string, that does not use <see langword="Integrated Security = true" /> and a <see cref="T:System.Data.SqlClient.SqlCredential" /> object that contains the user ID and password.</summary>
+      <param name="connectionString">A connection string that does not use any of the following connection string keywords: <see langword="Integrated Security = true" />, <see langword="UserId" />, or <see langword="Password" />; or that does not use <see langword="ContextConnection = true" />.</param>
+      <param name="credential">A <see cref="T:System.Data.SqlClient.SqlCredential" /> object. If <paramref name="credential" /> is null, <see cref="M:System.Data.SqlClient.SqlConnection.#ctor(System.String,System.Data.SqlClient.SqlCredential)" /> is functionally equivalent to <see cref="M:System.Data.SqlClient.SqlConnection.#ctor(System.String)" />.</param>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnection.AccessToken">
+      <summary>Gets or sets the access token for the connection.</summary>
+      <returns>The access token for the connection.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlConnection.BeginTransaction">
+      <summary>Starts a database transaction.</summary>
+      <returns>An object representing the new transaction.</returns>
+      <exception cref="T:System.Data.SqlClient.SqlException">Parallel transactions are not allowed when using Multiple Active Result Sets (MARS).</exception>
+      <exception cref="T:System.InvalidOperationException">Parallel transactions are not supported.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlConnection.BeginTransaction(System.Data.IsolationLevel)">
+      <summary>Starts a database transaction with the specified isolation level.</summary>
+      <param name="iso">The isolation level under which the transaction should run.</param>
+      <returns>An object representing the new transaction.</returns>
+      <exception cref="T:System.Data.SqlClient.SqlException">Parallel transactions are not allowed when using Multiple Active Result Sets (MARS).</exception>
+      <exception cref="T:System.InvalidOperationException">Parallel transactions are not supported.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlConnection.BeginTransaction(System.Data.IsolationLevel,System.String)">
+      <summary>Starts a database transaction with the specified isolation level and transaction name.</summary>
+      <param name="iso">The isolation level under which the transaction should run.</param>
+      <param name="transactionName">The name of the transaction.</param>
+      <returns>An object representing the new transaction.</returns>
+      <exception cref="T:System.Data.SqlClient.SqlException">Parallel transactions are not allowed when using Multiple Active Result Sets (MARS).</exception>
+      <exception cref="T:System.InvalidOperationException">Parallel transactions are not supported.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlConnection.BeginTransaction(System.String)">
+      <summary>Starts a database transaction with the specified transaction name.</summary>
+      <param name="transactionName">The name of the transaction.</param>
+      <returns>An object representing the new transaction.</returns>
+      <exception cref="T:System.Data.SqlClient.SqlException">Parallel transactions are not allowed when using Multiple Active Result Sets (MARS).</exception>
+      <exception cref="T:System.InvalidOperationException">Parallel transactions are not supported.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlConnection.ChangeDatabase(System.String)">
+      <summary>Changes the current database for an open <see cref="T:System.Data.SqlClient.SqlConnection" />.</summary>
+      <param name="database">The name of the database to use instead of the current database.</param>
+      <exception cref="T:System.ArgumentException">The database name is not valid.</exception>
+      <exception cref="T:System.InvalidOperationException">The connection is not open.</exception>
+      <exception cref="T:System.Data.SqlClient.SqlException">Cannot change the database.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlConnection.ChangePassword(System.String,System.Data.SqlClient.SqlCredential,System.Security.SecureString)">
+      <summary>Changes the SQL Server password for the user indicated in the <see cref="T:System.Data.SqlClient.SqlCredential" /> object.</summary>
+      <param name="connectionString">The connection string that contains enough information to connect to a server. The connection string should not use any of the following connection string keywords: <see langword="Integrated Security = true" />, <see langword="UserId" />, or <see langword="Password" />; or <see langword="ContextConnection = true" />.</param>
+      <param name="credential">A <see cref="T:System.Data.SqlClient.SqlCredential" /> object.</param>
+      <param name="newPassword">The new password.<paramref name="newPassword" /> must be read only. The password must also comply with any password security policy set on the server (for example, minimum length and requirements for specific characters).</param>
+      <exception cref="T:System.ArgumentException">The connection string contains any combination of <see langword="UserId" />, <see langword="Password" />, or <see langword="Integrated Security=true" />.
+-or-
+The connection string contains <see langword="Context Connection=true" />.
+-or-
+<paramref name="newSecurePassword" /> (or <paramref name="newPassword" />) is greater than 128 characters.
+-or-
+<paramref name="newSecurePassword" /> (or <paramref name="newPassword" />) is not read only.
+-or-
+<paramref name="newSecurePassword" /> (or <paramref name="newPassword" />) is an empty string.</exception>
+      <exception cref="T:System.ArgumentNullException">One of the parameters (<paramref name="connectionString" />, <paramref name="credential" />, or <paramref name="newSecurePassword" />) is null.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlConnection.ChangePassword(System.String,System.String)">
+      <summary>Changes the SQL Server password for the user indicated in the connection string to the supplied new password.</summary>
+      <param name="connectionString">The connection string that contains enough information to connect to the server that you want. The connection string must contain the user ID and the current password.</param>
+      <param name="newPassword">The new password to set. This password must comply with any password security policy set on the server, including minimum length, requirements for specific characters, and so on.</param>
+      <exception cref="T:System.ArgumentException">The connection string includes the option to use integrated security.
+Or
+The <paramref name="newPassword" /> exceeds 128 characters.</exception>
+      <exception cref="T:System.ArgumentNullException">Either the <paramref name="connectionString" /> or the <paramref name="newPassword" /> parameter is null.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlConnection.ClearAllPools">
+      <summary>Empties the connection pool.</summary>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlConnection.ClearPool(System.Data.SqlClient.SqlConnection)">
+      <summary>Empties the connection pool associated with the specified connection.</summary>
+      <param name="connection">The <see cref="T:System.Data.SqlClient.SqlConnection" /> to be cleared from the pool.</param>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnection.ClientConnectionId">
+      <summary>The connection ID of the most recent connection attempt, regardless of whether the attempt succeeded or failed.</summary>
+      <returns>The connection ID of the most recent connection attempt.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlConnection.Close">
+      <summary>Closes the connection to the database. This is the preferred method of closing any open connection.</summary>
+      <exception cref="T:System.Data.SqlClient.SqlException">The connection-level error that occurred while opening the connection.</exception>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnection.ConnectionString">
+      <summary>Gets or sets the string used to open a SQL Server database.</summary>
+      <returns>The connection string that includes the source database name, and other parameters needed to establish the initial connection. The default value is an empty string.</returns>
+      <exception cref="T:System.ArgumentException">An invalid connection string argument has been supplied, or a required connection string argument has not been supplied.</exception>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnection.ConnectionTimeout">
+      <summary>Gets the time to wait while trying to establish a connection before terminating the attempt and generating an error.</summary>
+      <returns>The time (in seconds) to wait for a connection to open. The default value is 15 seconds.</returns>
+      <exception cref="T:System.ArgumentException">The value set is less than 0.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlConnection.CreateCommand">
+      <summary>Creates and returns a <see cref="T:System.Data.SqlClient.SqlCommand" /> object associated with the <see cref="T:System.Data.SqlClient.SqlConnection" />.</summary>
+      <returns>A <see cref="T:System.Data.SqlClient.SqlCommand" /> object.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnection.Credential">
+      <summary>Gets or sets the <see cref="T:System.Data.SqlClient.SqlCredential" /> object for this connection.</summary>
+      <returns>The <see cref="T:System.Data.SqlClient.SqlCredential" /> object for this connection.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnection.Database">
+      <summary>Gets the name of the current database or the database to be used after a connection is opened.</summary>
+      <returns>The name of the current database or the name of the database to be used after a connection is opened. The default value is an empty string.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnection.DataSource">
+      <summary>Gets the name of the instance of SQL Server to which to connect.</summary>
+      <returns>The name of the instance of SQL Server to which to connect. The default value is an empty string.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnection.FireInfoMessageEventOnUserErrors">
+      <summary>Gets or sets the <see cref="P:System.Data.SqlClient.SqlConnection.FireInfoMessageEventOnUserErrors" /> property.</summary>
+      <returns>
+        <see langword="true" /> if the <see cref="P:System.Data.SqlClient.SqlConnection.FireInfoMessageEventOnUserErrors" /> property has been set; otherwise <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlConnection.GetSchema">
+      <summary>Returns schema information for the data source of this <see cref="T:System.Data.SqlClient.SqlConnection" />. For more information about scheme, see SQL Server Schema Collections.</summary>
+      <returns>A <see cref="T:System.Data.DataTable" /> that contains schema information.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlConnection.GetSchema(System.String)">
+      <summary>Returns schema information for the data source of this <see cref="T:System.Data.SqlClient.SqlConnection" /> using the specified string for the schema name.</summary>
+      <param name="collectionName">Specifies the name of the schema to return.</param>
+      <returns>A <see cref="T:System.Data.DataTable" /> that contains schema information.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="collectionName" /> is specified as null.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlConnection.GetSchema(System.String,System.String[])">
+      <summary>Returns schema information for the data source of this <see cref="T:System.Data.SqlClient.SqlConnection" /> using the specified string for the schema name and the specified string array for the restriction values.</summary>
+      <param name="collectionName">Specifies the name of the schema to return.</param>
+      <param name="restrictionValues">A set of restriction values for the requested schema.</param>
+      <returns>A <see cref="T:System.Data.DataTable" /> that contains schema information.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="collectionName" /> is specified as null.</exception>
+    </member>
+    <member name="E:System.Data.SqlClient.SqlConnection.InfoMessage">
+      <summary>Occurs when SQL Server returns a warning or informational message.</summary>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlConnection.Open">
+      <summary>Opens a database connection with the property settings specified by the <see cref="P:System.Data.SqlClient.SqlConnection.ConnectionString" />.</summary>
+      <exception cref="T:System.InvalidOperationException">Cannot open a connection without specifying a data source or server.
+or
+The connection is already open.</exception>
+      <exception cref="T:System.Data.SqlClient.SqlException">A connection-level error occurred while opening the connection. If the <see cref="P:System.Data.SqlClient.SqlException.Number" /> property contains the value 18487 or 18488, this indicates that the specified password has expired or must be reset. See the <see cref="M:System.Data.SqlClient.SqlConnection.ChangePassword(System.String,System.String)" /> method for more information.
+The <see langword="&lt;system.data.localdb&gt;" /> tag in the app.config file has invalid or unknown elements.</exception>
+      <exception cref="T:System.Configuration.ConfigurationErrorsException">There are two entries with the same name in the <see langword="&lt;localdbinstances&gt;" /> section.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlConnection.OpenAsync(System.Threading.CancellationToken)">
+      <summary>An asynchronous version of <see cref="M:System.Data.SqlClient.SqlConnection.Open" />, which opens a database connection with the property settings specified by the <see cref="P:System.Data.SqlClient.SqlConnection.ConnectionString" />. The cancellation token can be used to request that the operation be abandoned before the connection timeout elapses.  Exceptions will be propagated via the returned Task. If the connection timeout time elapses without successfully connecting, the returned Task will be marked as faulted with an Exception. The implementation returns a Task without blocking the calling thread for both pooled and non-pooled connections.</summary>
+      <param name="cancellationToken">The cancellation instruction.</param>
+      <returns>A task representing the asynchronous operation.</returns>
+      <exception cref="T:System.InvalidOperationException">Calling <see cref="M:System.Data.SqlClient.SqlConnection.OpenAsync(System.Threading.CancellationToken)" /> more than once for the same instance before task completion.
+<see langword="Context Connection=true" /> is specified in the connection string.
+A connection was not available from the connection pool before the connection time out elapsed.</exception>
+      <exception cref="T:System.Data.SqlClient.SqlException">Any error returned by SQL Server that occurred while opening the connection.</exception>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnection.PacketSize">
+      <summary>Gets the size (in bytes) of network packets used to communicate with an instance of SQL Server.</summary>
+      <returns>The size (in bytes) of network packets. The default value is 8000.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlConnection.ResetStatistics">
+      <summary>If statistics gathering is enabled, all values are reset to zero.</summary>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlConnection.RetrieveStatistics">
+      <summary>Returns a name value pair collection of statistics at the point in time the method is called.</summary>
+      <returns>Returns a reference of type <see cref="T:System.Collections.IDictionary" /> of <see cref="T:System.Collections.DictionaryEntry" /> items.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnection.ServerVersion">
+      <summary>Gets a string that contains the version of the instance of SQL Server to which the client is connected.</summary>
+      <returns>The version of the instance of SQL Server.</returns>
+      <exception cref="T:System.InvalidOperationException">The connection is closed.
+<see cref="P:System.Data.SqlClient.SqlConnection.ServerVersion" /> was called while the returned Task was not completed and the connection was not opened after a call to <see cref="M:System.Data.SqlClient.SqlConnection.OpenAsync(System.Threading.CancellationToken)" />.</exception>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnection.State">
+      <summary>Indicates the state of the <see cref="T:System.Data.SqlClient.SqlConnection" /> during the most recent network operation performed on the connection.</summary>
+      <returns>An <see cref="T:System.Data.ConnectionState" /> enumeration.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnection.StatisticsEnabled">
+      <summary>When set to <see langword="true" />, enables statistics gathering for the current connection.</summary>
+      <returns>Returns <see langword="true" /> if statistics gathering is enabled; otherwise <see langword="false" />. <see langword="false" /> is the default.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlConnection.System#ICloneable#Clone">
+      <summary>Creates a new object that is a copy of the current instance.</summary>
+      <returns>A new object that is a copy of this instance.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnection.WorkstationId">
+      <summary>Gets a string that identifies the database client.</summary>
+      <returns>A string that identifies the database client. If not specified, the name of the client computer. If neither is specified, the value is an empty string.</returns>
+    </member>
+    <member name="T:System.Data.SqlClient.SqlConnectionStringBuilder">
+      <summary>Provides a simple way to create and manage the contents of connection strings used by the <see cref="T:System.Data.SqlClient.SqlConnection" /> class.</summary>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlConnectionStringBuilder.#ctor">
+      <summary>Initializes a new instance of the <see cref="T:System.Data.SqlClient.SqlConnectionStringBuilder" /> class.</summary>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlConnectionStringBuilder.#ctor(System.String)">
+      <summary>Initializes a new instance of the <see cref="T:System.Data.SqlClient.SqlConnectionStringBuilder" /> class. The provided connection string provides the data for the instance's internal connection information.</summary>
+      <param name="connectionString">The basis for the object's internal connection information. Parsed into name/value pairs. Invalid key names raise <see cref="T:System.Collections.Generic.KeyNotFoundException" />.</param>
+      <exception cref="T:System.Collections.Generic.KeyNotFoundException">Invalid key name within the connection string.</exception>
+      <exception cref="T:System.FormatException">Invalid value within the connection string (specifically, when a Boolean or numeric value was expected but not supplied).</exception>
+      <exception cref="T:System.ArgumentException">The supplied <paramref name="connectionString" /> is not valid.</exception>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnectionStringBuilder.ApplicationIntent">
+      <summary>Declares the application workload type when connecting to a database in an SQL Server Availability Group. You can set the value of this property with <see cref="T:System.Data.SqlClient.ApplicationIntent" />. For more information about SqlClient support for Always On Availability Groups, see SqlClient Support for High Availability, Disaster Recovery.</summary>
+      <returns>Returns the current value of the property (a value of type <see cref="T:System.Data.SqlClient.ApplicationIntent" />).</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnectionStringBuilder.ApplicationName">
+      <summary>Gets or sets the name of the application associated with the connection string.</summary>
+      <returns>The name of the application, or ".NET SqlClient Data Provider" if no name has been supplied.</returns>
+      <exception cref="T:System.ArgumentNullException">To set the value to null, use <see cref="F:System.DBNull.Value" />.</exception>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnectionStringBuilder.AttachDBFilename">
+      <summary>Gets or sets a string that contains the name of the primary data file. This includes the full path name of an attachable database.</summary>
+      <returns>The value of the <see langword="AttachDBFilename" /> property, or <see langword="String.Empty" /> if no value has been supplied.</returns>
+      <exception cref="T:System.ArgumentNullException">To set the value to null, use <see cref="F:System.DBNull.Value" />.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlConnectionStringBuilder.Clear">
+      <summary>Clears the contents of the <see cref="T:System.Data.SqlClient.SqlConnectionStringBuilder" /> instance.</summary>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnectionStringBuilder.ConnectRetryCount">
+      <summary>The number of reconnections attempted after identifying that there was an idle connection failure. This must be an integer between 0 and 255. Default is 1. Set to 0 to disable reconnecting on idle connection failures. An <see cref="T:System.ArgumentException" /> will be thrown if set to a value outside of the allowed range.</summary>
+      <returns>The number of reconnections attempted after identifying that there was an idle connection failure.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnectionStringBuilder.ConnectRetryInterval">
+      <summary>Amount of time (in seconds) between each reconnection attempt after identifying that there was an idle connection failure. This must be an integer between 1 and 60. The default is 10 seconds. An <see cref="T:System.ArgumentException" /> will be thrown if set to a value outside of the allowed range.</summary>
+      <returns>Amount of time (in seconds) between each reconnection attempt after identifying that there was an idle connection failure.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnectionStringBuilder.ConnectTimeout">
+      <summary>Gets or sets the length of time (in seconds) to wait for a connection to the server before terminating the attempt and generating an error.</summary>
+      <returns>The value of the <see cref="P:System.Data.SqlClient.SqlConnectionStringBuilder.ConnectTimeout" /> property, or 15 seconds if no value has been supplied.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlConnectionStringBuilder.ContainsKey(System.String)">
+      <summary>Determines whether the <see cref="T:System.Data.SqlClient.SqlConnectionStringBuilder" /> contains a specific key.</summary>
+      <param name="keyword">The key to locate in the <see cref="T:System.Data.SqlClient.SqlConnectionStringBuilder" />.</param>
+      <returns>
+        <see langword="true" /> if the <see cref="T:System.Data.SqlClient.SqlConnectionStringBuilder" /> contains an element that has the specified key; otherwise, <see langword="false" />.</returns>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="keyword" /> is null (<see langword="Nothing" /> in Visual Basic)</exception>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnectionStringBuilder.CurrentLanguage">
+      <summary>Gets or sets the SQL Server Language record name.</summary>
+      <returns>The value of the <see cref="P:System.Data.SqlClient.SqlConnectionStringBuilder.CurrentLanguage" /> property, or <see langword="String.Empty" /> if no value has been supplied.</returns>
+      <exception cref="T:System.ArgumentNullException">To set the value to null, use <see cref="F:System.DBNull.Value" />.</exception>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnectionStringBuilder.DataSource">
+      <summary>Gets or sets the name or network address of the instance of SQL Server to connect to.</summary>
+      <returns>The value of the <see cref="P:System.Data.SqlClient.SqlConnectionStringBuilder.DataSource" /> property, or <see langword="String.Empty" /> if none has been supplied.</returns>
+      <exception cref="T:System.ArgumentNullException">To set the value to null, use <see cref="F:System.DBNull.Value" />.</exception>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnectionStringBuilder.Encrypt">
+      <summary>Gets or sets a Boolean value that indicates whether SQL Server uses SSL encryption for all data sent between the client and server if the server has a certificate installed.</summary>
+      <returns>The value of the <see cref="P:System.Data.SqlClient.SqlConnectionStringBuilder.Encrypt" /> property, or <see langword="false" /> if none has been supplied.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnectionStringBuilder.Enlist">
+      <summary>Gets or sets a Boolean value that indicates whether the SQL Server connection pooler automatically enlists the connection in the creation thread's current transaction context.</summary>
+      <returns>The value of the <see cref="P:System.Data.SqlClient.SqlConnectionStringBuilder.Enlist" /> property, or <see langword="true" /> if none has been supplied.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnectionStringBuilder.FailoverPartner">
+      <summary>Gets or sets the name or address of the partner server to connect to if the primary server is down.</summary>
+      <returns>The value of the <see cref="P:System.Data.SqlClient.SqlConnectionStringBuilder.FailoverPartner" /> property, or <see langword="String.Empty" /> if none has been supplied.</returns>
+      <exception cref="T:System.ArgumentNullException">To set the value to null, use <see cref="F:System.DBNull.Value" />.</exception>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnectionStringBuilder.InitialCatalog">
+      <summary>Gets or sets the name of the database associated with the connection.</summary>
+      <returns>The value of the <see cref="P:System.Data.SqlClient.SqlConnectionStringBuilder.InitialCatalog" /> property, or <see langword="String.Empty" /> if none has been supplied.</returns>
+      <exception cref="T:System.ArgumentNullException">To set the value to null, use <see cref="F:System.DBNull.Value" />.</exception>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnectionStringBuilder.IntegratedSecurity">
+      <summary>Gets or sets a Boolean value that indicates whether User ID and Password are specified in the connection (when <see langword="false" />) or whether the current Windows account credentials are used for authentication (when <see langword="true" />).</summary>
+      <returns>The value of the <see cref="P:System.Data.SqlClient.SqlConnectionStringBuilder.IntegratedSecurity" /> property, or <see langword="false" /> if none has been supplied.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnectionStringBuilder.Item(System.String)">
+      <summary>Gets or sets the value associated with the specified key. In C#, this property is the indexer.</summary>
+      <param name="keyword">The key of the item to get or set.</param>
+      <returns>The value associated with the specified key.</returns>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="keyword" /> is a null reference (<see langword="Nothing" /> in Visual Basic).</exception>
+      <exception cref="T:System.Collections.Generic.KeyNotFoundException">Tried to add a key that does not exist within the available keys.</exception>
+      <exception cref="T:System.FormatException">Invalid value within the connection string (specifically, a Boolean or numeric value was expected but not supplied).</exception>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnectionStringBuilder.Keys">
+      <summary>Gets an <see cref="T:System.Collections.ICollection" /> that contains the keys in the <see cref="T:System.Data.SqlClient.SqlConnectionStringBuilder" />.</summary>
+      <returns>An <see cref="T:System.Collections.ICollection" /> that contains the keys in the <see cref="T:System.Data.SqlClient.SqlConnectionStringBuilder" />.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnectionStringBuilder.LoadBalanceTimeout">
+      <summary>Gets or sets the minimum time, in seconds, for the connection to live in the connection pool before being destroyed.</summary>
+      <returns>The value of the <see cref="P:System.Data.SqlClient.SqlConnectionStringBuilder.LoadBalanceTimeout" /> property, or 0 if none has been supplied.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnectionStringBuilder.MaxPoolSize">
+      <summary>Gets or sets the maximum number of connections allowed in the connection pool for this specific connection string.</summary>
+      <returns>The value of the <see cref="P:System.Data.SqlClient.SqlConnectionStringBuilder.MaxPoolSize" /> property, or 100 if none has been supplied.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnectionStringBuilder.MinPoolSize">
+      <summary>Gets or sets the minimum number of connections allowed in the connection pool for this specific connection string.</summary>
+      <returns>The value of the <see cref="P:System.Data.SqlClient.SqlConnectionStringBuilder.MinPoolSize" /> property, or 0 if none has been supplied.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnectionStringBuilder.MultipleActiveResultSets">
+      <summary>When true, an application can maintain multiple active result sets (MARS). When false, an application must process or cancel all result sets from one batch before it can execute any other batch on that connection.
+For more information, see Multiple Active Result Sets (MARS).</summary>
+      <returns>The value of the <see cref="P:System.Data.SqlClient.SqlConnectionStringBuilder.MultipleActiveResultSets" /> property, or <see langword="false" /> if none has been supplied.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnectionStringBuilder.MultiSubnetFailover">
+      <summary>If your application is connecting to an AlwaysOn availability group (AG) on different subnets, setting MultiSubnetFailover=true provides faster detection of and connection to the (currently) active server. For more information about SqlClient support for Always On Availability Groups, see SqlClient Support for High Availability, Disaster Recovery.</summary>
+      <returns>Returns <see cref="T:System.Boolean" /> indicating the current value of the property.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnectionStringBuilder.PacketSize">
+      <summary>Gets or sets the size in bytes of the network packets used to communicate with an instance of SQL Server.</summary>
+      <returns>The value of the <see cref="P:System.Data.SqlClient.SqlConnectionStringBuilder.PacketSize" /> property, or 8000 if none has been supplied.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnectionStringBuilder.Password">
+      <summary>Gets or sets the password for the SQL Server account.</summary>
+      <returns>The value of the <see cref="P:System.Data.SqlClient.SqlConnectionStringBuilder.Password" /> property, or <see langword="String.Empty" /> if none has been supplied.</returns>
+      <exception cref="T:System.ArgumentNullException">The password was incorrectly set to null.  See code sample below.</exception>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnectionStringBuilder.PersistSecurityInfo">
+      <summary>Gets or sets a Boolean value that indicates if security-sensitive information, such as the password, is not returned as part of the connection if the connection is open or has ever been in an open state.</summary>
+      <returns>The value of the <see cref="P:System.Data.SqlClient.SqlConnectionStringBuilder.PersistSecurityInfo" /> property, or <see langword="false" /> if none has been supplied.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnectionStringBuilder.PoolBlockingPeriod">
+      <summary>The blocking period behavior for a connection pool.</summary>
+      <returns>The available blocking period settings.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnectionStringBuilder.Pooling">
+      <summary>Gets or sets a Boolean value that indicates whether the connection will be pooled or explicitly opened every time that the connection is requested.</summary>
+      <returns>The value of the <see cref="P:System.Data.SqlClient.SqlConnectionStringBuilder.Pooling" /> property, or <see langword="true" /> if none has been supplied.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlConnectionStringBuilder.Remove(System.String)">
+      <summary>Removes the entry with the specified key from the <see cref="T:System.Data.SqlClient.SqlConnectionStringBuilder" /> instance.</summary>
+      <param name="keyword">The key of the key/value pair to be removed from the connection string in this <see cref="T:System.Data.SqlClient.SqlConnectionStringBuilder" />.</param>
+      <returns>
+        <see langword="true" /> if the key existed within the connection string and was removed; <see langword="false" /> if the key did not exist.</returns>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="keyword" /> is null (<see langword="Nothing" /> in Visual Basic)</exception>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnectionStringBuilder.Replication">
+      <summary>Gets or sets a Boolean value that indicates whether replication is supported using the connection.</summary>
+      <returns>The value of the <see cref="P:System.Data.SqlClient.SqlConnectionStringBuilder.Replication" /> property, or false if none has been supplied.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlConnectionStringBuilder.ShouldSerialize(System.String)">
+      <summary>Indicates whether the specified key exists in this <see cref="T:System.Data.SqlClient.SqlConnectionStringBuilder" /> instance.</summary>
+      <param name="keyword">The key to locate in the <see cref="T:System.Data.SqlClient.SqlConnectionStringBuilder" />.</param>
+      <returns>
+        <see langword="true" /> if the <see cref="T:System.Data.SqlClient.SqlConnectionStringBuilder" /> contains an entry with the specified key; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnectionStringBuilder.TransactionBinding">
+      <summary>Gets or sets a string value that indicates how the connection maintains its association with an enlisted <see langword="System.Transactions" /> transaction.</summary>
+      <returns>The value of the <see cref="P:System.Data.SqlClient.SqlConnectionStringBuilder.TransactionBinding" /> property, or <see langword="String.Empty" /> if none has been supplied.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnectionStringBuilder.TrustServerCertificate">
+      <summary>Gets or sets a value that indicates whether the channel will be encrypted while bypassing walking the certificate chain to validate trust.</summary>
+      <returns>A <see langword="Boolean" />. Recognized values are <see langword="true" />, <see langword="false" />, <see langword="yes" />, and <see langword="no" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlConnectionStringBuilder.TryGetValue(System.String,System.Object@)">
+      <summary>Retrieves a value corresponding to the supplied key from this <see cref="T:System.Data.SqlClient.SqlConnectionStringBuilder" />.</summary>
+      <param name="keyword">The key of the item to retrieve.</param>
+      <param name="value">The value corresponding to <paramref name="keyword" />.</param>
+      <returns>
+        <see langword="true" /> if <paramref name="keyword" /> was found within the connection string; otherwise, <see langword="false" />.</returns>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="keyword" /> contains a null value (<see langword="Nothing" /> in Visual Basic).</exception>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnectionStringBuilder.TypeSystemVersion">
+      <summary>Gets or sets a string value that indicates the type system the application expects.</summary>
+      <returns>The following table shows the possible values for the <see cref="P:System.Data.SqlClient.SqlConnectionStringBuilder.TypeSystemVersion" /> property:
+  Value  
+  
+  Description  
+  
+  SQL Server 2005  
+  
+  Uses the SQL Server 2005 type system. No conversions are made for the current version of ADO.NET.  
+  
+  SQL Server 2008  
+  
+  Uses the SQL Server 2008 type system.  
+  
+  Latest  
+  
+  Use the latest version than this client-server pair can handle. This will automatically move forward as the client and server components are upgraded.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnectionStringBuilder.UserID">
+      <summary>Gets or sets the user ID to be used when connecting to SQL Server.</summary>
+      <returns>The value of the <see cref="P:System.Data.SqlClient.SqlConnectionStringBuilder.UserID" /> property, or <see langword="String.Empty" /> if none has been supplied.</returns>
+      <exception cref="T:System.ArgumentNullException">To set the value to null, use <see cref="F:System.DBNull.Value" />.</exception>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnectionStringBuilder.UserInstance">
+      <summary>Gets or sets a value that indicates whether to redirect the connection from the default SQL Server Express instance to a runtime-initiated instance running under the account of the caller.</summary>
+      <returns>The value of the <see cref="P:System.Data.SqlClient.SqlConnectionStringBuilder.UserInstance" /> property, or <see langword="False" /> if none has been supplied.</returns>
+      <exception cref="T:System.ArgumentNullException">To set the value to null, use <see cref="F:System.DBNull.Value" />.</exception>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnectionStringBuilder.Values">
+      <summary>Gets an <see cref="T:System.Collections.ICollection" /> that contains the values in the <see cref="T:System.Data.SqlClient.SqlConnectionStringBuilder" />.</summary>
+      <returns>An <see cref="T:System.Collections.ICollection" /> that contains the values in the <see cref="T:System.Data.SqlClient.SqlConnectionStringBuilder" />.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlConnectionStringBuilder.WorkstationID">
+      <summary>Gets or sets the name of the workstation connecting to SQL Server.</summary>
+      <returns>The value of the <see cref="P:System.Data.SqlClient.SqlConnectionStringBuilder.WorkstationID" /> property, or <see langword="String.Empty" /> if none has been supplied.</returns>
+      <exception cref="T:System.ArgumentNullException">To set the value to null, use <see cref="F:System.DBNull.Value" />.</exception>
+    </member>
+    <member name="T:System.Data.SqlClient.SqlCredential">
+      <summary>
+        <see cref="T:System.Data.SqlClient.SqlCredential" /> provides a more secure way to specify the password for a login attempt using SQL Server Authentication.
+<see cref="T:System.Data.SqlClient.SqlCredential" /> is comprised of a user id and a password that will be used for SQL Server Authentication. The password in a <see cref="T:System.Data.SqlClient.SqlCredential" /> object is of type <see cref="T:System.Security.SecureString" />.
+<see cref="T:System.Data.SqlClient.SqlCredential" /> cannot be inherited.
+Windows Authentication (<see langword="Integrated Security = true" />) remains the most secure way to log in to a SQL Server database.</summary>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlCredential.#ctor(System.String,System.Security.SecureString)">
+      <summary>Creates an object of type <see cref="T:System.Data.SqlClient.SqlCredential" />.</summary>
+      <param name="userId">The user id.</param>
+      <param name="password">The password; a <see cref="T:System.Security.SecureString" /> value marked as read-only.  Passing a read/write <see cref="T:System.Security.SecureString" /> parameter will raise an <see cref="T:System.ArgumentException" />.</param>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlCredential.Password">
+      <summary>Gets the password component of the <see cref="T:System.Data.SqlClient.SqlCredential" /> object.</summary>
+      <returns>The password component of the <see cref="T:System.Data.SqlClient.SqlCredential" /> object.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlCredential.UserId">
+      <summary>Gets the user ID component of the <see cref="T:System.Data.SqlClient.SqlCredential" /> object.</summary>
+      <returns>The user ID component of the <see cref="T:System.Data.SqlClient.SqlCredential" /> object.</returns>
+    </member>
+    <member name="T:System.Data.SqlClient.SqlDataAdapter">
+      <summary>Represents a set of data commands and a database connection that are used to fill the <see cref="T:System.Data.DataSet" /> and update a SQL Server database. This class cannot be inherited.</summary>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataAdapter.#ctor">
+      <summary>Initializes a new instance of the <see cref="T:System.Data.SqlClient.SqlDataAdapter" /> class.</summary>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataAdapter.#ctor(System.Data.SqlClient.SqlCommand)">
+      <summary>Initializes a new instance of the <see cref="T:System.Data.SqlClient.SqlDataAdapter" /> class with the specified <see cref="T:System.Data.SqlClient.SqlCommand" /> as the <see cref="P:System.Data.SqlClient.SqlDataAdapter.SelectCommand" /> property.</summary>
+      <param name="selectCommand">A <see cref="T:System.Data.SqlClient.SqlCommand" /> that is a Transact-SQL SELECT statement or stored procedure and is set as the <see cref="P:System.Data.SqlClient.SqlDataAdapter.SelectCommand" /> property of the <see cref="T:System.Data.SqlClient.SqlDataAdapter" />.</param>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataAdapter.#ctor(System.String,System.Data.SqlClient.SqlConnection)">
+      <summary>Initializes a new instance of the <see cref="T:System.Data.SqlClient.SqlDataAdapter" /> class with a <see cref="P:System.Data.SqlClient.SqlDataAdapter.SelectCommand" /> and a <see cref="T:System.Data.SqlClient.SqlConnection" /> object.</summary>
+      <param name="selectCommandText">A <see cref="T:System.String" /> that is a Transact-SQL SELECT statement or stored procedure to be used by the <see cref="P:System.Data.SqlClient.SqlDataAdapter.SelectCommand" /> property of the <see cref="T:System.Data.SqlClient.SqlDataAdapter" />.</param>
+      <param name="selectConnection">A <see cref="T:System.Data.SqlClient.SqlConnection" /> that represents the connection. If your connection string does not use <see langword="Integrated Security = true" />, you can use <see cref="T:System.Data.SqlClient.SqlCredential" /> to pass the user ID and password more securely than by specifying the user ID and password as text in the connection string.</param>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataAdapter.#ctor(System.String,System.String)">
+      <summary>Initializes a new instance of the <see cref="T:System.Data.SqlClient.SqlDataAdapter" /> class with a <see cref="P:System.Data.SqlClient.SqlDataAdapter.SelectCommand" /> and a connection string.</summary>
+      <param name="selectCommandText">A <see cref="T:System.String" /> that is a Transact-SQL SELECT statement or stored procedure to be used by the <see cref="P:System.Data.SqlClient.SqlDataAdapter.SelectCommand" /> property of the <see cref="T:System.Data.SqlClient.SqlDataAdapter" />.</param>
+      <param name="selectConnectionString">The connection string. If your connection string does not use <see langword="Integrated Security = true" />, you can use <see cref="M:System.Data.SqlClient.SqlDataAdapter.#ctor(System.String,System.Data.SqlClient.SqlConnection)" /> and <see cref="T:System.Data.SqlClient.SqlCredential" /> to pass the user ID and password more securely than by specifying the user ID and password as text in the connection string.</param>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlDataAdapter.DeleteCommand">
+      <summary>Gets or sets a Transact-SQL statement or stored procedure to delete records from the data set.</summary>
+      <returns>A <see cref="T:System.Data.SqlClient.SqlCommand" /> used during <see cref="M:System.Data.Common.DbDataAdapter.Update(System.Data.DataSet)" /> to delete records in the database that correspond to deleted rows in the <see cref="T:System.Data.DataSet" />.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlDataAdapter.InsertCommand">
+      <summary>Gets or sets a Transact-SQL statement or stored procedure to insert new records into the data source.</summary>
+      <returns>A <see cref="T:System.Data.SqlClient.SqlCommand" /> used during <see cref="M:System.Data.Common.DbDataAdapter.Update(System.Data.DataSet)" /> to insert records into the database that correspond to new rows in the <see cref="T:System.Data.DataSet" />.</returns>
+    </member>
+    <member name="E:System.Data.SqlClient.SqlDataAdapter.RowUpdated">
+      <summary>Occurs during <see cref="M:System.Data.Common.DbDataAdapter.Update(System.Data.DataSet)" /> after a command is executed against the data source. The attempt to update is made, so the event fires.</summary>
+    </member>
+    <member name="E:System.Data.SqlClient.SqlDataAdapter.RowUpdating">
+      <summary>Occurs during <see cref="M:System.Data.Common.DbDataAdapter.Update(System.Data.DataSet)" /> before a command is executed against the data source. The attempt to update is made, so the event fires.</summary>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlDataAdapter.SelectCommand">
+      <summary>Gets or sets a Transact-SQL statement or stored procedure used to select records in the data source.</summary>
+      <returns>A <see cref="T:System.Data.SqlClient.SqlCommand" /> used during <see cref="M:System.Data.Common.DbDataAdapter.Fill(System.Data.DataSet)" /> to select records from the database for placement in the <see cref="T:System.Data.DataSet" />.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlDataAdapter.System#Data#IDbDataAdapter#DeleteCommand">
+      <summary>For a description of this member, see <see cref="P:System.Data.IDbDataAdapter.DeleteCommand" />.</summary>
+      <returns>An <see cref="T:System.Data.IDbCommand" /> that is used during <see cref="M:System.Data.Common.DbDataAdapter.Update(System.Data.DataSet)" /> to delete records in the data source for deleted rows in the data set.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlDataAdapter.System#Data#IDbDataAdapter#InsertCommand">
+      <summary>For a description of this member, see <see cref="P:System.Data.IDbDataAdapter.InsertCommand" />.</summary>
+      <returns>An <see cref="T:System.Data.IDbCommand" /> that is used during <see cref="M:System.Data.Common.DbDataAdapter.Update(System.Data.DataSet)" /> to insert records in the data source for new rows in the data set.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlDataAdapter.System#Data#IDbDataAdapter#SelectCommand">
+      <summary>For a description of this member, see <see cref="P:System.Data.IDbDataAdapter.SelectCommand" />.</summary>
+      <returns>An <see cref="T:System.Data.IDbCommand" /> that is used during <see cref="M:System.Data.Common.DbDataAdapter.Update(System.Data.DataSet)" /> to select records from data source for placement in the data set.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlDataAdapter.System#Data#IDbDataAdapter#UpdateCommand">
+      <summary>For a description of this member, see <see cref="P:System.Data.IDbDataAdapter.UpdateCommand" />.</summary>
+      <returns>An <see cref="T:System.Data.IDbCommand" /> that is used during <see cref="M:System.Data.Common.DbDataAdapter.Update(System.Data.DataSet)" /> to update records in the data source for modified rows in the data set.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataAdapter.System#ICloneable#Clone">
+      <summary>For a description of this member, see <see cref="M:System.ICloneable.Clone" />.</summary>
+      <returns>A new object that is a copy of the current instance.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlDataAdapter.UpdateBatchSize">
+      <summary>Gets or sets the number of rows that are processed in each round-trip to the server.</summary>
+      <returns>The number of rows to process per-batch.
+  Value is  
+  
+  Effect  
+  
+  0  
+  
+  There is no limit on the batch size. 
+  
+  1  
+  
+  Disables batch updating.  
+  
+  &gt;1  
+  
+  Changes are sent using batches of <see cref="P:System.Data.SqlClient.SqlDataAdapter.UpdateBatchSize" /> operations at a time.  
+  
+   
+When setting this to a value other than 1, all the commands associated with the <see cref="T:System.Data.SqlClient.SqlDataAdapter" /> have to have their UpdatedRowSource property set to <see langword="None" /> or <see langword="OutputParameters" />. An exception is thrown otherwise.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlDataAdapter.UpdateCommand">
+      <summary>Gets or sets a Transact-SQL statement or stored procedure used to update records in the data source.</summary>
+      <returns>A <see cref="T:System.Data.SqlClient.SqlCommand" /> used during <see cref="M:System.Data.Common.DbDataAdapter.Update(System.Data.DataSet)" /> to update records in the database that correspond to modified rows in the <see cref="T:System.Data.DataSet" />.</returns>
+    </member>
+    <member name="T:System.Data.SqlClient.SqlDataReader">
+      <summary>Provides a way of reading a forward-only stream of rows from a SQL Server database. This class cannot be inherited.</summary>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlDataReader.Connection">
+      <summary>Gets the <see cref="T:System.Data.SqlClient.SqlConnection" /> associated with the <see cref="T:System.Data.SqlClient.SqlDataReader" />.</summary>
+      <returns>The <see cref="T:System.Data.SqlClient.SqlConnection" /> associated with the <see cref="T:System.Data.SqlClient.SqlDataReader" />.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlDataReader.Depth">
+      <summary>Gets a value that indicates the depth of nesting for the current row.</summary>
+      <returns>The depth of nesting for the current row.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlDataReader.FieldCount">
+      <summary>Gets the number of columns in the current row.</summary>
+      <returns>When not positioned in a valid recordset, 0; otherwise the number of columns in the current row. The default is -1.</returns>
+      <exception cref="T:System.NotSupportedException">There is no current connection to an instance of SQL Server.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetBoolean(System.Int32)">
+      <summary>Gets the value of the specified column as a Boolean.</summary>
+      <param name="i">The zero-based column ordinal.</param>
+      <returns>The value of the column.</returns>
+      <exception cref="T:System.InvalidCastException">The specified cast is not valid.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetByte(System.Int32)">
+      <summary>Gets the value of the specified column as a byte.</summary>
+      <param name="i">The zero-based column ordinal.</param>
+      <returns>The value of the specified column as a byte.</returns>
+      <exception cref="T:System.InvalidCastException">The specified cast is not valid.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetBytes(System.Int32,System.Int64,System.Byte[],System.Int32,System.Int32)">
+      <summary>Reads a stream of bytes from the specified column offset into the buffer an array starting at the given buffer offset.</summary>
+      <param name="i">The zero-based column ordinal.</param>
+      <param name="dataIndex">The index within the field from which to begin the read operation.</param>
+      <param name="buffer">The buffer into which to read the stream of bytes.</param>
+      <param name="bufferIndex">The index within the <paramref name="buffer" /> where the write operation is to start.</param>
+      <param name="length">The maximum length to copy into the buffer.</param>
+      <returns>The actual number of bytes read.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetChar(System.Int32)">
+      <summary>Gets the value of the specified column as a single character.</summary>
+      <param name="i">The zero-based column ordinal.</param>
+      <returns>The value of the specified column.</returns>
+      <exception cref="T:System.InvalidCastException">The specified cast is not valid.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetChars(System.Int32,System.Int64,System.Char[],System.Int32,System.Int32)">
+      <summary>Reads a stream of characters from the specified column offset into the buffer as an array starting at the given buffer offset.</summary>
+      <param name="i">The zero-based column ordinal.</param>
+      <param name="dataIndex">The index within the field from which to begin the read operation.</param>
+      <param name="buffer">The buffer into which to read the stream of bytes.</param>
+      <param name="bufferIndex">The index within the <paramref name="buffer" /> where the write operation is to start.</param>
+      <param name="length">The maximum length to copy into the buffer.</param>
+      <returns>The actual number of characters read.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetColumnSchema" />
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetDataTypeName(System.Int32)">
+      <summary>Gets a string representing the data type of the specified column.</summary>
+      <param name="i">The zero-based ordinal position of the column to find.</param>
+      <returns>The string representing the data type of the specified column.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetDateTime(System.Int32)">
+      <summary>Gets the value of the specified column as a <see cref="T:System.DateTime" /> object.</summary>
+      <param name="i">The zero-based column ordinal.</param>
+      <returns>The value of the specified column.</returns>
+      <exception cref="T:System.InvalidCastException">The specified cast is not valid.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetDateTimeOffset(System.Int32)">
+      <summary>Retrieves the value of the specified column as a <see cref="T:System.DateTimeOffset" /> object.</summary>
+      <param name="i">The zero-based column ordinal.</param>
+      <returns>The value of the specified column.</returns>
+      <exception cref="T:System.InvalidCastException">The specified cast is not valid.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetDecimal(System.Int32)">
+      <summary>Gets the value of the specified column as a <see cref="T:System.Decimal" /> object.</summary>
+      <param name="i">The zero-based column ordinal.</param>
+      <returns>The value of the specified column.</returns>
+      <exception cref="T:System.InvalidCastException">The specified cast is not valid.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetDouble(System.Int32)">
+      <summary>Gets the value of the specified column as a double-precision floating point number.</summary>
+      <param name="i">The zero-based column ordinal.</param>
+      <returns>The value of the specified column.</returns>
+      <exception cref="T:System.InvalidCastException">The specified cast is not valid.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetEnumerator">
+      <summary>Returns an <see cref="T:System.Collections.IEnumerator" /> that iterates through the <see cref="T:System.Data.SqlClient.SqlDataReader" />.</summary>
+      <returns>An <see cref="T:System.Collections.IEnumerator" /> for the <see cref="T:System.Data.SqlClient.SqlDataReader" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetFieldType(System.Int32)">
+      <summary>Gets the <see cref="T:System.Type" /> that is the data type of the object.</summary>
+      <param name="i">The zero-based column ordinal.</param>
+      <returns>The <see cref="T:System.Type" /> that is the data type of the object. If the type does not exist on the client, in the case of a User-Defined Type (UDT) returned from the database, GetFieldType returns null.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetFieldValue``1(System.Int32)">
+      <summary>Synchronously gets the value of the specified column as a type. <see cref="M:System.Data.SqlClient.SqlDataReader.GetFieldValueAsync``1(System.Int32,System.Threading.CancellationToken)" /> is the asynchronous version of this method.</summary>
+      <param name="i">The column to be retrieved.</param>
+      <typeparam name="T">The type of the value to be returned.</typeparam>
+      <returns>The returned type object.</returns>
+      <exception cref="T:System.InvalidOperationException">The connection drops or is closed during the data retrieval.
+The <see cref="T:System.Data.SqlClient.SqlDataReader" /> is closed during the data retrieval.
+There is no data ready to be read (for example, the first <see cref="M:System.Data.SqlClient.SqlDataReader.Read" /> hasn't been called, or returned false).
+Tried to read a previously-read column in sequential mode.
+There was an asynchronous operation in progress. This applies to all Get* methods when running in sequential mode, as they could be called while reading a stream.</exception>
+      <exception cref="T:System.IndexOutOfRangeException">Trying to read a column that does not exist.</exception>
+      <exception cref="T:System.Data.SqlTypes.SqlNullValueException">The value of the column was null (<see cref="M:System.Data.SqlClient.SqlDataReader.IsDBNull(System.Int32)" /> == <see langword="true" />), retrieving a non-SQL type.</exception>
+      <exception cref="T:System.InvalidCastException">
+        <paramref name="T" /> doesn't match the type returned by SQL Server or cannot be cast.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetFieldValueAsync``1(System.Int32,System.Threading.CancellationToken)">
+      <summary>Asynchronously gets the value of the specified column as a type. <see cref="M:System.Data.SqlClient.SqlDataReader.GetFieldValue``1(System.Int32)" /> is the synchronous version of this method.</summary>
+      <param name="i">The column to be retrieved.</param>
+      <param name="cancellationToken">The cancellation instruction, which propagates a notification that operations should be canceled. This does not guarantee the cancellation. A setting of <see langword="CancellationToken.None" /> makes this method equivalent to <see cref="M:System.Data.SqlClient.SqlDataReader.IsDBNull(System.Int32)" />. The returned task must be marked as cancelled.</param>
+      <typeparam name="T">The type of the value to be returned.</typeparam>
+      <returns>The returned type object.</returns>
+      <exception cref="T:System.InvalidOperationException">The connection drops or is closed during the data retrieval.
+The <see cref="T:System.Data.SqlClient.SqlDataReader" /> is closed during the data retrieval.
+There is no data ready to be read (for example, the first <see cref="M:System.Data.SqlClient.SqlDataReader.Read" /> hasn't been called, or returned false).
+Tried to read a previously-read column in sequential mode.
+There was an asynchronous operation in progress. This applies to all Get* methods when running in sequential mode, as they could be called while reading a stream.
+<see langword="Context Connection=true" /> is specified in the connection string.</exception>
+      <exception cref="T:System.IndexOutOfRangeException">Trying to read a column that does not exist.</exception>
+      <exception cref="T:System.Data.SqlTypes.SqlNullValueException">The value of the column was null (<see cref="M:System.Data.SqlClient.SqlDataReader.IsDBNull(System.Int32)" /> == <see langword="true" />), retrieving a non-SQL type.</exception>
+      <exception cref="T:System.InvalidCastException">
+        <paramref name="T" /> doesn't match the type returned by SQL Server or cannot be cast.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetFloat(System.Int32)">
+      <summary>Gets the value of the specified column as a single-precision floating point number.</summary>
+      <param name="i">The zero-based column ordinal.</param>
+      <returns>The value of the specified column.</returns>
+      <exception cref="T:System.InvalidCastException">The specified cast is not valid.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetGuid(System.Int32)">
+      <summary>Gets the value of the specified column as a globally unique identifier (GUID).</summary>
+      <param name="i">The zero-based column ordinal.</param>
+      <returns>The value of the specified column.</returns>
+      <exception cref="T:System.InvalidCastException">The specified cast is not valid.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetInt16(System.Int32)">
+      <summary>Gets the value of the specified column as a 16-bit signed integer.</summary>
+      <param name="i">The zero-based column ordinal.</param>
+      <returns>The value of the specified column.</returns>
+      <exception cref="T:System.InvalidCastException">The specified cast is not valid.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetInt32(System.Int32)">
+      <summary>Gets the value of the specified column as a 32-bit signed integer.</summary>
+      <param name="i">The zero-based column ordinal.</param>
+      <returns>The value of the specified column.</returns>
+      <exception cref="T:System.InvalidCastException">The specified cast is not valid.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetInt64(System.Int32)">
+      <summary>Gets the value of the specified column as a 64-bit signed integer.</summary>
+      <param name="i">The zero-based column ordinal.</param>
+      <returns>The value of the specified column.</returns>
+      <exception cref="T:System.InvalidCastException">The specified cast is not valid.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetName(System.Int32)">
+      <summary>Gets the name of the specified column.</summary>
+      <param name="i">The zero-based column ordinal.</param>
+      <returns>The name of the specified column.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetOrdinal(System.String)">
+      <summary>Gets the column ordinal, given the name of the column.</summary>
+      <param name="name">The name of the column.</param>
+      <returns>The zero-based column ordinal.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The name specified is not a valid column name.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetProviderSpecificFieldType(System.Int32)">
+      <summary>Gets an <see langword="Object" /> that is a representation of the underlying provider-specific field type.</summary>
+      <param name="i">An <see cref="T:System.Int32" /> representing the column ordinal.</param>
+      <returns>Gets an <see cref="T:System.Object" /> that is a representation of the underlying provider-specific field type.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetProviderSpecificValue(System.Int32)">
+      <summary>Gets an <see langword="Object" /> that is a representation of the underlying provider specific value.</summary>
+      <param name="i">An <see cref="T:System.Int32" /> representing the column ordinal.</param>
+      <returns>An <see cref="T:System.Object" /> that is a representation of the underlying provider specific value.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetProviderSpecificValues(System.Object[])">
+      <summary>Gets an array of objects that are a representation of the underlying provider specific values.</summary>
+      <param name="values">An array of <see cref="T:System.Object" /> into which to copy the column values.</param>
+      <returns>The array of objects that are a representation of the underlying provider specific values.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetSchemaTable">
+      <summary>Returns a <see cref="T:System.Data.DataTable" /> that describes the column metadata of the <see cref="T:System.Data.SqlClient.SqlDataReader" />.</summary>
+      <returns>A <see cref="T:System.Data.DataTable" /> that describes the column metadata.</returns>
+      <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Data.SqlClient.SqlDataReader" /> is closed.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetSqlBinary(System.Int32)">
+      <summary>Gets the value of the specified column as a <see cref="T:System.Data.SqlTypes.SqlBinary" />.</summary>
+      <param name="i">The zero-based column ordinal.</param>
+      <returns>The value of the column expressed as a <see cref="T:System.Data.SqlTypes.SqlBinary" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetSqlBoolean(System.Int32)">
+      <summary>Gets the value of the specified column as a <see cref="T:System.Data.SqlTypes.SqlBoolean" />.</summary>
+      <param name="i">The zero-based column ordinal.</param>
+      <returns>The value of the column.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetSqlByte(System.Int32)">
+      <summary>Gets the value of the specified column as a <see cref="T:System.Data.SqlTypes.SqlByte" />.</summary>
+      <param name="i">The zero-based column ordinal.</param>
+      <returns>The value of the column expressed as a  <see cref="T:System.Data.SqlTypes.SqlByte" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetSqlBytes(System.Int32)">
+      <summary>Gets the value of the specified column as <see cref="T:System.Data.SqlTypes.SqlBytes" />.</summary>
+      <param name="i">The zero-based column ordinal.</param>
+      <returns>The value of the column expressed as a <see cref="T:System.Data.SqlTypes.SqlBytes" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetSqlChars(System.Int32)">
+      <summary>Gets the value of the specified column as <see cref="T:System.Data.SqlTypes.SqlChars" />.</summary>
+      <param name="i">The zero-based column ordinal.</param>
+      <returns>The value of the column expressed as a  <see cref="T:System.Data.SqlTypes.SqlChars" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetSqlDateTime(System.Int32)">
+      <summary>Gets the value of the specified column as a <see cref="T:System.Data.SqlTypes.SqlDateTime" />.</summary>
+      <param name="i">The zero-based column ordinal.</param>
+      <returns>The value of the column expressed as a  <see cref="T:System.Data.SqlTypes.SqlDateTime" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetSqlDecimal(System.Int32)">
+      <summary>Gets the value of the specified column as a <see cref="T:System.Data.SqlTypes.SqlDecimal" />.</summary>
+      <param name="i">The zero-based column ordinal.</param>
+      <returns>The value of the column expressed as a <see cref="T:System.Data.SqlTypes.SqlDecimal" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetSqlDouble(System.Int32)">
+      <summary>Gets the value of the specified column as a <see cref="T:System.Data.SqlTypes.SqlDouble" />.</summary>
+      <param name="i">The zero-based column ordinal.</param>
+      <returns>The value of the column expressed as a  <see cref="T:System.Data.SqlTypes.SqlDouble" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetSqlGuid(System.Int32)">
+      <summary>Gets the value of the specified column as a <see cref="T:System.Data.SqlTypes.SqlGuid" />.</summary>
+      <param name="i">The zero-based column ordinal.</param>
+      <returns>The value of the column expressed as a  <see cref="T:System.Data.SqlTypes.SqlGuid" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetSqlInt16(System.Int32)">
+      <summary>Gets the value of the specified column as a <see cref="T:System.Data.SqlTypes.SqlInt16" />.</summary>
+      <param name="i">The zero-based column ordinal.</param>
+      <returns>The value of the column expressed as a <see cref="T:System.Data.SqlTypes.SqlInt16" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetSqlInt32(System.Int32)">
+      <summary>Gets the value of the specified column as a <see cref="T:System.Data.SqlTypes.SqlInt32" />.</summary>
+      <param name="i">The zero-based column ordinal.</param>
+      <returns>The value of the column expressed as a <see cref="T:System.Data.SqlTypes.SqlInt32" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetSqlInt64(System.Int32)">
+      <summary>Gets the value of the specified column as a <see cref="T:System.Data.SqlTypes.SqlInt64" />.</summary>
+      <param name="i">The zero-based column ordinal.</param>
+      <returns>The value of the column expressed as a <see cref="T:System.Data.SqlTypes.SqlInt64" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetSqlMoney(System.Int32)">
+      <summary>Gets the value of the specified column as a <see cref="T:System.Data.SqlTypes.SqlMoney" />.</summary>
+      <param name="i">The zero-based column ordinal.</param>
+      <returns>The value of the column expressed as a <see cref="T:System.Data.SqlTypes.SqlMoney" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetSqlSingle(System.Int32)">
+      <summary>Gets the value of the specified column as a <see cref="T:System.Data.SqlTypes.SqlSingle" />.</summary>
+      <param name="i">The zero-based column ordinal.</param>
+      <returns>The value of the column expressed as a <see cref="T:System.Data.SqlTypes.SqlSingle" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetSqlString(System.Int32)">
+      <summary>Gets the value of the specified column as a <see cref="T:System.Data.SqlTypes.SqlString" />.</summary>
+      <param name="i">The zero-based column ordinal.</param>
+      <returns>The value of the column expressed as a <see cref="T:System.Data.SqlTypes.SqlString" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetSqlValue(System.Int32)">
+      <summary>Returns the data value in the specified column as a SQL Server type.</summary>
+      <param name="i">The zero-based column ordinal.</param>
+      <returns>The value of the column expressed as a <see cref="T:System.Data.SqlDbType" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetSqlValues(System.Object[])">
+      <summary>Fills an array of <see cref="T:System.Object" /> that contains the values for all the columns in the record, expressed as SQL Server types.</summary>
+      <param name="values">An array of <see cref="T:System.Object" /> into which to copy the values. The column values are expressed as SQL Server types.</param>
+      <returns>An integer indicating the number of columns copied.</returns>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="values" /> is null.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetSqlXml(System.Int32)">
+      <summary>Gets the value of the specified column as an XML value.</summary>
+      <param name="i">The zero-based column ordinal.</param>
+      <returns>A <see cref="T:System.Data.SqlTypes.SqlXml" /> value that contains the XML stored within the corresponding field.</returns>
+      <exception cref="T:System.ArgumentOutOfRangeException">The index passed was outside the range of 0 to <see cref="P:System.Data.DataTableReader.FieldCount" /> - 1</exception>
+      <exception cref="T:System.InvalidOperationException">An attempt was made to read or access columns in a closed <see cref="T:System.Data.SqlClient.SqlDataReader" />.</exception>
+      <exception cref="T:System.InvalidCastException">The retrieved data is not compatible with the <see cref="T:System.Data.SqlTypes.SqlXml" /> type.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetStream(System.Int32)">
+      <summary>Retrieves binary, image, varbinary, UDT, and variant data types as a <see cref="T:System.IO.Stream" />.</summary>
+      <param name="i">The zero-based column ordinal.</param>
+      <returns>A stream object.</returns>
+      <exception cref="T:System.InvalidOperationException">The connection drops or is closed during the data retrieval.
+The <see cref="T:System.Data.SqlClient.SqlDataReader" /> is closed during the data retrieval.
+There is no data ready to be read (for example, the first <see cref="M:System.Data.SqlClient.SqlDataReader.Read" /> hasn't been called, or returned false).
+Tried to read a previously-read column in sequential mode.
+There was an asynchronous operation in progress. This applies to all Get* methods when running in sequential mode, as they could be called while reading a stream.</exception>
+      <exception cref="T:System.IndexOutOfRangeException">Trying to read a column that does not exist.</exception>
+      <exception cref="T:System.InvalidCastException">The returned type was not one of the types below:
+
+binary
+
+image
+
+varbinary
+
+udt</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetString(System.Int32)">
+      <summary>Gets the value of the specified column as a string.</summary>
+      <param name="i">The zero-based column ordinal.</param>
+      <returns>The value of the specified column.</returns>
+      <exception cref="T:System.InvalidCastException">The specified cast is not valid.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetTextReader(System.Int32)">
+      <summary>Retrieves Char, NChar, NText, NVarChar, text, varChar, and Variant data types as a <see cref="T:System.IO.TextReader" />.</summary>
+      <param name="i">The column to be retrieved.</param>
+      <returns>The returned object.</returns>
+      <exception cref="T:System.InvalidOperationException">The connection drops or is closed during the data retrieval.
+The <see cref="T:System.Data.SqlClient.SqlDataReader" /> is closed during the data retrieval.
+There is no data ready to be read (for example, the first <see cref="M:System.Data.SqlClient.SqlDataReader.Read" /> hasn't been called, or returned false).
+Tried to read a previously-read column in sequential mode.
+There was an asynchronous operation in progress. This applies to all Get* methods when running in sequential mode, as they could be called while reading a stream.</exception>
+      <exception cref="T:System.IndexOutOfRangeException">Trying to read a column that does not exist.</exception>
+      <exception cref="T:System.InvalidCastException">The returned type was not one of the types below:
+
+char
+
+nchar
+
+ntext
+
+nvarchar
+
+text
+
+varchar</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetTimeSpan(System.Int32)">
+      <summary>Retrieves the value of the specified column as a <see cref="T:System.TimeSpan" /> object.</summary>
+      <param name="i">The zero-based column ordinal.</param>
+      <returns>The value of the specified column.</returns>
+      <exception cref="T:System.InvalidCastException">The specified cast is not valid.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetValue(System.Int32)">
+      <summary>Gets the value of the specified column in its native format.</summary>
+      <param name="i">The zero-based column ordinal.</param>
+      <returns>This method returns <see cref="T:System.DBNull" /> for null database columns.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetValues(System.Object[])">
+      <summary>Populates an array of objects with the column values of the current row.</summary>
+      <param name="values">An array of <see cref="T:System.Object" /> into which to copy the attribute columns.</param>
+      <returns>The number of instances of <see cref="T:System.Object" /> in the array.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.GetXmlReader(System.Int32)">
+      <summary>Retrieves data of type XML as an <see cref="T:System.Xml.XmlReader" />.</summary>
+      <param name="i">The value of the specified column.</param>
+      <returns>The returned object.</returns>
+      <exception cref="T:System.InvalidOperationException">The connection drops or is closed during the data retrieval.
+The <see cref="T:System.Data.SqlClient.SqlDataReader" /> is closed during the data retrieval.
+There is no data ready to be read (for example, the first <see cref="M:System.Data.SqlClient.SqlDataReader.Read" /> hasn't been called, or returned false).
+Trying to read a previously read column in sequential mode.
+There was an asynchronous operation in progress. This applies to all Get* methods when running in sequential mode, as they could be called while reading a stream.</exception>
+      <exception cref="T:System.IndexOutOfRangeException">Trying to read a column that does not exist.</exception>
+      <exception cref="T:System.InvalidCastException">The returned type was not xml.</exception>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlDataReader.HasRows">
+      <summary>Gets a value that indicates whether the <see cref="T:System.Data.SqlClient.SqlDataReader" /> contains one or more rows.</summary>
+      <returns>
+        <see langword="true" /> if the <see cref="T:System.Data.SqlClient.SqlDataReader" /> contains one or more rows; otherwise <see langword="false" />.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlDataReader.IsClosed">
+      <summary>Retrieves a Boolean value that indicates whether the specified <see cref="T:System.Data.SqlClient.SqlDataReader" /> instance has been closed.</summary>
+      <returns>
+        <see langword="true" /> if the specified <see cref="T:System.Data.SqlClient.SqlDataReader" /> instance is closed; otherwise <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.IsCommandBehavior(System.Data.CommandBehavior)">
+      <summary>Determines whether the specified <see cref="T:System.Data.CommandBehavior" /> matches that of the <see cref="T:System.Data.SqlClient.SqlDataReader" /> .</summary>
+      <param name="condition">A <see cref="T:System.Data.CommandBehavior" /> enumeration.</param>
+      <returns>
+        <see langword="true" /> if the specified <see cref="T:System.Data.CommandBehavior" /> is true, <see langword="false" /> otherwise.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.IsDBNull(System.Int32)">
+      <summary>Gets a value that indicates whether the column contains non-existent or missing values.</summary>
+      <param name="i">The zero-based column ordinal.</param>
+      <returns>
+        <see langword="true" /> if the specified column value is equivalent to <see cref="T:System.DBNull" />; otherwise <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.IsDBNullAsync(System.Int32,System.Threading.CancellationToken)">
+      <summary>An asynchronous version of <see cref="M:System.Data.SqlClient.SqlDataReader.IsDBNull(System.Int32)" />, which gets a value that indicates whether the column contains non-existent or missing values.
+The cancellation token can be used to request that the operation be abandoned before the command timeout elapses. Exceptions will be reported via the returned Task object.</summary>
+      <param name="i">The zero-based column to be retrieved.</param>
+      <param name="cancellationToken">The cancellation instruction, which propagates a notification that operations should be canceled. This does not guarantee the cancellation. A setting of <see langword="CancellationToken.None" /> makes this method equivalent to <see cref="M:System.Data.SqlClient.SqlDataReader.IsDBNull(System.Int32)" />. The returned task must be marked as cancelled.</param>
+      <returns>
+        <see langword="true" /> if the specified column value is equivalent to <see langword="DBNull" /> otherwise <see langword="false" />.</returns>
+      <exception cref="T:System.InvalidOperationException">The connection drops or is closed during the data retrieval.
+The <see cref="T:System.Data.SqlClient.SqlDataReader" /> is closed during the data retrieval.
+There is no data ready to be read (for example, the first <see cref="M:System.Data.SqlClient.SqlDataReader.Read" /> hasn't been called, or returned false).
+Trying to read a previously read column in sequential mode.
+There was an asynchronous operation in progress. This applies to all Get* methods when running in sequential mode, as they could be called while reading a stream.
+<see langword="Context Connection=true" /> is specified in the connection string.</exception>
+      <exception cref="T:System.IndexOutOfRangeException">Trying to read a column that does not exist.</exception>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlDataReader.Item(System.Int32)">
+      <summary>Gets the value of the specified column in its native format given the column ordinal.</summary>
+      <param name="i">The zero-based column ordinal.</param>
+      <returns>The value of the specified column in its native format.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The index passed was outside the range of 0 through <see cref="P:System.Data.IDataRecord.FieldCount" />.</exception>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlDataReader.Item(System.String)">
+      <summary>Gets the value of the specified column in its native format given the column name.</summary>
+      <param name="name">The column name.</param>
+      <returns>The value of the specified column in its native format.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">No column with the specified name was found.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.NextResult">
+      <summary>Advances the data reader to the next result, when reading the results of batch Transact-SQL statements.</summary>
+      <returns>
+        <see langword="true" /> if there are more result sets; otherwise <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.NextResultAsync(System.Threading.CancellationToken)">
+      <summary>An asynchronous version of <see cref="M:System.Data.SqlClient.SqlDataReader.NextResult" />, which advances the data reader to the next result, when reading the results of batch Transact-SQL statements.
+The cancellation token can be used to request that the operation be abandoned before the command timeout elapses.  Exceptions will be reported via the returned Task object.</summary>
+      <param name="cancellationToken">The cancellation instruction.</param>
+      <returns>A task representing the asynchronous operation.</returns>
+      <exception cref="T:System.InvalidOperationException">Calling <see cref="M:System.Data.SqlClient.SqlDataReader.NextResultAsync(System.Threading.CancellationToken)" /> more than once for the same instance before task completion.
+<see langword="Context Connection=true" /> is specified in the connection string.</exception>
+      <exception cref="T:System.Data.SqlClient.SqlException">SQL Server returned an error while executing the command text.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.Read">
+      <summary>Advances the <see cref="T:System.Data.SqlClient.SqlDataReader" /> to the next record.</summary>
+      <returns>
+        <see langword="true" /> if there are more rows; otherwise <see langword="false" />.</returns>
+      <exception cref="T:System.Data.SqlClient.SqlException">SQL Server returned an error while executing the command text.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDataReader.ReadAsync(System.Threading.CancellationToken)">
+      <summary>An asynchronous version of <see cref="M:System.Data.SqlClient.SqlDataReader.Read" />, which advances the <see cref="T:System.Data.SqlClient.SqlDataReader" /> to the next record.
+The cancellation token can be used to request that the operation be abandoned before the command timeout elapses. Exceptions will be reported via the returned Task object.</summary>
+      <param name="cancellationToken">The cancellation instruction.</param>
+      <returns>A task representing the asynchronous operation.</returns>
+      <exception cref="T:System.InvalidOperationException">Calling <see cref="M:System.Data.SqlClient.SqlDataReader.ReadAsync(System.Threading.CancellationToken)" /> more than once for the same instance before task completion.
+<see langword="Context Connection=true" /> is specified in the connection string.</exception>
+      <exception cref="T:System.Data.SqlClient.SqlException">SQL Server returned an error while executing the command text.</exception>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlDataReader.RecordsAffected">
+      <summary>Gets the number of rows changed, inserted, or deleted by execution of the Transact-SQL statement.</summary>
+      <returns>The number of rows changed, inserted, or deleted; 0 if no rows were affected or the statement failed; and -1 for SELECT statements.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlDataReader.VisibleFieldCount">
+      <summary>Gets the number of fields in the <see cref="T:System.Data.SqlClient.SqlDataReader" /> that are not hidden.</summary>
+      <returns>The number of fields that are not hidden.</returns>
+    </member>
+    <member name="T:System.Data.SqlClient.SqlDependency">
+      <summary>The <see cref="T:System.Data.SqlClient.SqlDependency" /> object represents a query notification dependency between an application and an instance of SQL Server. An application can create a <see cref="T:System.Data.SqlClient.SqlDependency" /> object and register to receive notifications via the <see cref="T:System.Data.SqlClient.OnChangeEventHandler" /> event handler.</summary>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDependency.#ctor">
+      <summary>Creates a new instance of the <see cref="T:System.Data.SqlClient.SqlDependency" /> class with the default settings.</summary>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDependency.#ctor(System.Data.SqlClient.SqlCommand)">
+      <summary>Creates a new instance of the <see cref="T:System.Data.SqlClient.SqlDependency" /> class and associates it with the <see cref="T:System.Data.SqlClient.SqlCommand" /> parameter.</summary>
+      <param name="command">The <see cref="T:System.Data.SqlClient.SqlCommand" /> object to associate with this <see cref="T:System.Data.SqlClient.SqlDependency" /> object. The constructor will set up a <see cref="T:System.Data.Sql.SqlNotificationRequest" /> object and bind it to the command.</param>
+      <exception cref="T:System.ArgumentNullException">The <paramref name="command" /> parameter is NULL.</exception>
+      <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Data.SqlClient.SqlCommand" /> object already has a <see cref="T:System.Data.Sql.SqlNotificationRequest" /> object assigned to its <see cref="P:System.Data.SqlClient.SqlCommand.Notification" /> property, and that <see cref="T:System.Data.Sql.SqlNotificationRequest" /> is not associated with this dependency.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDependency.#ctor(System.Data.SqlClient.SqlCommand,System.String,System.Int32)">
+      <summary>Creates a new instance of the <see cref="T:System.Data.SqlClient.SqlDependency" /> class, associates it with the <see cref="T:System.Data.SqlClient.SqlCommand" /> parameter, and specifies notification options and a time-out value.</summary>
+      <param name="command">The <see cref="T:System.Data.SqlClient.SqlCommand" /> object to associate with this <see cref="T:System.Data.SqlClient.SqlDependency" /> object. The constructor sets up a <see cref="T:System.Data.Sql.SqlNotificationRequest" /> object and bind it to the command.</param>
+      <param name="options">The notification request options to be used by this dependency. <see langword="null" /> to use the default service.</param>
+      <param name="timeout">The time-out for this notification in seconds. The default is 0, indicating that the server's time-out should be used.</param>
+      <exception cref="T:System.ArgumentNullException">The <paramref name="command" /> parameter is NULL.</exception>
+      <exception cref="T:System.ArgumentOutOfRangeException">The time-out value is less than zero.</exception>
+      <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Data.SqlClient.SqlCommand" /> object already has a <see cref="T:System.Data.Sql.SqlNotificationRequest" /> object assigned to its <see cref="P:System.Data.SqlClient.SqlCommand.Notification" /> property and that <see cref="T:System.Data.Sql.SqlNotificationRequest" /> is not associated with this dependency.
+An attempt was made to create a SqlDependency instance from within SQLCLR.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDependency.AddCommandDependency(System.Data.SqlClient.SqlCommand)">
+      <summary>Associates a <see cref="T:System.Data.SqlClient.SqlCommand" /> object with this <see cref="T:System.Data.SqlClient.SqlDependency" /> instance.</summary>
+      <param name="command">A <see cref="T:System.Data.SqlClient.SqlCommand" /> object containing a statement that is valid for notifications.</param>
+      <exception cref="T:System.ArgumentNullException">The <paramref name="command" /> parameter is null.</exception>
+      <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Data.SqlClient.SqlCommand" /> object already has a <see cref="T:System.Data.Sql.SqlNotificationRequest" /> object assigned to its <see cref="P:System.Data.SqlClient.SqlCommand.Notification" /> property, and that <see cref="T:System.Data.Sql.SqlNotificationRequest" /> is not associated with this dependency.</exception>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlDependency.HasChanges">
+      <summary>Gets a value that indicates whether one of the result sets associated with the dependency has changed.</summary>
+      <returns>A Boolean value indicating whether one of the result sets has changed.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlDependency.Id">
+      <summary>Gets a value that uniquely identifies this instance of the <see cref="T:System.Data.SqlClient.SqlDependency" /> class.</summary>
+      <returns>A string representation of a GUID that is generated for each instance of the <see cref="T:System.Data.SqlClient.SqlDependency" /> class.</returns>
+    </member>
+    <member name="E:System.Data.SqlClient.SqlDependency.OnChange">
+      <summary>Occurs when a notification is received for any of the commands associated with this <see cref="T:System.Data.SqlClient.SqlDependency" /> object.</summary>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDependency.Start(System.String)">
+      <summary>Starts the listener for receiving dependency change notifications from the instance of SQL Server specified by the connection string.</summary>
+      <param name="connectionString">The connection string for the instance of SQL Server from which to obtain change notifications.</param>
+      <returns>
+        <see langword="true" /> if the listener initialized successfully; <see langword="false" /> if a compatible listener already exists.</returns>
+      <exception cref="T:System.ArgumentNullException">The <paramref name="connectionString" /> parameter is NULL.</exception>
+      <exception cref="T:System.InvalidOperationException">The <paramref name="connectionString" /> parameter is the same as a previous call to this method, but the parameters are different.
+The method was called from within the CLR.</exception>
+      <exception cref="T:System.Security.SecurityException">The caller does not have the required <see cref="T:System.Data.SqlClient.SqlClientPermission" /> code access security (CAS) permission.</exception>
+      <exception cref="T:System.Data.SqlClient.SqlException">A subsequent call to the method has been made with an equivalent <paramref name="connectionString" /> parameter with a different user, or a user that does not default to the same schema.
+Also, any underlying SqlClient exceptions.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDependency.Start(System.String,System.String)">
+      <summary>Starts the listener for receiving dependency change notifications from the instance of SQL Server specified by the connection string using the specified SQL Server Service Broker queue.</summary>
+      <param name="connectionString">The connection string for the instance of SQL Server from which to obtain change notifications.</param>
+      <param name="queue">An existing SQL Server Service Broker queue to be used. If <see langword="null" />, the default queue is used.</param>
+      <returns>
+        <see langword="true" /> if the listener initialized successfully; <see langword="false" /> if a compatible listener already exists.</returns>
+      <exception cref="T:System.ArgumentNullException">The <paramref name="connectionString" /> parameter is NULL.</exception>
+      <exception cref="T:System.InvalidOperationException">The <paramref name="connectionString" /> parameter is the same as a previous call to this method, but the parameters are different.
+The method was called from within the CLR.</exception>
+      <exception cref="T:System.Security.SecurityException">The caller does not have the required <see cref="T:System.Data.SqlClient.SqlClientPermission" /> code access security (CAS) permission.</exception>
+      <exception cref="T:System.Data.SqlClient.SqlException">A subsequent call to the method has been made with an equivalent <paramref name="connectionString" /> parameter but a different user, or a user that does not default to the same schema.
+Also, any underlying SqlClient exceptions.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDependency.Stop(System.String)">
+      <summary>Stops a listener for a connection specified in a previous <see cref="Overload:System.Data.SqlClient.SqlDependency.Start" /> call.</summary>
+      <param name="connectionString">Connection string for the instance of SQL Server that was used in a previous <see cref="M:System.Data.SqlClient.SqlDependency.Start(System.String)" /> call.</param>
+      <returns>
+        <see langword="true" /> if the listener was completely stopped; <see langword="false" /> if the <see cref="T:System.AppDomain" /> was unbound from the listener, but there are is at least one other <see cref="T:System.AppDomain" /> using the same listener.</returns>
+      <exception cref="T:System.ArgumentNullException">The <paramref name="connectionString" /> parameter is NULL.</exception>
+      <exception cref="T:System.InvalidOperationException">The method was called from within SQLCLR.</exception>
+      <exception cref="T:System.Security.SecurityException">The caller does not have the required <see cref="T:System.Data.SqlClient.SqlClientPermission" /> code access security (CAS) permission.</exception>
+      <exception cref="T:System.Data.SqlClient.SqlException">An underlying SqlClient exception occurred.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlDependency.Stop(System.String,System.String)">
+      <summary>Stops a listener for a connection specified in a previous <see cref="Overload:System.Data.SqlClient.SqlDependency.Start" /> call.</summary>
+      <param name="connectionString">Connection string for the instance of SQL Server that was used in a previous <see cref="M:System.Data.SqlClient.SqlDependency.Start(System.String,System.String)" /> call.</param>
+      <param name="queue">The SQL Server Service Broker queue that was used in a previous <see cref="M:System.Data.SqlClient.SqlDependency.Start(System.String,System.String)" /> call.</param>
+      <returns>
+        <see langword="true" /> if the listener was completely stopped; <see langword="false" /> if the <see cref="T:System.AppDomain" /> was unbound from the listener, but there is at least one other <see cref="T:System.AppDomain" /> using the same listener.</returns>
+      <exception cref="T:System.ArgumentNullException">The <paramref name="connectionString" /> parameter is NULL.</exception>
+      <exception cref="T:System.InvalidOperationException">The method was called from within SQLCLR.</exception>
+      <exception cref="T:System.Security.SecurityException">The caller does not have the required <see cref="T:System.Data.SqlClient.SqlClientPermission" /> code access security (CAS) permission.</exception>
+      <exception cref="T:System.Data.SqlClient.SqlException">And underlying SqlClient exception occurred.</exception>
+    </member>
+    <member name="T:System.Data.SqlClient.SqlError">
+      <summary>Collects information relevant to a warning or error returned by SQL Server.</summary>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlError.Class">
+      <summary>Gets the severity level of the error returned from SQL Server.</summary>
+      <returns>A value from 1 to 25 that indicates the severity level of the error. The default is 0.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlError.LineNumber">
+      <summary>Gets the line number within the Transact-SQL command batch or stored procedure that contains the error.</summary>
+      <returns>The line number within the Transact-SQL command batch or stored procedure that contains the error.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlError.Message">
+      <summary>Gets the text describing the error.</summary>
+      <returns>The text describing the error. For more information on errors generated by SQL Server, see Database Engine Events and Errors.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlError.Number">
+      <summary>Gets a number that identifies the type of error.</summary>
+      <returns>The number that identifies the type of error.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlError.Procedure">
+      <summary>Gets the name of the stored procedure or remote procedure call (RPC) that generated the error.</summary>
+      <returns>The name of the stored procedure or RPC. For more information on errors generated by SQL Server, see Database Engine Events and Errors.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlError.Server">
+      <summary>Gets the name of the instance of SQL Server that generated the error.</summary>
+      <returns>The name of the instance of SQL Server.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlError.Source">
+      <summary>Gets the name of the provider that generated the error.</summary>
+      <returns>The name of the provider that generated the error.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlError.State">
+      <summary>Some error messages can be raised at multiple points in the code for the Database Engine. For example, an 1105 error can be raised for several different conditions. Each specific condition that raises an error assigns a unique state code.</summary>
+      <returns>The state code.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlError.ToString">
+      <summary>Gets the complete text of the error message.</summary>
+      <returns>The complete text of the error.</returns>
+    </member>
+    <member name="T:System.Data.SqlClient.SqlErrorCollection">
+      <summary>Collects all errors generated by the .NET Framework Data Provider for SQL Server. This class cannot be inherited.</summary>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlErrorCollection.CopyTo(System.Array,System.Int32)">
+      <summary>Copies the elements of the <see cref="T:System.Data.SqlClient.SqlErrorCollection" /> collection into an <see cref="T:System.Array" />, starting at the specified index.</summary>
+      <param name="array">The <see cref="T:System.Array" /> to copy elements into.</param>
+      <param name="index">The index from which to start copying into the <paramref name="array" /> parameter.</param>
+      <exception cref="T:System.ArgumentException">The sum of <paramref name="index" /> and the number of elements in the <see cref="T:System.Data.SqlClient.SqlErrorCollection" /> collection is greater than the <see cref="P:System.Array.Length" /> of the <see cref="T:System.Array" />.</exception>
+      <exception cref="T:System.ArgumentNullException">The <paramref name="array" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="index" /> is not valid for <paramref name="array" />.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlErrorCollection.CopyTo(System.Data.SqlClient.SqlError[],System.Int32)">
+      <summary>Copies the elements of the <see cref="T:System.Data.SqlClient.SqlErrorCollection" /> collection into a <see cref="T:System.Data.SqlClient.SqlErrorCollection" />, starting at the specified index.</summary>
+      <param name="array">The <see cref="T:System.Data.SqlClient.SqlErrorCollection" /> to copy the elements into.</param>
+      <param name="index">The index from which to start copying into the <paramref name="array" /> parameter.</param>
+      <exception cref="T:System.ArgumentException">The sum of <paramref name="index" /> and the number of elements in the <see cref="T:System.Data.SqlClient.SqlErrorCollection" /> collection is greater than the length of the <see cref="T:System.Data.SqlClient.SqlErrorCollection" />.</exception>
+      <exception cref="T:System.ArgumentNullException">The <paramref name="array" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="index" /> is not valid for <paramref name="array" />.</exception>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlErrorCollection.Count">
+      <summary>Gets the number of errors in the collection.</summary>
+      <returns>The total number of errors in the collection.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlErrorCollection.GetEnumerator">
+      <summary>Returns an enumerator that iterates through the <see cref="T:System.Data.SqlClient.SqlErrorCollection" />.</summary>
+      <returns>An <see cref="T:System.Collections.IEnumerator" /> for the <see cref="T:System.Data.SqlClient.SqlErrorCollection" />.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlErrorCollection.Item(System.Int32)">
+      <summary>Gets the error at the specified index.</summary>
+      <param name="index">The zero-based index of the error to retrieve.</param>
+      <returns>A <see cref="T:System.Data.SqlClient.SqlError" /> that contains the error at the specified index.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">Index parameter is outside array bounds.</exception>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlErrorCollection.System#Collections#ICollection#IsSynchronized">
+      <summary>For a description of this member, see <see cref="P:System.Collections.ICollection.IsSynchronized" />.</summary>
+      <returns>
+        <see langword="true" /> if access to the <see cref="T:System.Collections.ICollection" /> is synchronized (thread safe); otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlErrorCollection.System#Collections#ICollection#SyncRoot">
+      <summary>For a description of this member, see <see cref="P:System.Collections.ICollection.SyncRoot" />.</summary>
+      <returns>An object that can be used to synchronize access to the <see cref="T:System.Collections.ICollection" />.</returns>
+    </member>
+    <member name="T:System.Data.SqlClient.SqlException">
+      <summary>The exception that is thrown when SQL Server returns a warning or error. This class cannot be inherited.</summary>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlException.Class">
+      <summary>Gets the severity level of the error returned from the .NET Framework Data Provider for SQL Server.</summary>
+      <returns>A value from 1 to 25 that indicates the severity level of the error.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlException.ClientConnectionId">
+      <summary>Represents the client connection ID. For more information, see Data Tracing in ADO.NET.</summary>
+      <returns>The client connection ID.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlException.Errors">
+      <summary>Gets a collection of one or more <see cref="T:System.Data.SqlClient.SqlError" /> objects that give detailed information about exceptions generated by the .NET Framework Data Provider for SQL Server.</summary>
+      <returns>The collected instances of the <see cref="T:System.Data.SqlClient.SqlError" /> class.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlException.GetObjectData(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)">
+      <summary>Sets the <see cref="T:System.Runtime.Serialization.SerializationInfo" /> with information about the exception.</summary>
+      <param name="si">The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
+      <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext" /> that contains contextual information about the source or destination.</param>
+      <exception cref="T:System.ArgumentNullException">The <paramref name="si" /> parameter is a null reference (<see langword="Nothing" /> in Visual Basic).</exception>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlException.LineNumber">
+      <summary>Gets the line number within the Transact-SQL command batch or stored procedure that generated the error.</summary>
+      <returns>The line number within the Transact-SQL command batch or stored procedure that generated the error.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlException.Number">
+      <summary>Gets a number that identifies the type of error.</summary>
+      <returns>The number that identifies the type of error.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlException.Procedure">
+      <summary>Gets the name of the stored procedure or remote procedure call (RPC) that generated the error.</summary>
+      <returns>The name of the stored procedure or RPC.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlException.Server">
+      <summary>Gets the name of the computer that is running an instance of SQL Server that generated the error.</summary>
+      <returns>The name of the computer running an instance of SQL Server.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlException.Source">
+      <summary>Gets the name of the provider that generated the error.</summary>
+      <returns>The name of the provider that generated the error.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlException.State">
+      <summary>Gets a numeric error code from SQL Server that represents an error, warning or "no data found" message. For more information about how to decode these values, see Database Engine Events and Errors.</summary>
+      <returns>The number representing the error code.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlException.ToString">
+      <summary>Returns a string that represents the current <see cref="T:System.Data.SqlClient.SqlException" /> object, and includes the client connection ID (for more information, see <see cref="P:System.Data.SqlClient.SqlException.ClientConnectionId" />).</summary>
+      <returns>A string that represents the current <see cref="T:System.Data.SqlClient.SqlException" /> object.<see cref="T:System.String" />.</returns>
+    </member>
+    <member name="T:System.Data.SqlClient.SqlInfoMessageEventArgs">
+      <summary>Provides data for the <see cref="E:System.Data.SqlClient.SqlConnection.InfoMessage" /> event.</summary>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlInfoMessageEventArgs.Errors">
+      <summary>Gets the collection of warnings sent from the server.</summary>
+      <returns>The collection of warnings sent from the server.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlInfoMessageEventArgs.Message">
+      <summary>Gets the full text of the error sent from the database.</summary>
+      <returns>The full text of the error.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlInfoMessageEventArgs.Source">
+      <summary>Gets the name of the object that generated the error.</summary>
+      <returns>The name of the object that generated the error.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlInfoMessageEventArgs.ToString">
+      <summary>Retrieves a string representation of the <see cref="E:System.Data.SqlClient.SqlConnection.InfoMessage" /> event.</summary>
+      <returns>A string representing the <see cref="E:System.Data.SqlClient.SqlConnection.InfoMessage" /> event.</returns>
+    </member>
+    <member name="T:System.Data.SqlClient.SqlInfoMessageEventHandler">
+      <summary>Represents the method that will handle the <see cref="E:System.Data.SqlClient.SqlConnection.InfoMessage" /> event of a <see cref="T:System.Data.SqlClient.SqlConnection" />.</summary>
+      <param name="sender">The source of the event.</param>
+      <param name="e">A <see cref="T:System.Data.SqlClient.SqlInfoMessageEventArgs" /> object that contains the event data.</param>
+    </member>
+    <member name="T:System.Data.SqlClient.SqlNotificationEventArgs">
+      <summary>Represents the set of arguments passed to the notification event handler.</summary>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlNotificationEventArgs.#ctor(System.Data.SqlClient.SqlNotificationType,System.Data.SqlClient.SqlNotificationInfo,System.Data.SqlClient.SqlNotificationSource)">
+      <summary>Creates a new instance of the <see cref="T:System.Data.SqlClient.SqlNotificationEventArgs" /> object.</summary>
+      <param name="type">
+        <see cref="T:System.Data.SqlClient.SqlNotificationType" /> value that indicates whether this notification is generated because of an actual change, or by the subscription.</param>
+      <param name="info">
+        <see cref="T:System.Data.SqlClient.SqlNotificationInfo" /> value that indicates the reason for the notification event. This may occur because the data in the store actually changed, or the notification became invalid (for example, it timed out).</param>
+      <param name="source">
+        <see cref="T:System.Data.SqlClient.SqlNotificationSource" /> value that indicates the source that generated the notification.</param>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlNotificationEventArgs.Info">
+      <summary>Gets a value that indicates the reason for the notification event, such as a row in the database being modified or a table being truncated.</summary>
+      <returns>The notification event reason.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlNotificationEventArgs.Source">
+      <summary>Gets a value that indicates the source that generated the notification, such as a change to the query data or the database's state.</summary>
+      <returns>The source of the notification.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlNotificationEventArgs.Type">
+      <summary>Gets a value that indicates whether this notification is generated because of an actual change, or by the subscription.</summary>
+      <returns>A value indicating whether the notification was generated by a change or a subscription.</returns>
+    </member>
+    <member name="T:System.Data.SqlClient.SqlNotificationInfo">
+      <summary>This enumeration provides additional information about the different notifications that can be received by the dependency event handler.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlNotificationInfo.AlreadyChanged">
+      <summary>The <see langword="SqlDependency" /> object already fired, and new commands cannot be added to it.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlNotificationInfo.Alter">
+      <summary>An underlying server object related to the query was modified.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlNotificationInfo.Delete">
+      <summary>Data was changed by a DELETE statement.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlNotificationInfo.Drop">
+      <summary>An underlying object related to the query was dropped.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlNotificationInfo.Error">
+      <summary>An internal server error occurred.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlNotificationInfo.Expired">
+      <summary>The <see langword="SqlDependency" /> object has expired.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlNotificationInfo.Insert">
+      <summary>Data was changed by an INSERT statement.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlNotificationInfo.Invalid">
+      <summary>A statement was provided that cannot be notified (for example, an UPDATE statement).</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlNotificationInfo.Isolation">
+      <summary>The statement was executed under an isolation mode that was not valid (for example, Snapshot).</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlNotificationInfo.Merge">
+      <summary>Used to distinguish the server-side cause for a query notification firing.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlNotificationInfo.Options">
+      <summary>The SET options were not set appropriately at subscription time.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlNotificationInfo.PreviousFire">
+      <summary>A previous statement has caused query notifications to fire under the current transaction.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlNotificationInfo.Query">
+      <summary>A SELECT statement that cannot be notified or was provided.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlNotificationInfo.Resource">
+      <summary>Fires as a result of server resource pressure.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlNotificationInfo.Restart">
+      <summary>The server was restarted (notifications are sent during restart.).</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlNotificationInfo.TemplateLimit">
+      <summary>The subscribing query causes the number of templates on one of the target tables to exceed the maximum allowable limit.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlNotificationInfo.Truncate">
+      <summary>One or more tables were truncated.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlNotificationInfo.Unknown">
+      <summary>Used when the info option sent by the server was not recognized by the client.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlNotificationInfo.Update">
+      <summary>Data was changed by an UPDATE statement.</summary>
+    </member>
+    <member name="T:System.Data.SqlClient.SqlNotificationSource">
+      <summary>Indicates the source of the notification received by the dependency event handler.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlNotificationSource.Client">
+      <summary>A client-initiated notification occurred, such as a client-side time-out or as a result of attempting to add a command to a dependency that has already fired.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlNotificationSource.Data">
+      <summary>Data has changed; for example, an insert, update, delete, or truncate operation occurred.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlNotificationSource.Database">
+      <summary>The database state changed; for example, the database related to the query was dropped or detached.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlNotificationSource.Environment">
+      <summary>The run-time environment was not compatible with notifications; for example, the isolation level was set to snapshot, or one or more SET options are not compatible.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlNotificationSource.Execution">
+      <summary>A run-time error occurred during execution.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlNotificationSource.Object">
+      <summary>A database object changed; for example, an underlying object related to the query was dropped or modified.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlNotificationSource.Owner">
+      <summary>Internal only; not intended to be used in your code.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlNotificationSource.Statement">
+      <summary>The Transact-SQL statement is not valid for notifications; for example, a SELECT statement that could not be notified or a non-SELECT statement was executed.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlNotificationSource.System">
+      <summary>A system-related event occurred. For example, there was an internal error, the server was restarted, or resource pressure caused the invalidation.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlNotificationSource.Timeout">
+      <summary>The subscription time-out expired.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlNotificationSource.Unknown">
+      <summary>Used when the source option sent by the server was not recognized by the client.</summary>
+    </member>
+    <member name="T:System.Data.SqlClient.SqlNotificationType">
+      <summary>Describes the different notification types that can be received by an <see cref="T:System.Data.SqlClient.OnChangeEventHandler" /> event handler through the <see cref="T:System.Data.SqlClient.SqlNotificationEventArgs" /> parameter.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlNotificationType.Change">
+      <summary>Data on the server being monitored changed. Use the <see cref="T:System.Data.SqlClient.SqlNotificationInfo" /> item to determine the details of the change.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlNotificationType.Subscribe">
+      <summary>There was a failure to create a notification subscription. Use the <see cref="T:System.Data.SqlClient.SqlNotificationEventArgs" /> object's <see cref="T:System.Data.SqlClient.SqlNotificationInfo" /> item to determine the cause of the failure.</summary>
+    </member>
+    <member name="F:System.Data.SqlClient.SqlNotificationType.Unknown">
+      <summary>Used when the type option sent by the server was not recognized by the client.</summary>
+    </member>
+    <member name="T:System.Data.SqlClient.SqlParameter">
+      <summary>Represents a parameter to a <see cref="T:System.Data.SqlClient.SqlCommand" /> and optionally its mapping to <see cref="T:System.Data.DataSet" /> columns. This class cannot be inherited. For more information on parameters, see Configuring Parameters and Parameter Data Types.</summary>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlParameter.#ctor">
+      <summary>Initializes a new instance of the <see cref="T:System.Data.SqlClient.SqlParameter" /> class.</summary>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlParameter.#ctor(System.String,System.Data.SqlDbType)">
+      <summary>Initializes a new instance of the <see cref="T:System.Data.SqlClient.SqlParameter" /> class that uses the parameter name and the data type.</summary>
+      <param name="parameterName">The name of the parameter to map.</param>
+      <param name="dbType">One of the <see cref="T:System.Data.SqlDbType" /> values.</param>
+      <exception cref="T:System.ArgumentException">The value supplied in the <paramref name="dbType" /> parameter is an invalid back-end data type.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlParameter.#ctor(System.String,System.Data.SqlDbType,System.Int32)">
+      <summary>Initializes a new instance of the <see cref="T:System.Data.SqlClient.SqlParameter" /> class that uses the parameter name, the <see cref="T:System.Data.SqlDbType" />, and the size.</summary>
+      <param name="parameterName">The name of the parameter to map.</param>
+      <param name="dbType">One of the <see cref="T:System.Data.SqlDbType" /> values.</param>
+      <param name="size">The length of the parameter.</param>
+      <exception cref="T:System.ArgumentException">The value supplied in the <paramref name="dbType" /> parameter is an invalid back-end data type.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlParameter.#ctor(System.String,System.Data.SqlDbType,System.Int32,System.Data.ParameterDirection,System.Boolean,System.Byte,System.Byte,System.String,System.Data.DataRowVersion,System.Object)">
+      <summary>Initializes a new instance of the <see cref="T:System.Data.SqlClient.SqlParameter" /> class that uses the parameter name, the type of the parameter, the size of the parameter, a <see cref="T:System.Data.ParameterDirection" />, the precision of the parameter, the scale of the parameter, the source column, a <see cref="T:System.Data.DataRowVersion" /> to use, and the value of the parameter.</summary>
+      <param name="parameterName">The name of the parameter to map.</param>
+      <param name="dbType">One of the <see cref="T:System.Data.SqlDbType" /> values.</param>
+      <param name="size">The length of the parameter.</param>
+      <param name="direction">One of the <see cref="T:System.Data.ParameterDirection" /> values.</param>
+      <param name="isNullable">
+        <see langword="true" /> if the value of the field can be null; otherwise, <see langword="false" />.</param>
+      <param name="precision">The total number of digits to the left and right of the decimal point to which <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> is resolved.</param>
+      <param name="scale">The total number of decimal places to which <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> is resolved.</param>
+      <param name="sourceColumn">The name of the source column (<see cref="P:System.Data.SqlClient.SqlParameter.SourceColumn" />) if this <see cref="T:System.Data.SqlClient.SqlParameter" /> is used in a call to <see cref="Overload:System.Data.Common.DbDataAdapter.Update" />.</param>
+      <param name="sourceVersion">One of the <see cref="T:System.Data.DataRowVersion" /> values.</param>
+      <param name="value">An <see cref="T:System.Object" /> that is the value of the <see cref="T:System.Data.SqlClient.SqlParameter" />.</param>
+      <exception cref="T:System.ArgumentException">The value supplied in the <paramref name="dbType" /> parameter is an invalid back-end data type.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlParameter.#ctor(System.String,System.Data.SqlDbType,System.Int32,System.String)">
+      <summary>Initializes a new instance of the <see cref="T:System.Data.SqlClient.SqlParameter" /> class that uses the parameter name, the <see cref="T:System.Data.SqlDbType" />, the size, and the source column name.</summary>
+      <param name="parameterName">The name of the parameter to map.</param>
+      <param name="dbType">One of the <see cref="T:System.Data.SqlDbType" /> values.</param>
+      <param name="size">The length of the parameter.</param>
+      <param name="sourceColumn">The name of the source column (<see cref="P:System.Data.SqlClient.SqlParameter.SourceColumn" />) if this <see cref="T:System.Data.SqlClient.SqlParameter" /> is used in a call to <see cref="Overload:System.Data.Common.DbDataAdapter.Update" />.</param>
+      <exception cref="T:System.ArgumentException">The value supplied in the <paramref name="dbType" /> parameter is an invalid back-end data type.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlParameter.#ctor(System.String,System.Data.SqlDbType,System.String,System.String,System.String,System.Int32,System.Data.ParameterDirection,System.Byte,System.Byte,System.String,System.Data.DataRowVersion,System.Boolean,System.Object)">
+      <summary>Initializes a new instance of the <see cref="T:System.Data.SqlClient.SqlParameter" /> class that uses the parameter name, the type of the parameter, the length of the parameter the direction, the precision, the scale, the name of the source column, one of the <see cref="T:System.Data.DataRowVersion" /> values, a Boolean for source column mapping, the value of the <see langword="SqlParameter" />, the name of the database where the schema collection for this XML instance is located, the owning relational schema where the schema collection for this XML instance is located, and the name of the schema collection for this parameter.</summary>
+      <param name="parameterName">The name of the parameter to map.</param>
+      <param name="dbType">One of the <see cref="T:System.Data.SqlDbType" /> values.</param>
+      <param name="xmlSchemaCollectionDatabase">The name of the database where the schema collection for this XML instance is located.</param>
+      <param name="xmlSchemaCollectionOwningSchema">The owning relational schema where the schema collection for this XML instance is located.</param>
+      <param name="xmlSchemaCollectionName">The name of the schema collection for this parameter.</param>
+      <param name="size">The length of the parameter.</param>
+      <param name="direction">One of the <see cref="T:System.Data.ParameterDirection" /> values.</param>
+      <param name="precision">The total number of digits to the left and right of the decimal point to which <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> is resolved.</param>
+      <param name="scale">The total number of decimal places to which <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> is resolved.</param>
+      <param name="sourceColumn">The name of the source column (<see cref="P:System.Data.SqlClient.SqlParameter.SourceColumn" />) if this <see cref="T:System.Data.SqlClient.SqlParameter" /> is used in a call to <see cref="Overload:System.Data.Common.DbDataAdapter.Update" />.</param>
+      <param name="sourceVersion">One of the <see cref="T:System.Data.DataRowVersion" /> values.</param>
+      <param name="sourceColumnNullMapping">
+        <see langword="true" /> if the source column is nullable; <see langword="false" /> if it is not.</param>
+      <param name="value">An <see cref="T:System.Object" /> that is the value of the <see cref="T:System.Data.SqlClient.SqlParameter" />.</param>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlParameter.#ctor(System.String,System.Object)">
+      <summary>Initializes a new instance of the <see cref="T:System.Data.SqlClient.SqlParameter" /> class that uses the parameter name and a value of the new <see cref="T:System.Data.SqlClient.SqlParameter" />.</summary>
+      <param name="parameterName">The name of the parameter to map.</param>
+      <param name="value">An <see cref="T:System.Object" /> that is the value of the <see cref="T:System.Data.SqlClient.SqlParameter" />.</param>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlParameter.CompareInfo">
+      <summary>Gets or sets the <see cref="T:System.Globalization.CompareInfo" /> object that defines how string comparisons should be performed for this parameter.</summary>
+      <returns>A <see cref="T:System.Globalization.CompareInfo" /> object that defines string comparison for this parameter.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlParameter.DbType">
+      <summary>Gets or sets the <see cref="T:System.Data.SqlDbType" /> of the parameter.</summary>
+      <returns>One of the <see cref="T:System.Data.SqlDbType" /> values. The default is <see langword="NVarChar" />.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlParameter.Direction">
+      <summary>Gets or sets a value that indicates whether the parameter is input-only, output-only, bidirectional, or a stored procedure return value parameter.</summary>
+      <returns>One of the <see cref="T:System.Data.ParameterDirection" /> values. The default is <see langword="Input" />.</returns>
+      <exception cref="T:System.ArgumentException">The property was not set to one of the valid <see cref="T:System.Data.ParameterDirection" /> values.</exception>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlParameter.IsNullable">
+      <summary>Gets or sets a value that indicates whether the parameter accepts null values. <see cref="P:System.Data.SqlClient.SqlParameter.IsNullable" /> is not used to validate the parameter's value and will not prevent sending or receiving a null value when executing a command.</summary>
+      <returns>
+        <see langword="true" /> if null values are accepted; otherwise, <see langword="false" />. The default is <see langword="false" />.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlParameter.LocaleId">
+      <summary>Gets or sets the locale identifier that determines conventions and language for a particular region.</summary>
+      <returns>The locale identifier associated with the parameter.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlParameter.Offset">
+      <summary>Gets or sets the offset to the <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> property.</summary>
+      <returns>The offset to the <see cref="P:System.Data.SqlClient.SqlParameter.Value" />. The default is 0.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlParameter.ParameterName">
+      <summary>Gets or sets the name of the <see cref="T:System.Data.SqlClient.SqlParameter" />.</summary>
+      <returns>The name of the <see cref="T:System.Data.SqlClient.SqlParameter" />. The default is an empty string.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlParameter.Precision">
+      <summary>Gets or sets the maximum number of digits used to represent the <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> property.</summary>
+      <returns>The maximum number of digits used to represent the <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> property. The default value is 0. This indicates that the data provider sets the precision for <see cref="P:System.Data.SqlClient.SqlParameter.Value" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlParameter.ResetDbType">
+      <summary>Resets the type associated with this <see cref="T:System.Data.SqlClient.SqlParameter" />.</summary>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlParameter.ResetSqlDbType">
+      <summary>Resets the type associated with this <see cref="T:System.Data.SqlClient.SqlParameter" />.</summary>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlParameter.Scale">
+      <summary>Gets or sets the number of decimal places to which <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> is resolved.</summary>
+      <returns>The number of decimal places to which <see cref="P:System.Data.SqlClient.SqlParameter.Value" /> is resolved. The default is 0.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlParameter.Size">
+      <summary>Gets or sets the maximum size, in bytes, of the data within the column.</summary>
+      <returns>The maximum size, in bytes, of the data within the column. The default value is inferred from the parameter value.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlParameter.SourceColumn">
+      <summary>Gets or sets the name of the source column mapped to the <see cref="T:System.Data.DataSet" /> and used for loading or returning the <see cref="P:System.Data.SqlClient.SqlParameter.Value" /></summary>
+      <returns>The name of the source column mapped to the <see cref="T:System.Data.DataSet" />. The default is an empty string.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlParameter.SourceColumnNullMapping">
+      <summary>Sets or gets a value which indicates whether the source column is nullable. This allows <see cref="T:System.Data.SqlClient.SqlCommandBuilder" /> to correctly generate Update statements for nullable columns.</summary>
+      <returns>
+        <see langword="true" /> if the source column is nullable; <see langword="false" /> if it is not.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlParameter.SourceVersion">
+      <summary>Gets or sets the <see cref="T:System.Data.DataRowVersion" /> to use when you load <see cref="P:System.Data.SqlClient.SqlParameter.Value" /></summary>
+      <returns>One of the <see cref="T:System.Data.DataRowVersion" /> values. The default is <see langword="Current" />.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlParameter.SqlDbType">
+      <summary>Gets or sets the <see cref="T:System.Data.SqlDbType" /> of the parameter.</summary>
+      <returns>One of the <see cref="T:System.Data.SqlDbType" /> values. The default is <see langword="NVarChar" />.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlParameter.SqlValue">
+      <summary>Gets or sets the value of the parameter as an SQL type.</summary>
+      <returns>An <see cref="T:System.Object" /> that is the value of the parameter, using SQL types. The default value is null.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlParameter.System#ICloneable#Clone">
+      <summary>For a description of this member, see <see cref="M:System.ICloneable.Clone" />.</summary>
+      <returns>A new <see cref="T:System.Object" /> that is a copy of this instance.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlParameter.ToString">
+      <summary>Gets a string that contains the <see cref="P:System.Data.SqlClient.SqlParameter.ParameterName" />.</summary>
+      <returns>A string that contains the <see cref="P:System.Data.SqlClient.SqlParameter.ParameterName" />.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlParameter.TypeName">
+      <summary>Gets or sets the type name for a table-valued parameter.</summary>
+      <returns>The type name of the specified table-valued parameter.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlParameter.UdtTypeName">
+      <summary>Gets or sets a <see langword="string" /> that represents a user-defined type as a parameter.</summary>
+      <returns>A <see langword="string" /> that represents the fully qualified name of a user-defined type in the database.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlParameter.Value">
+      <summary>Gets or sets the value of the parameter.</summary>
+      <returns>An <see cref="T:System.Object" /> that is the value of the parameter. The default value is null.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlParameter.XmlSchemaCollectionDatabase">
+      <summary>Gets the name of the database where the schema collection for this XML instance is located.</summary>
+      <returns>The name of the database where the schema collection for this XML instance is located.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlParameter.XmlSchemaCollectionName">
+      <summary>Gets the name of the schema collection for this XML instance.</summary>
+      <returns>The name of the schema collection for this XML instance.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlParameter.XmlSchemaCollectionOwningSchema">
+      <summary>The owning relational schema where the schema collection for this XML instance is located.</summary>
+      <returns>The owning relational schema for this XML instance.</returns>
+    </member>
+    <member name="T:System.Data.SqlClient.SqlParameterCollection">
+      <summary>Represents a collection of parameters associated with a <see cref="T:System.Data.SqlClient.SqlCommand" /> and their respective mappings to columns in a <see cref="T:System.Data.DataSet" />. This class cannot be inherited.</summary>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlParameterCollection.Add(System.Data.SqlClient.SqlParameter)">
+      <summary>Adds the specified <see cref="T:System.Data.SqlClient.SqlParameter" /> object to the <see cref="T:System.Data.SqlClient.SqlParameterCollection" />.</summary>
+      <param name="value">The <see cref="T:System.Data.SqlClient.SqlParameter" /> to add to the collection.</param>
+      <returns>A new <see cref="T:System.Data.SqlClient.SqlParameter" /> object.</returns>
+      <exception cref="T:System.ArgumentException">The <see cref="T:System.Data.SqlClient.SqlParameter" /> specified in the <paramref name="value" /> parameter is already added to this or another <see cref="T:System.Data.SqlClient.SqlParameterCollection" />.</exception>
+      <exception cref="T:System.InvalidCastException">The parameter passed was not a <see cref="T:System.Data.SqlClient.SqlParameter" />.</exception>
+      <exception cref="T:System.ArgumentNullException">The <paramref name="value" /> parameter is null.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlParameterCollection.Add(System.Object)">
+      <summary>Adds the specified <see cref="T:System.Data.SqlClient.SqlParameter" /> object to the <see cref="T:System.Data.SqlClient.SqlParameterCollection" />.</summary>
+      <param name="value">An <see cref="T:System.Object" />.</param>
+      <returns>The index of the new <see cref="T:System.Data.SqlClient.SqlParameter" /> object.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlParameterCollection.Add(System.String,System.Data.SqlDbType)">
+      <summary>Adds a <see cref="T:System.Data.SqlClient.SqlParameter" /> to the <see cref="T:System.Data.SqlClient.SqlParameterCollection" /> given the parameter name and the data type.</summary>
+      <param name="parameterName">The name of the parameter.</param>
+      <param name="sqlDbType">One of the <see cref="T:System.Data.SqlDbType" /> values.</param>
+      <returns>A new <see cref="T:System.Data.SqlClient.SqlParameter" /> object.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlParameterCollection.Add(System.String,System.Data.SqlDbType,System.Int32)">
+      <summary>Adds a <see cref="T:System.Data.SqlClient.SqlParameter" /> to the <see cref="T:System.Data.SqlClient.SqlParameterCollection" />, given the specified parameter name, <see cref="T:System.Data.SqlDbType" /> and size.</summary>
+      <param name="parameterName">The name of the parameter.</param>
+      <param name="sqlDbType">The <see cref="T:System.Data.SqlDbType" /> of the <see cref="T:System.Data.SqlClient.SqlParameter" /> to add to the collection.</param>
+      <param name="size">The size as an <see cref="T:System.Int32" />.</param>
+      <returns>A new <see cref="T:System.Data.SqlClient.SqlParameter" /> object.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlParameterCollection.Add(System.String,System.Data.SqlDbType,System.Int32,System.String)">
+      <summary>Adds a <see cref="T:System.Data.SqlClient.SqlParameter" /> to the <see cref="T:System.Data.SqlClient.SqlParameterCollection" /> with the parameter name, the data type, and the column length.</summary>
+      <param name="parameterName">The name of the parameter.</param>
+      <param name="sqlDbType">One of the <see cref="T:System.Data.SqlDbType" /> values.</param>
+      <param name="size">The column length.</param>
+      <param name="sourceColumn">The name of the source column (<see cref="P:System.Data.SqlClient.SqlParameter.SourceColumn" />) if this <see cref="T:System.Data.SqlClient.SqlParameter" /> is used in a call to <see cref="Overload:System.Data.Common.DbDataAdapter.Update" />.</param>
+      <returns>A new <see cref="T:System.Data.SqlClient.SqlParameter" /> object.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlParameterCollection.AddRange(System.Array)">
+      <summary>Adds an array of values to the end of the <see cref="T:System.Data.SqlClient.SqlParameterCollection" />.</summary>
+      <param name="values">The <see cref="T:System.Array" /> values to add.</param>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlParameterCollection.AddRange(System.Data.SqlClient.SqlParameter[])">
+      <summary>Adds an array of <see cref="T:System.Data.SqlClient.SqlParameter" /> values to the end of the <see cref="T:System.Data.SqlClient.SqlParameterCollection" />.</summary>
+      <param name="values">The <see cref="T:System.Data.SqlClient.SqlParameter" /> values to add.</param>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlParameterCollection.AddWithValue(System.String,System.Object)">
+      <summary>Adds a value to the end of the <see cref="T:System.Data.SqlClient.SqlParameterCollection" />.</summary>
+      <param name="parameterName">The name of the parameter.</param>
+      <param name="value">The value to be added. Use <see cref="F:System.DBNull.Value" /> instead of null, to indicate a null value.</param>
+      <returns>A <see cref="T:System.Data.SqlClient.SqlParameter" /> object.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlParameterCollection.Clear">
+      <summary>Removes all the <see cref="T:System.Data.SqlClient.SqlParameter" /> objects from the <see cref="T:System.Data.SqlClient.SqlParameterCollection" />.</summary>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlParameterCollection.Contains(System.Data.SqlClient.SqlParameter)">
+      <summary>Determines whether the specified <see cref="T:System.Data.SqlClient.SqlParameter" /> is in this <see cref="T:System.Data.SqlClient.SqlParameterCollection" />.</summary>
+      <param name="value">The <see cref="T:System.Data.SqlClient.SqlParameter" /> value.</param>
+      <returns>
+        <see langword="true" /> if the <see cref="T:System.Data.SqlClient.SqlParameterCollection" /> contains the value; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlParameterCollection.Contains(System.Object)">
+      <summary>Determines whether the specified <see cref="T:System.Object" /> is in this <see cref="T:System.Data.SqlClient.SqlParameterCollection" />.</summary>
+      <param name="value">The <see cref="T:System.Object" /> value.</param>
+      <returns>
+        <see langword="true" /> if the <see cref="T:System.Data.SqlClient.SqlParameterCollection" /> contains the value; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlParameterCollection.Contains(System.String)">
+      <summary>Determines whether the specified parameter name is in this <see cref="T:System.Data.SqlClient.SqlParameterCollection" />.</summary>
+      <param name="value">The <see cref="T:System.String" /> value.</param>
+      <returns>
+        <see langword="true" /> if the <see cref="T:System.Data.SqlClient.SqlParameterCollection" /> contains the value; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlParameterCollection.CopyTo(System.Array,System.Int32)">
+      <summary>Copies all the elements of the current <see cref="T:System.Data.SqlClient.SqlParameterCollection" /> to the specified one-dimensional <see cref="T:System.Array" /> starting at the specified destination <see cref="T:System.Array" /> index.</summary>
+      <param name="array">The one-dimensional <see cref="T:System.Array" /> that is the destination of the elements copied from the current <see cref="T:System.Data.SqlClient.SqlParameterCollection" />.</param>
+      <param name="index">A 32-bit integer that represents the index in the <see cref="T:System.Array" /> at which copying starts.</param>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlParameterCollection.CopyTo(System.Data.SqlClient.SqlParameter[],System.Int32)">
+      <summary>Copies all the elements of the current <see cref="T:System.Data.SqlClient.SqlParameterCollection" /> to the specified <see cref="T:System.Data.SqlClient.SqlParameterCollection" /> starting at the specified destination index.</summary>
+      <param name="array">The <see cref="T:System.Data.SqlClient.SqlParameterCollection" /> that is the destination of the elements copied from the current <see cref="T:System.Data.SqlClient.SqlParameterCollection" />.</param>
+      <param name="index">A 32-bit integer that represents the index in the <see cref="T:System.Data.SqlClient.SqlParameterCollection" /> at which copying starts.</param>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlParameterCollection.Count">
+      <summary>Returns an Integer that contains the number of elements in the <see cref="T:System.Data.SqlClient.SqlParameterCollection" />. Read-only.</summary>
+      <returns>The number of elements in the <see cref="T:System.Data.SqlClient.SqlParameterCollection" /> as an Integer.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlParameterCollection.GetEnumerator">
+      <summary>Returns an enumerator that iterates through the <see cref="T:System.Data.SqlClient.SqlParameterCollection" />.</summary>
+      <returns>An <see cref="T:System.Collections.IEnumerator" /> for the <see cref="T:System.Data.SqlClient.SqlParameterCollection" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlParameterCollection.IndexOf(System.Data.SqlClient.SqlParameter)">
+      <summary>Gets the location of the specified <see cref="T:System.Data.SqlClient.SqlParameter" /> within the collection.</summary>
+      <param name="value">The <see cref="T:System.Data.SqlClient.SqlParameter" /> to find.</param>
+      <returns>The zero-based location of the specified <see cref="T:System.Data.SqlClient.SqlParameter" /> that is a <see cref="T:System.Data.SqlClient.SqlParameter" /> within the collection. Returns -1 when the object does not exist in the <see cref="T:System.Data.SqlClient.SqlParameterCollection" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlParameterCollection.IndexOf(System.Object)">
+      <summary>Gets the location of the specified <see cref="T:System.Object" /> within the collection.</summary>
+      <param name="value">The <see cref="T:System.Object" /> to find.</param>
+      <returns>The zero-based location of the specified <see cref="T:System.Object" /> that is a <see cref="T:System.Data.SqlClient.SqlParameter" /> within the collection. Returns -1 when the object does not exist in the <see cref="T:System.Data.SqlClient.SqlParameterCollection" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlParameterCollection.IndexOf(System.String)">
+      <summary>Gets the location of the specified <see cref="T:System.Data.SqlClient.SqlParameter" /> with the specified name.</summary>
+      <param name="parameterName">The case-sensitive name of the <see cref="T:System.Data.SqlClient.SqlParameter" /> to find.</param>
+      <returns>The zero-based location of the specified <see cref="T:System.Data.SqlClient.SqlParameter" /> with the specified case-sensitive name. Returns -1 when the object does not exist in the <see cref="T:System.Data.SqlClient.SqlParameterCollection" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlParameterCollection.Insert(System.Int32,System.Data.SqlClient.SqlParameter)">
+      <summary>Inserts a <see cref="T:System.Data.SqlClient.SqlParameter" /> object into the <see cref="T:System.Data.SqlClient.SqlParameterCollection" /> at the specified index.</summary>
+      <param name="index">The zero-based index at which value should be inserted.</param>
+      <param name="value">A <see cref="T:System.Data.SqlClient.SqlParameter" /> object to be inserted in the <see cref="T:System.Data.SqlClient.SqlParameterCollection" />.</param>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlParameterCollection.Insert(System.Int32,System.Object)">
+      <summary>Inserts an <see cref="T:System.Object" /> into the <see cref="T:System.Data.SqlClient.SqlParameterCollection" /> at the specified index.</summary>
+      <param name="index">The zero-based index at which value should be inserted.</param>
+      <param name="value">An <see cref="T:System.Object" /> to be inserted in the <see cref="T:System.Data.SqlClient.SqlParameterCollection" />.</param>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlParameterCollection.IsFixedSize">
+      <summary>Gets a value that indicates whether the <see cref="T:System.Data.SqlClient.SqlParameterCollection" /> has a fixed size.</summary>
+      <returns>
+        <see langword="true" /> if the <see cref="T:System.Data.SqlClient.SqlParameterCollection" /> has a fixed size; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlParameterCollection.IsReadOnly">
+      <summary>Gets a value that indicates whether the <see cref="T:System.Data.SqlClient.SqlParameterCollection" /> is read-only.</summary>
+      <returns>
+        <see langword="true" /> if the <see cref="T:System.Data.SqlClient.SqlParameterCollection" /> is read-only; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlParameterCollection.Item(System.Int32)">
+      <summary>Gets the <see cref="T:System.Data.SqlClient.SqlParameter" /> at the specified index.</summary>
+      <param name="index">The zero-based index of the parameter to retrieve.</param>
+      <returns>The <see cref="T:System.Data.SqlClient.SqlParameter" /> at the specified index.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The specified index does not exist.</exception>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlParameterCollection.Item(System.String)">
+      <summary>Gets the <see cref="T:System.Data.SqlClient.SqlParameter" /> with the specified name.</summary>
+      <param name="parameterName">The name of the parameter to retrieve.</param>
+      <returns>The <see cref="T:System.Data.SqlClient.SqlParameter" /> with the specified name.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">The specified <paramref name="parameterName" /> is not valid.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlParameterCollection.Remove(System.Data.SqlClient.SqlParameter)">
+      <summary>Removes the specified <see cref="T:System.Data.SqlClient.SqlParameter" /> from the collection.</summary>
+      <param name="value">A <see cref="T:System.Data.SqlClient.SqlParameter" /> object to remove from the collection.</param>
+      <exception cref="T:System.InvalidCastException">The parameter is not a <see cref="T:System.Data.SqlClient.SqlParameter" />.</exception>
+      <exception cref="T:System.SystemException">The parameter does not exist in the collection.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlParameterCollection.Remove(System.Object)">
+      <summary>Removes the specified <see cref="T:System.Data.SqlClient.SqlParameter" /> from the collection.</summary>
+      <param name="value">The object to remove from the collection.</param>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlParameterCollection.RemoveAt(System.Int32)">
+      <summary>Removes the <see cref="T:System.Data.SqlClient.SqlParameter" /> from the <see cref="T:System.Data.SqlClient.SqlParameterCollection" /> at the specified index.</summary>
+      <param name="index">The zero-based index of the <see cref="T:System.Data.SqlClient.SqlParameter" /> object to remove.</param>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlParameterCollection.RemoveAt(System.String)">
+      <summary>Removes the <see cref="T:System.Data.SqlClient.SqlParameter" /> from the <see cref="T:System.Data.SqlClient.SqlParameterCollection" /> at the specified parameter name.</summary>
+      <param name="parameterName">The name of the <see cref="T:System.Data.SqlClient.SqlParameter" /> to remove.</param>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlParameterCollection.SyncRoot">
+      <summary>Gets an object that can be used to synchronize access to the <see cref="T:System.Data.SqlClient.SqlParameterCollection" />.</summary>
+      <returns>An object that can be used to synchronize access to the <see cref="T:System.Data.SqlClient.SqlParameterCollection" />.</returns>
+    </member>
+    <member name="T:System.Data.SqlClient.SqlRowsCopiedEventArgs">
+      <summary>Represents the set of arguments passed to the <see cref="T:System.Data.SqlClient.SqlRowsCopiedEventHandler" />.</summary>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlRowsCopiedEventArgs.#ctor(System.Int64)">
+      <summary>Creates a new instance of the <see cref="T:System.Data.SqlClient.SqlRowsCopiedEventArgs" /> object.</summary>
+      <param name="rowsCopied">An <see cref="T:System.Int64" /> that indicates the number of rows copied during the current bulk copy operation.</param>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlRowsCopiedEventArgs.Abort">
+      <summary>Gets or sets a value that indicates whether the bulk copy operation should be aborted.</summary>
+      <returns>
+        <see langword="true" /> if the bulk copy operation should be aborted; otherwise <see langword="false" />.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlRowsCopiedEventArgs.RowsCopied">
+      <summary>Gets a value that returns the number of rows copied during the current bulk copy operation.</summary>
+      <returns>
+        <see langword="int" /> that returns the number of rows copied.</returns>
+    </member>
+    <member name="T:System.Data.SqlClient.SqlRowsCopiedEventHandler">
+      <summary>Represents the method that handles the <see cref="E:System.Data.SqlClient.SqlBulkCopy.SqlRowsCopied" /> event of a <see cref="T:System.Data.SqlClient.SqlBulkCopy" />.</summary>
+      <param name="sender">The source of the event.</param>
+      <param name="e">A <see cref="T:System.Data.SqlClient.SqlRowsCopiedEventArgs" /> object that contains the event data.</param>
+    </member>
+    <member name="T:System.Data.SqlClient.SqlRowUpdatedEventArgs">
+      <summary>Provides data for the <see cref="E:System.Data.SqlClient.SqlDataAdapter.RowUpdated" /> event.</summary>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlRowUpdatedEventArgs.#ctor(System.Data.DataRow,System.Data.IDbCommand,System.Data.StatementType,System.Data.Common.DataTableMapping)">
+      <summary>Initializes a new instance of the <see cref="T:System.Data.SqlClient.SqlRowUpdatedEventArgs" /> class.</summary>
+      <param name="row">The <see cref="T:System.Data.DataRow" /> sent through an <see cref="M:System.Data.Common.DbDataAdapter.Update(System.Data.DataSet)" />.</param>
+      <param name="command">The <see cref="T:System.Data.IDbCommand" /> executed when <see cref="M:System.Data.Common.DbDataAdapter.Update(System.Data.DataSet)" /> is called.</param>
+      <param name="statementType">One of the <see cref="T:System.Data.StatementType" /> values that specifies the type of query executed.</param>
+      <param name="tableMapping">The <see cref="T:System.Data.Common.DataTableMapping" /> sent through an <see cref="M:System.Data.Common.DbDataAdapter.Update(System.Data.DataSet)" />.</param>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlRowUpdatedEventArgs.Command">
+      <summary>Gets or sets the <see cref="T:System.Data.SqlClient.SqlCommand" /> executed when <see cref="M:System.Data.Common.DbDataAdapter.Update(System.Data.DataSet)" /> is called.</summary>
+      <returns>The <see cref="T:System.Data.SqlClient.SqlCommand" /> executed when <see cref="M:System.Data.Common.DbDataAdapter.Update(System.Data.DataSet)" /> is called.</returns>
+    </member>
+    <member name="T:System.Data.SqlClient.SqlRowUpdatedEventHandler">
+      <summary>Represents the method that will handle the <see cref="E:System.Data.SqlClient.SqlDataAdapter.RowUpdated" /> event of a <see cref="T:System.Data.SqlClient.SqlDataAdapter" />.</summary>
+      <param name="sender">The source of the event.</param>
+      <param name="e">The <see cref="T:System.Data.SqlClient.SqlRowUpdatedEventArgs" /> that contains the event data.</param>
+    </member>
+    <member name="T:System.Data.SqlClient.SqlRowUpdatingEventArgs">
+      <summary>Provides data for the <see cref="E:System.Data.SqlClient.SqlDataAdapter.RowUpdating" /> event.</summary>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlRowUpdatingEventArgs.#ctor(System.Data.DataRow,System.Data.IDbCommand,System.Data.StatementType,System.Data.Common.DataTableMapping)">
+      <summary>Initializes a new instance of the <see cref="T:System.Data.SqlClient.SqlRowUpdatingEventArgs" /> class.</summary>
+      <param name="row">The <see cref="T:System.Data.DataRow" /> to <see cref="M:System.Data.Common.DbDataAdapter.Update(System.Data.DataSet)" />.</param>
+      <param name="command">The <see cref="T:System.Data.IDbCommand" /> to execute during <see cref="M:System.Data.Common.DbDataAdapter.Update(System.Data.DataSet)" />.</param>
+      <param name="statementType">One of the <see cref="T:System.Data.StatementType" /> values that specifies the type of query executed.</param>
+      <param name="tableMapping">The <see cref="T:System.Data.Common.DataTableMapping" /> sent through an <see cref="M:System.Data.Common.DbDataAdapter.Update(System.Data.DataSet)" />.</param>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlRowUpdatingEventArgs.Command">
+      <summary>Gets or sets the <see cref="T:System.Data.SqlClient.SqlCommand" /> to execute when performing the <see cref="M:System.Data.Common.DbDataAdapter.Update(System.Data.DataSet)" />.</summary>
+      <returns>The <see cref="T:System.Data.SqlClient.SqlCommand" /> to execute when performing the <see cref="M:System.Data.Common.DbDataAdapter.Update(System.Data.DataSet)" />.</returns>
+    </member>
+    <member name="T:System.Data.SqlClient.SqlRowUpdatingEventHandler">
+      <summary>Represents the method that will handle the <see cref="E:System.Data.SqlClient.SqlDataAdapter.RowUpdating" /> event of a <see cref="T:System.Data.SqlClient.SqlDataAdapter" />.</summary>
+      <param name="sender">The source of the event.</param>
+      <param name="e">The <see cref="T:System.Data.SqlClient.SqlRowUpdatingEventArgs" /> that contains the event data.</param>
+    </member>
+    <member name="T:System.Data.SqlClient.SqlTransaction">
+      <summary>Represents a Transact-SQL transaction to be made in a SQL Server database. This class cannot be inherited.</summary>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlTransaction.Commit">
+      <summary>Commits the database transaction.</summary>
+      <exception cref="T:System.Exception">An error occurred while trying to commit the transaction.</exception>
+      <exception cref="T:System.InvalidOperationException">The transaction has already been committed or rolled back.
+-or-
+The connection is broken.</exception>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlTransaction.Connection">
+      <summary>Gets the <see cref="T:System.Data.SqlClient.SqlConnection" /> object associated with the transaction, or <see langword="null" /> if the transaction is no longer valid.</summary>
+      <returns>The <see cref="T:System.Data.SqlClient.SqlConnection" /> object associated with the transaction.</returns>
+    </member>
+    <member name="P:System.Data.SqlClient.SqlTransaction.IsolationLevel">
+      <summary>Specifies the <see cref="T:System.Data.IsolationLevel" /> for this transaction.</summary>
+      <returns>The <see cref="T:System.Data.IsolationLevel" /> for this transaction. The default is <see langword="ReadCommitted" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlTransaction.Rollback">
+      <summary>Rolls back a transaction from a pending state.</summary>
+      <exception cref="T:System.Exception">An error occurred while trying to commit the transaction.</exception>
+      <exception cref="T:System.InvalidOperationException">The transaction has already been committed or rolled back.
+-or-
+The connection is broken.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlTransaction.Rollback(System.String)">
+      <summary>Rolls back a transaction from a pending state, and specifies the transaction or savepoint name.</summary>
+      <param name="transactionName">The name of the transaction to roll back, or the savepoint to which to roll back.</param>
+      <exception cref="T:System.ArgumentException">No transaction name was specified.</exception>
+      <exception cref="T:System.InvalidOperationException">The transaction has already been committed or rolled back.
+-or-
+The connection is broken.</exception>
+    </member>
+    <member name="M:System.Data.SqlClient.SqlTransaction.Save(System.String)">
+      <summary>Creates a savepoint in the transaction that can be used to roll back a part of the transaction, and specifies the savepoint name.</summary>
+      <param name="savePointName">The name of the savepoint.</param>
+      <exception cref="T:System.Exception">An error occurred while trying to commit the transaction.</exception>
+      <exception cref="T:System.InvalidOperationException">The transaction has already been committed or rolled back.
+-or-
+The connection is broken.</exception>
+    </member>
+    <member name="T:System.Data.SqlTypes.SqlFileStream">
+      <summary>Exposes SQL Server data that is stored with the FILESTREAM column attribute as a sequence of bytes.</summary>
+    </member>
+    <member name="M:System.Data.SqlTypes.SqlFileStream.#ctor(System.String,System.Byte[],System.IO.FileAccess)">
+      <summary>Initializes a new instance of the <see cref="T:System.Data.SqlTypes.SqlFileStream" /> class.</summary>
+      <param name="path">The logical path to the file. The path can be retrieved by using the Transact-SQL Pathname function on the underlying FILESTREAM column in the table.</param>
+      <param name="transactionContext">The transaction context for the <see langword="SqlFileStream" /> object. Applications should return the byte array returned by calling the GET_FILESTREAM_TRANSACTION_CONTEXT method.</param>
+      <param name="access">The access mode to use when opening the file. Supported <see cref="T:System.IO.FileAccess" /> enumeration values are <see cref="F:System.IO.FileAccess.Read" />, <see cref="F:System.IO.FileAccess.Write" />, and <see cref="F:System.IO.FileAccess.ReadWrite" />.
+When using <see langword="FileAccess.Read" />, the <see langword="SqlFileStream" /> object can be used to read all of the existing data.
+When using <see langword="FileAccess.Write" />, <see langword="SqlFileStream" /> points to a zero byte file. Existing data will be overwritten when the object is closed and the transaction is committed.
+When using <see langword="FileAccess.ReadWrite" />, the <see langword="SqlFileStream" /> points to a file which has all the existing data in it. The handle is positioned at the beginning of the file. You can use one of the <see langword="System.IO" /><see langword="Seek" /> methods to move the handle position within the file to write or append new data.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="path" /> is a null reference, or <paramref name="transactionContext" /> is null.</exception>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        <paramref name="path" /> is an empty string (""), contains only white space, or contains one or more invalid characters.
+<paramref name="path" /> begins with "\\.\", for example "\\.\PHYSICALDRIVE0 ".
+The handle returned by the call to NTCreateFile is not of type FILE_TYPE_DISK.
+<paramref name="options" /> contains an unsupported value.</exception>
+      <exception cref="T:System.IO.FileNotFoundException">The file cannot be found.</exception>
+      <exception cref="T:System.IO.IOException">An I/O error occurred.</exception>
+      <exception cref="T:System.Security.SecurityException">The caller does not have the required permission.</exception>
+      <exception cref="T:System.IO.DirectoryNotFoundException">The specified <paramref name="path" /> is invalid, such as being on an unmapped drive.</exception>
+      <exception cref="T:System.UnauthorizedAccessException">The access requested is not permitted by the operating system for the specified path. This occurs when Write or ReadWrite access is specified, and the file or directory is set for read-only access.</exception>
+      <exception cref="T:System.InvalidOperationException">NtCreateFile fails with error code set to ERROR_SHARING_VIOLATION.</exception>
+    </member>
+    <member name="M:System.Data.SqlTypes.SqlFileStream.#ctor(System.String,System.Byte[],System.IO.FileAccess,System.IO.FileOptions,System.Int64)">
+      <summary>Initializes a new instance of the <see cref="T:System.Data.SqlTypes.SqlFileStream" /> class.</summary>
+      <param name="path">The logical path to the file. The path can be retrieved by using the Transact-SQL Pathname function on the underlying FILESTREAM column in the table.</param>
+      <param name="transactionContext">The transaction context for the <see langword="SqlFileStream" /> object. When set to null, an implicit transaction will be used for the <see langword="SqlFileStream" /> object. Applications should return the byte array returned by calling the GET_FILESTREAM_TRANSACTION_CONTEXT method.</param>
+      <param name="access">The access mode to use when opening the file. Supported <see cref="T:System.IO.FileAccess" /> enumeration values are <see cref="F:System.IO.FileAccess.Read" />, <see cref="F:System.IO.FileAccess.Write" />, and <see cref="F:System.IO.FileAccess.ReadWrite" />.
+When using <see langword="FileAccess.Read" />, the <see langword="SqlFileStream" /> object can be used to read all of the existing data.
+When using <see langword="FileAccess.Write" />, <see langword="SqlFileStream" /> points to a zero byte file. Existing data will be overwritten when the object is closed and the transaction is committed.
+When using <see langword="FileAccess.ReadWrite" />, the <see langword="SqlFileStream" /> points to a file which has all the existing data in it. The handle is positioned at the beginning of the file. You can use one of the <see langword="System.IO" /><see langword="Seek" /> methods to move the handle position within the file to write or append new data.</param>
+      <param name="options">Specifies the option to use while opening the file. Supported <see cref="T:System.IO.FileOptions" /> values are <see cref="F:System.IO.FileOptions.Asynchronous" />, <see cref="F:System.IO.FileOptions.WriteThrough" />, <see cref="F:System.IO.FileOptions.SequentialScan" />, and <see cref="F:System.IO.FileOptions.RandomAccess" />.</param>
+      <param name="allocationSize">The allocation size to use while creating a file. If set to 0, the default value is used.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="path" /> is a null reference, or <paramref name="transactionContext" /> is null.</exception>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        <paramref name="path" /> is an empty string (""), contains only white space, or contains one or more invalid characters.
+<paramref name="path" /> begins with "\\.\", for example "\\.\PHYSICALDRIVE0 ".
+The handle returned by call to NTCreateFile is not of type FILE_TYPE_DISK.
+<paramref name="options" /> contains an unsupported value.</exception>
+      <exception cref="T:System.IO.FileNotFoundException">The file cannot be found.</exception>
+      <exception cref="T:System.IO.IOException">An I/O error occurred.</exception>
+      <exception cref="T:System.Security.SecurityException">The caller does not have the required permission.</exception>
+      <exception cref="T:System.IO.DirectoryNotFoundException">The specified <paramref name="path" /> is invalid, such as being on an unmapped drive.</exception>
+      <exception cref="T:System.UnauthorizedAccessException">The access requested is not permitted by the operating system for the specified path. This occurs when Write or ReadWrite access is specified, and the file or directory is set for read-only access.</exception>
+      <exception cref="T:System.InvalidOperationException">NtCreateFile fails with error code set to ERROR_SHARING_VIOLATION.</exception>
+    </member>
+    <member name="P:System.Data.SqlTypes.SqlFileStream.CanRead">
+      <summary>Gets a value indicating whether the current stream supports reading.</summary>
+      <returns>
+        <see langword="true" /> if the current stream supports reading; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="P:System.Data.SqlTypes.SqlFileStream.CanSeek">
+      <summary>Gets a value indicating whether the current stream supports seeking.</summary>
+      <returns>
+        <see langword="true" /> if the current stream supports seeking; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="P:System.Data.SqlTypes.SqlFileStream.CanWrite">
+      <summary>Gets a value indicating whether the current stream supports writing.</summary>
+      <returns>
+        <see langword="true" /> if the current stream supports writing; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlTypes.SqlFileStream.Flush">
+      <summary>clears all buffers for this stream and causes any buffered data to be written to the underlying device.</summary>
+    </member>
+    <member name="P:System.Data.SqlTypes.SqlFileStream.Length">
+      <summary>Gets a value indicating the length of the current stream in bytes.</summary>
+      <returns>An <see cref="T:System.Int64" /> indicating the length of the current stream in bytes.</returns>
+    </member>
+    <member name="P:System.Data.SqlTypes.SqlFileStream.Name">
+      <summary>Gets the logical path of the <see cref="T:System.Data.SqlTypes.SqlFileStream" /> passed to the constructor.</summary>
+      <returns>A string value indicating the name of the <see cref="T:System.Data.SqlTypes.SqlFileStream" />.</returns>
+    </member>
+    <member name="P:System.Data.SqlTypes.SqlFileStream.Position">
+      <summary>Gets or sets the position within the current stream.</summary>
+      <returns>The current position within the <see cref="T:System.Data.SqlTypes.SqlFileStream" />.</returns>
+    </member>
+    <member name="M:System.Data.SqlTypes.SqlFileStream.Read(System.Byte[],System.Int32,System.Int32)">
+      <summary>Reads a sequence of bytes from the current stream and advances the position within the stream by the number of bytes read.</summary>
+      <param name="buffer">An array of bytes. When this method returns, the buffer contains the specified byte array with the values between offset and (offset + count - 1) replaced by the bytes read from the current source.</param>
+      <param name="offset">The zero-based byte offset in buffer at which to begin storing the data read from the current stream.</param>
+      <param name="count">The maximum number of bytes to be read from the current stream.</param>
+      <returns>The total number of bytes read into the buffer. This can be less than the number of bytes requested if that many bytes are not currently available, or zero (0) if the end of the stream has been reached.</returns>
+      <exception cref="T:System.NotSupportedException">The object does not support reading of data.</exception>
+    </member>
+    <member name="M:System.Data.SqlTypes.SqlFileStream.Seek(System.Int64,System.IO.SeekOrigin)">
+      <summary>Sets the position within the current stream.</summary>
+      <param name="offset">A byte offset relative to the <paramref name="origin" /> parameter</param>
+      <param name="origin">A value of type <see cref="T:System.IO.SeekOrigin" /> indicating the reference point used to obtain the new position</param>
+      <returns>The new position within the current stream.</returns>
+    </member>
+    <member name="M:System.Data.SqlTypes.SqlFileStream.SetLength(System.Int64)">
+      <summary>Sets the length of the current stream.</summary>
+      <param name="value">The desired length of the current stream in bytes.</param>
+      <exception cref="T:System.NotSupportedException">The object does not support reading of data.</exception>
+    </member>
+    <member name="P:System.Data.SqlTypes.SqlFileStream.TransactionContext">
+      <summary>Gets or sets the transaction context for this <see cref="T:System.Data.SqlTypes.SqlFileStream" /> object.</summary>
+      <returns>The <paramref name="transactionContext" /> array that was passed to the constructor for this <see cref="T:System.Data.SqlTypes.SqlFileStream" /> object.</returns>
+    </member>
+    <member name="M:System.Data.SqlTypes.SqlFileStream.Write(System.Byte[],System.Int32,System.Int32)">
+      <summary>Writes a sequence of bytes to the current stream and advances the current position within this stream by the number of bytes written.</summary>
+      <param name="buffer">An array of bytes. This method copies <paramref name="count" /> bytes from <paramref name="buffer" /> to the current stream.</param>
+      <param name="offset">The zero-based byte offset in <paramref name="buffer" /> at which to begin copying bytes to the current stream.</param>
+      <param name="count">The number of bytes to be written to the current stream.</param>
+      <exception cref="T:System.NotSupportedException">The object does not support writing of data.</exception>
+    </member>
+  </members>
+</doc>

--- a/src/System.Json/src/System.Json.xml
+++ b/src/System.Json/src/System.Json.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>System.Json</name>
+    </assembly>
+    <members>
+        <member name="P:System.SR.ArgumentException_ExtraCharacters">
+            <summary>Extra characters in JSON input.</summary>
+        </member>
+        <member name="P:System.SR.ArgumentException_IncompleteInput">
+            <summary>Incomplete JSON input.</summary>
+        </member>
+        <member name="P:System.SR.ArgumentException_UnexpectedCharacter">
+            <summary>Unexpected character '{0}'.</summary>
+        </member>
+        <member name="P:System.SR.ArgumentException_ArrayMustEndWithBracket">
+            <summary>JSON array must end with ']'.</summary>
+        </member>
+        <member name="P:System.SR.ArgumentException_LeadingZeros">
+            <summary>Leading zeros are not allowed.</summary>
+        </member>
+        <member name="P:System.SR.ArgumentException_NoDigitFound">
+            <summary>Invalid JSON numeric literal; no digit found.</summary>
+        </member>
+        <member name="P:System.SR.ArgumentException_ExtraDot">
+            <summary>Invalid JSON numeric literal; extra dot.</summary>
+        </member>
+        <member name="P:System.SR.ArgumentException_IncompleteExponent">
+            <summary>Invalid JSON numeric literal; incomplete exponent.</summary>
+        </member>
+        <member name="P:System.SR.ArgumentException_InvalidLiteralFormat">
+            <summary>Invalid JSON string literal format.</summary>
+        </member>
+        <member name="P:System.SR.ArgumentException_StringNotClosed">
+            <summary>JSON string is not closed.</summary>
+        </member>
+        <member name="P:System.SR.ArgumentException_IncompleteEscapeSequence">
+            <summary>Invalid JSON string literal; incomplete escape sequence.</summary>
+        </member>
+        <member name="P:System.SR.ArgumentException_IncompleteEscapeLiteral">
+            <summary>Incomplete unicode character escape literal.</summary>
+        </member>
+        <member name="P:System.SR.ArgumentException_UnexpectedEscapeCharacter">
+            <summary>Invalid JSON string literal; unexpected escape character.</summary>
+        </member>
+        <member name="P:System.SR.ArgumentException_ExpectedXButGotY">
+            <summary>Expected '{0}', got '{1}'.</summary>
+        </member>
+        <member name="P:System.SR.ArgumentException_ExpectedXDiferedAtY">
+            <summary>Expected '{0}', differed at {1}.</summary>
+        </member>
+        <member name="P:System.SR.ArgumentException_MessageAt">
+            <summary>{0} At line {1}, column {2}.</summary>
+        </member>
+        <member name="P:System.SR.NotImplemented_GetFormattedString">
+            <summary>GetFormattedString from value type {0}.</summary>
+        </member>
+    </members>
+</doc>

--- a/src/System.Memory/src/System.Memory.xml
+++ b/src/System.Memory/src/System.Memory.xml
@@ -1,0 +1,3489 @@
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>System.Memory</name>
+    </assembly>
+    <members>
+        <member name="T:System.Buffers.Binary.BinaryPrimitives">
+            <summary>
+            Reads bytes as primitives with specific endianness
+            </summary>
+            <remarks>
+            For native formats, MemoryExtensions.Read{T}; should be used.
+            Use these helpers when you need to read specific endinanness.
+            </remarks>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.ReverseEndianness(System.SByte)">
+            <summary>
+            This is a no-op and added only for consistency.
+            This allows the caller to read a struct of numeric primitives and reverse each field
+            rather than having to skip sbyte fields.
+            </summary> 
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.ReverseEndianness(System.Int16)">
+            <summary>
+            Reverses a primitive value - performs an endianness swap
+            </summary> 
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.ReverseEndianness(System.Int32)">
+            <summary>
+            Reverses a primitive value - performs an endianness swap
+            </summary> 
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.ReverseEndianness(System.Int64)">
+            <summary>
+            Reverses a primitive value - performs an endianness swap
+            </summary> 
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.ReverseEndianness(System.Byte)">
+            <summary>
+            This is a no-op and added only for consistency.
+            This allows the caller to read a struct of numeric primitives and reverse each field
+            rather than having to skip byte fields.
+            </summary> 
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.ReverseEndianness(System.UInt16)">
+            <summary>
+            Reverses a primitive value - performs an endianness swap
+            </summary> 
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.ReverseEndianness(System.UInt32)">
+            <summary>
+            Reverses a primitive value - performs an endianness swap
+            </summary> 
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.ReverseEndianness(System.UInt64)">
+            <summary>
+            Reverses a primitive value - performs an endianness swap
+            </summary> 
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.ReadInt16BigEndian(System.ReadOnlySpan{System.Byte})">
+            <summary>
+            Reads an Int16 out of a read-only span of bytes as big endian.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.ReadInt32BigEndian(System.ReadOnlySpan{System.Byte})">
+            <summary>
+            Reads an Int32 out of a read-only span of bytes as big endian.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.ReadInt64BigEndian(System.ReadOnlySpan{System.Byte})">
+            <summary>
+            Reads an Int64 out of a read-only span of bytes as big endian.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.ReadUInt16BigEndian(System.ReadOnlySpan{System.Byte})">
+            <summary>
+            Reads a UInt16 out of a read-only span of bytes as big endian.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.ReadUInt32BigEndian(System.ReadOnlySpan{System.Byte})">
+            <summary>
+            Reads a UInt32 out of a read-only span of bytes as big endian.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.ReadUInt64BigEndian(System.ReadOnlySpan{System.Byte})">
+            <summary>
+            Reads a UInt64 out of a read-only span of bytes as big endian.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.TryReadInt16BigEndian(System.ReadOnlySpan{System.Byte},System.Int16@)">
+            <summary>
+            Reads an Int16 out of a read-only span of bytes as big endian.
+            <returns>If the span is too small to contain an Int16, return false.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.TryReadInt32BigEndian(System.ReadOnlySpan{System.Byte},System.Int32@)">
+            <summary>
+            Reads an Int32 out of a read-only span of bytes as big endian.
+            <returns>If the span is too small to contain an Int32, return false.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.TryReadInt64BigEndian(System.ReadOnlySpan{System.Byte},System.Int64@)">
+            <summary>
+            Reads an Int64 out of a read-only span of bytes as big endian.
+            <returns>If the span is too small to contain an Int64, return false.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.TryReadUInt16BigEndian(System.ReadOnlySpan{System.Byte},System.UInt16@)">
+            <summary>
+            Reads a UInt16 out of a read-only span of bytes as big endian.
+            <returns>If the span is too small to contain a UInt16, return false.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.TryReadUInt32BigEndian(System.ReadOnlySpan{System.Byte},System.UInt32@)">
+            <summary>
+            Reads a UInt32 out of a read-only span of bytes as big endian.
+            <returns>If the span is too small to contain a UInt32, return false.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.TryReadUInt64BigEndian(System.ReadOnlySpan{System.Byte},System.UInt64@)">
+            <summary>
+            Reads a UInt64 out of a read-only span of bytes as big endian.
+            <returns>If the span is too small to contain a UInt64, return false.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.ReadInt16LittleEndian(System.ReadOnlySpan{System.Byte})">
+            <summary>
+            Reads an Int16 out of a read-only span of bytes as little endian.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.ReadInt32LittleEndian(System.ReadOnlySpan{System.Byte})">
+            <summary>
+            Reads an Int32 out of a read-only span of bytes as little endian.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.ReadInt64LittleEndian(System.ReadOnlySpan{System.Byte})">
+            <summary>
+            Reads an Int64 out of a read-only span of bytes as little endian.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.ReadUInt16LittleEndian(System.ReadOnlySpan{System.Byte})">
+            <summary>
+            Reads a UInt16 out of a read-only span of bytes as little endian.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(System.ReadOnlySpan{System.Byte})">
+            <summary>
+            Reads a UInt32 out of a read-only span of bytes as little endian.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.ReadUInt64LittleEndian(System.ReadOnlySpan{System.Byte})">
+            <summary>
+            Reads a UInt64 out of a read-only span of bytes as little endian.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.TryReadInt16LittleEndian(System.ReadOnlySpan{System.Byte},System.Int16@)">
+            <summary>
+            Reads an Int16 out of a read-only span of bytes as little endian.
+            <returns>If the span is too small to contain an Int16, return false.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.TryReadInt32LittleEndian(System.ReadOnlySpan{System.Byte},System.Int32@)">
+            <summary>
+            Reads an Int32 out of a read-only span of bytes as little endian.
+            <returns>If the span is too small to contain an Int32, return false.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.TryReadInt64LittleEndian(System.ReadOnlySpan{System.Byte},System.Int64@)">
+            <summary>
+            Reads an Int64 out of a read-only span of bytes as little endian.
+            <returns>If the span is too small to contain an Int64, return false.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.TryReadUInt16LittleEndian(System.ReadOnlySpan{System.Byte},System.UInt16@)">
+            <summary>
+            Reads a UInt16 out of a read-only span of bytes as little endian.
+            <returns>If the span is too small to contain a UInt16, return false.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.TryReadUInt32LittleEndian(System.ReadOnlySpan{System.Byte},System.UInt32@)">
+            <summary>
+            Reads a UInt32 out of a read-only span of bytes as little endian.
+            <returns>If the span is too small to contain a UInt32, return false.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.TryReadUInt64LittleEndian(System.ReadOnlySpan{System.Byte},System.UInt64@)">
+            <summary>
+            Reads a UInt64 out of a read-only span of bytes as little endian.
+            <returns>If the span is too small to contain a UInt64, return false.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.WriteInt16BigEndian(System.Span{System.Byte},System.Int16)">
+            <summary>
+            Writes an Int16 into a span of bytes as big endian.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.WriteInt32BigEndian(System.Span{System.Byte},System.Int32)">
+            <summary>
+            Writes an Int32 into a span of bytes as big endian.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.WriteInt64BigEndian(System.Span{System.Byte},System.Int64)">
+            <summary>
+            Writes an Int64 into a span of bytes as big endian.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.WriteUInt16BigEndian(System.Span{System.Byte},System.UInt16)">
+            <summary>
+            Write a UInt16 into a span of bytes as big endian.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.WriteUInt32BigEndian(System.Span{System.Byte},System.UInt32)">
+            <summary>
+            Write a UInt32 into a span of bytes as big endian.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.WriteUInt64BigEndian(System.Span{System.Byte},System.UInt64)">
+            <summary>
+            Write a UInt64 into a span of bytes as big endian.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.TryWriteInt16BigEndian(System.Span{System.Byte},System.Int16)">
+            <summary>
+            Writes an Int16 into a span of bytes as big endian.
+            <returns>If the span is too small to contain the value, return false.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.TryWriteInt32BigEndian(System.Span{System.Byte},System.Int32)">
+            <summary>
+            Writes an Int32 into a span of bytes as big endian.
+            <returns>If the span is too small to contain the value, return false.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.TryWriteInt64BigEndian(System.Span{System.Byte},System.Int64)">
+            <summary>
+            Writes an Int64 into a span of bytes as big endian.
+            <returns>If the span is too small to contain the value, return false.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.TryWriteUInt16BigEndian(System.Span{System.Byte},System.UInt16)">
+            <summary>
+            Write a UInt16 into a span of bytes as big endian.
+            <returns>If the span is too small to contain the value, return false.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.TryWriteUInt32BigEndian(System.Span{System.Byte},System.UInt32)">
+            <summary>
+            Write a UInt32 into a span of bytes as big endian.
+            <returns>If the span is too small to contain the value, return false.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.TryWriteUInt64BigEndian(System.Span{System.Byte},System.UInt64)">
+            <summary>
+            Write a UInt64 into a span of bytes as big endian.
+            <returns>If the span is too small to contain the value, return false.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.WriteInt16LittleEndian(System.Span{System.Byte},System.Int16)">
+            <summary>
+            Writes an Int16 into a span of bytes as little endian.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.WriteInt32LittleEndian(System.Span{System.Byte},System.Int32)">
+            <summary>
+            Writes an Int32 into a span of bytes as little endian.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.WriteInt64LittleEndian(System.Span{System.Byte},System.Int64)">
+            <summary>
+            Writes an Int64 into a span of bytes as little endian.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(System.Span{System.Byte},System.UInt16)">
+            <summary>
+            Write a UInt16 into a span of bytes as little endian.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.WriteUInt32LittleEndian(System.Span{System.Byte},System.UInt32)">
+            <summary>
+            Write a UInt32 into a span of bytes as little endian.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.WriteUInt64LittleEndian(System.Span{System.Byte},System.UInt64)">
+            <summary>
+            Write a UInt64 into a span of bytes as little endian.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.TryWriteInt16LittleEndian(System.Span{System.Byte},System.Int16)">
+            <summary>
+            Writes an Int16 into a span of bytes as little endian.
+            <returns>If the span is too small to contain the value, return false.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.TryWriteInt32LittleEndian(System.Span{System.Byte},System.Int32)">
+            <summary>
+            Writes an Int32 into a span of bytes as little endian.
+            <returns>If the span is too small to contain the value, return false.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.TryWriteInt64LittleEndian(System.Span{System.Byte},System.Int64)">
+            <summary>
+            Writes an Int64 into a span of bytes as little endian.
+            <returns>If the span is too small to contain the value, return false.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.TryWriteUInt16LittleEndian(System.Span{System.Byte},System.UInt16)">
+            <summary>
+            Write a UInt16 into a span of bytes as little endian.
+            <returns>If the span is too small to contain the value, return false.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.TryWriteUInt32LittleEndian(System.Span{System.Byte},System.UInt32)">
+            <summary>
+            Write a UInt32 into a span of bytes as little endian.
+            <returns>If the span is too small to contain the value, return false.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Binary.BinaryPrimitives.TryWriteUInt64LittleEndian(System.Span{System.Byte},System.UInt64)">
+            <summary>
+            Write a UInt64 into a span of bytes as little endian.
+            <returns>If the span is too small to contain the value, return false.</returns>
+            </summary>
+        </member>
+        <member name="T:System.Buffers.BuffersExtensions">
+            <summary>
+            Extension methods for <see cref="T:System.Buffers.ReadOnlySequence`1"/>
+            </summary>
+        </member>
+        <member name="M:System.Buffers.BuffersExtensions.PositionOf``1(System.Buffers.ReadOnlySequence{``0}@,``0)">
+            <summary>
+            Returns position of first occurrence of item in the <see cref="T:System.Buffers.ReadOnlySequence`1"/>
+            </summary>
+        </member>
+        <member name="M:System.Buffers.BuffersExtensions.CopyTo``1(System.Buffers.ReadOnlySequence{``0}@,System.Span{``0})">
+            <summary>
+            Copy the <see cref="T:System.Buffers.ReadOnlySequence`1"/> to the specified <see cref="T:System.Span`1"/>.
+            </summary>
+            <param name="source">The source <see cref="T:System.Buffers.ReadOnlySequence`1"/>.</param>
+            <param name="destination">The destination <see cref="T:System.Span`1"/>.</param>
+        </member>
+        <member name="M:System.Buffers.BuffersExtensions.ToArray``1(System.Buffers.ReadOnlySequence{``0}@)">
+            <summary>
+            Converts the <see cref="T:System.Buffers.ReadOnlySequence`1"/> to an array
+            </summary>
+        </member>
+        <member name="M:System.Buffers.BuffersExtensions.Write``1(System.Buffers.IBufferWriter{``0},System.ReadOnlySpan{``0})">
+            <summary>
+            Writes contents of <paramref name="value"/> to <paramref name="writer"/>
+            </summary>
+        </member>
+        <member name="T:System.Buffers.IBufferWriter`1">
+            <summary>
+            Represents a <typeparam name="T"/> sink
+            </summary>
+        </member>
+        <member name="M:System.Buffers.IBufferWriter`1.Advance(System.Int32)">
+            <summary>
+            Notifies <see cref="T:System.Buffers.IBufferWriter`1"/> that <paramref name="count"/> amount of data was written to <see cref="T:System.Span`1"/>/<see cref="T:System.Memory`1"/>
+            </summary>
+        </member>
+        <member name="M:System.Buffers.IBufferWriter`1.GetMemory(System.Int32)">
+            <summary>
+            Requests the <see cref="T:System.Memory`1"/> that is at least <paramref name="sizeHint"/> in size if possible, otherwise returns maximum available memory.
+            If <paramref name="sizeHint"/> is equal to <code>0</code>, currently available memory would get returned.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.IBufferWriter`1.GetSpan(System.Int32)">
+            <summary>
+            Requests the <see cref="T:System.Span`1"/> that is at least <paramref name="sizeHint"/> in size if possible, otherwise returns maximum available memory.
+            If <paramref name="sizeHint"/> is equal to <code>0</code>, currently available memory would get returned.
+            </summary>
+        </member>
+        <member name="T:System.Buffers.IMemoryOwner`1">
+            <summary>
+            Owner of Memory<typeparamref name="T"/> that is responsible for disposing the underlying memory appropriately.
+            </summary>
+        </member>
+        <member name="P:System.Buffers.IMemoryOwner`1.Memory">
+            <summary>
+            Returns a Memory<typeparamref name="T"/>.
+            </summary>
+        </member>
+        <member name="T:System.Buffers.IPinnable">
+            <summary>
+            Provides a mechanism for pinning and unpinning objects to prevent the GC from moving them.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.IPinnable.Pin(System.Int32)">
+            <summary>
+            Call this method to indicate that the IPinnable object can not be moved by the garbage collector.
+            The address of the pinned object can be taken.
+            <param name="elementIndex">The offset to the element within the memory at which the returned <see cref="T:System.Buffers.MemoryHandle"/> points to.</param>
+            </summary>
+        </member>
+        <member name="M:System.Buffers.IPinnable.Unpin">
+            <summary>
+            Call this method to indicate that the IPinnable object no longer needs to be pinned.
+            The garbage collector is free to move the object now.
+            </summary>
+        </member>
+        <member name="T:System.Buffers.MemoryHandle">
+            <summary>
+            A handle for the memory.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.MemoryHandle.#ctor(System.Void*,System.Runtime.InteropServices.GCHandle,System.Buffers.IPinnable)">
+            <summary>
+            Creates a new memory handle for the memory.
+            </summary>
+            <param name="pointer">pointer to memory</param>
+            <param name="pinnable">reference to manually managed object, or default if there is no memory manager</param>
+            <param name="handle">handle used to pin array buffers</param>
+        </member>
+        <member name="P:System.Buffers.MemoryHandle.Pointer">
+            <summary>
+            Returns the pointer to memory, where the memory is assumed to be pinned and hence the address won't change.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.MemoryHandle.Dispose">
+            <summary>
+            Frees the pinned handle and releases IPinnable.
+            </summary>
+        </member>
+        <member name="T:System.Buffers.MemoryManager`1">
+            <summary>
+            Manager of <see cref="T:System.Memory`1"/> that provides the implementation.
+            </summary>
+        </member>
+        <member name="P:System.Buffers.MemoryManager`1.Memory">
+            <summary>
+            Returns a <see cref="T:System.Memory`1"/>.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.MemoryManager`1.GetSpan">
+            <summary>
+            Returns a span wrapping the underlying memory.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.MemoryManager`1.Pin(System.Int32)">
+            <summary>
+            Returns a handle to the memory that has been pinned and hence its address can be taken.
+            </summary>
+            <param name="elementIndex">The offset to the element within the memory at which the returned <see cref="T:System.Buffers.MemoryHandle"/> points to. (default = 0)</param>
+        </member>
+        <member name="M:System.Buffers.MemoryManager`1.Unpin">
+            <summary>
+            Lets the garbage collector know that the object is free to be moved now.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.MemoryManager`1.CreateMemory(System.Int32)">
+            <summary>
+            Returns a <see cref="T:System.Memory`1"/> for the current <see cref="T:System.Buffers.MemoryManager`1"/>.
+            </summary>
+            <param name="length">The element count in the memory, starting at offset 0.</param>
+        </member>
+        <member name="M:System.Buffers.MemoryManager`1.CreateMemory(System.Int32,System.Int32)">
+            <summary>
+            Returns a <see cref="T:System.Memory`1"/> for the current <see cref="T:System.Buffers.MemoryManager`1"/>.
+            </summary>
+            <param name="start">The offset to the element which the returned memory starts at.</param>
+            <param name="length">The element count in the memory, starting at element offset <paramref name="start"/>.</param>
+        </member>
+        <member name="M:System.Buffers.MemoryManager`1.TryGetArray(System.ArraySegment{`0}@)">
+            <summary>
+            Returns an array segment.
+            <remarks>Returns the default array segment if not overriden.</remarks>
+            </summary>
+        </member>
+        <member name="M:System.Buffers.MemoryManager`1.System#IDisposable#Dispose">
+            <summary>
+            Implements IDisposable.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.MemoryManager`1.Dispose(System.Boolean)">
+            <summary>
+            Clean up of any leftover managed and unmanaged resources.
+            </summary>
+        </member>
+        <member name="T:System.Buffers.MemoryPool`1">
+            <summary>
+            Represents a pool of memory blocks.
+            </summary>
+        </member>
+        <member name="P:System.Buffers.MemoryPool`1.Shared">
+            <summary>
+            Returns a singleton instance of a MemoryPool based on arrays.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.MemoryPool`1.Rent(System.Int32)">
+            <summary>
+            Returns a memory block capable of holding at least <paramref name="minBufferSize" /> elements of T.
+            </summary>
+            <param name="minBufferSize">If -1 is passed, this is set to a default value for the pool.</param>
+        </member>
+        <member name="P:System.Buffers.MemoryPool`1.MaxBufferSize">
+            <summary>
+            Returns the maximum buffer size supported by this pool.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.MemoryPool`1.#ctor">
+            <summary>
+            Constructs a new instance of a memory pool.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.MemoryPool`1.Dispose">
+            <summary>
+            Frees all resources used by the memory pool.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.MemoryPool`1.Dispose(System.Boolean)">
+            <summary>
+            Frees all resources used by the memory pool.
+            </summary>
+            <param name="disposing"></param>
+        </member>
+        <member name="T:System.Buffers.OperationStatus">
+            <summary>
+            This enum defines the various potential status that can be returned from Span-based operations
+            that support processing of input contained in multiple discontiguous buffers.
+            </summary>
+        </member>
+        <member name="F:System.Buffers.OperationStatus.Done">
+            <summary>
+            The entire input buffer has been processed and the operation is complete.
+            </summary>
+        </member>
+        <member name="F:System.Buffers.OperationStatus.DestinationTooSmall">
+            <summary>
+            The input is partially processed, up to what could fit into the destination buffer.
+            The caller can enlarge the destination buffer, slice the buffers appropriately, and retry.
+            </summary>
+        </member>
+        <member name="F:System.Buffers.OperationStatus.NeedMoreData">
+            <summary>
+            The input is partially processed, up to the last valid chunk of the input that could be consumed.
+            The caller can stitch the remaining unprocessed input with more data, slice the buffers appropriately, and retry.
+            </summary>
+        </member>
+        <member name="F:System.Buffers.OperationStatus.InvalidData">
+            <summary>
+            The input contained invalid bytes which could not be processed. If the input is partially processed,
+            the destination contains the partial result. This guarantees that no additional data appended to the input
+            will make the invalid sequence valid.
+            </summary>
+        </member>
+        <member name="T:System.Buffers.ReadOnlySequence`1">
+            <summary>
+            Represents a sequence that can read a sequential series of <typeparam name="T" />.
+            </summary>
+        </member>
+        <member name="F:System.Buffers.ReadOnlySequence`1.Empty">
+            <summary>
+            Returns empty <see cref="T:System.Buffers.ReadOnlySequence`1"/>
+            </summary>
+        </member>
+        <member name="P:System.Buffers.ReadOnlySequence`1.Length">
+            <summary>
+            Length of the <see cref="T:System.Buffers.ReadOnlySequence`1"/>.
+            </summary>
+        </member>
+        <member name="P:System.Buffers.ReadOnlySequence`1.IsEmpty">
+            <summary>
+            Determines if the <see cref="T:System.Buffers.ReadOnlySequence`1"/> is empty.
+            </summary>
+        </member>
+        <member name="P:System.Buffers.ReadOnlySequence`1.IsSingleSegment">
+            <summary>
+            Determines if the <see cref="T:System.Buffers.ReadOnlySequence`1"/> contains a single <see cref="T:System.ReadOnlyMemory`1"/> segment.
+            </summary>
+        </member>
+        <member name="P:System.Buffers.ReadOnlySequence`1.First">
+            <summary>
+            Gets <see cref="T:System.ReadOnlyMemory`1"/> from the first segment.
+            </summary>
+        </member>
+        <member name="P:System.Buffers.ReadOnlySequence`1.Start">
+            <summary>
+            A position to the start of the <see cref="T:System.Buffers.ReadOnlySequence`1"/>.
+            </summary>
+        </member>
+        <member name="P:System.Buffers.ReadOnlySequence`1.End">
+            <summary>
+            A position to the end of the <see cref="T:System.Buffers.ReadOnlySequence`1"/>
+            </summary>
+        </member>
+        <member name="M:System.Buffers.ReadOnlySequence`1.#ctor(System.Buffers.ReadOnlySequenceSegment{`0},System.Int32,System.Buffers.ReadOnlySequenceSegment{`0},System.Int32)">
+            <summary>
+            Creates an instance of <see cref="T:System.Buffers.ReadOnlySequence`1"/> from linked memory list represented by start and end segments
+            and corresponding indexes in them.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.ReadOnlySequence`1.#ctor(`0[])">
+            <summary>
+            Creates an instance of <see cref="T:System.Buffers.ReadOnlySequence`1"/> from the <see cref="T:T[]"/>.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.ReadOnlySequence`1.#ctor(`0[],System.Int32,System.Int32)">
+            <summary>
+            Creates an instance of <see cref="T:System.Buffers.ReadOnlySequence`1"/> from the <see cref="T:T[]"/>, start and index.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.ReadOnlySequence`1.#ctor(System.ReadOnlyMemory{`0})">
+            <summary>
+            Creates an instance of <see cref="T:System.Buffers.ReadOnlySequence`1"/> from the <see cref="T:System.ReadOnlyMemory`1"/>.
+            Consumer is expected to manage lifetime of memory until <see cref="T:System.Buffers.ReadOnlySequence`1"/> is not used anymore.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.ReadOnlySequence`1.Slice(System.Int64,System.Int64)">
+            <summary>
+            Forms a slice out of the given <see cref="T:System.Buffers.ReadOnlySequence`1"/>, beginning at <paramref name="start"/>, with <paramref name="length"/> items
+            </summary>
+            <param name="start">The index at which to begin this slice.</param>
+            <param name="length">The length of the slice</param>
+        </member>
+        <member name="M:System.Buffers.ReadOnlySequence`1.Slice(System.Int64,System.SequencePosition)">
+            <summary>
+            Forms a slice out of the given <see cref="T:System.Buffers.ReadOnlySequence`1"/>, beginning at <paramref name="start"/>, ending at <paramref name="end"/> (inclusive).
+            </summary>
+            <param name="start">The index at which to begin this slice.</param>
+            <param name="end">The end (inclusive) of the slice</param>
+        </member>
+        <member name="M:System.Buffers.ReadOnlySequence`1.Slice(System.SequencePosition,System.Int64)">
+            <summary>
+            Forms a slice out of the given <see cref="T:System.Buffers.ReadOnlySequence`1"/>, beginning at <paramref name="start"/>, with <paramref name="length"/> items
+            </summary>
+            <param name="start">The starting (inclusive) <see cref="T:System.SequencePosition"/> at which to begin this slice.</param>
+            <param name="length">The length of the slice</param>
+        </member>
+        <member name="M:System.Buffers.ReadOnlySequence`1.Slice(System.Int32,System.Int32)">
+            <summary>
+            Forms a slice out of the given <see cref="T:System.Buffers.ReadOnlySequence`1"/>, beginning at <paramref name="start"/>, with <paramref name="length"/> items
+            </summary>
+            <param name="start">The index at which to begin this slice.</param>
+            <param name="length">The length of the slice</param>
+        </member>
+        <member name="M:System.Buffers.ReadOnlySequence`1.Slice(System.Int32,System.SequencePosition)">
+            <summary>
+            Forms a slice out of the given <see cref="T:System.Buffers.ReadOnlySequence`1"/>, beginning at <paramref name="start"/>, ending at <paramref name="end"/> (inclusive).
+            </summary>
+            <param name="start">The index at which to begin this slice.</param>
+            <param name="end">The end (inclusive) of the slice</param>
+        </member>
+        <member name="M:System.Buffers.ReadOnlySequence`1.Slice(System.SequencePosition,System.Int32)">
+            <summary>
+            Forms a slice out of the given <see cref="T:System.Buffers.ReadOnlySequence`1"/>, beginning at '<paramref name="start"/>, with <paramref name="length"/> items
+            </summary>
+            <param name="start">The starting (inclusive) <see cref="T:System.SequencePosition"/> at which to begin this slice.</param>
+            <param name="length">The length of the slice</param>
+        </member>
+        <member name="M:System.Buffers.ReadOnlySequence`1.Slice(System.SequencePosition,System.SequencePosition)">
+            <summary>
+            Forms a slice out of the given <see cref="T:System.Buffers.ReadOnlySequence`1"/>, beginning at <paramref name="start"/>, ending at <paramref name="end"/> (inclusive).
+            </summary>
+            <param name="start">The starting (inclusive) <see cref="T:System.SequencePosition"/> at which to begin this slice.</param>
+            <param name="end">The ending (inclusive) <see cref="T:System.SequencePosition"/> of the slice</param>
+        </member>
+        <member name="M:System.Buffers.ReadOnlySequence`1.Slice(System.SequencePosition)">
+            <summary>
+            Forms a slice out of the given <see cref="T:System.Buffers.ReadOnlySequence`1"/>, beginning at <paramref name="start"/>, ending at the existing <see cref="T:System.Buffers.ReadOnlySequence`1"/>'s end.
+            </summary>
+            <param name="start">The starting (inclusive) <see cref="T:System.SequencePosition"/> at which to begin this slice.</param>
+        </member>
+        <member name="M:System.Buffers.ReadOnlySequence`1.Slice(System.Int64)">
+            <summary>
+            Forms a slice out of the given <see cref="T:System.Buffers.ReadOnlySequence`1"/>, beginning at <paramref name="start"/>, ending at the existing <see cref="T:System.Buffers.ReadOnlySequence`1"/>'s end.
+            </summary>
+            <param name="start">The start index at which to begin this slice.</param>
+        </member>
+        <member name="M:System.Buffers.ReadOnlySequence`1.ToString">
+            <inheritdoc />
+        </member>
+        <member name="M:System.Buffers.ReadOnlySequence`1.GetEnumerator">
+            <summary>
+            Returns an enumerator over the <see cref="T:System.Buffers.ReadOnlySequence`1"/>
+            </summary>
+        </member>
+        <member name="M:System.Buffers.ReadOnlySequence`1.GetPosition(System.Int64)">
+            <summary>
+            Returns a new <see cref="T:System.SequencePosition"/> at an <paramref name="offset"/> from the start of the sequence.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.ReadOnlySequence`1.GetPosition(System.Int64,System.SequencePosition)">
+            <summary>
+            Returns a new <see cref="T:System.SequencePosition"/> at an <paramref name="offset"/> from the <paramref name="origin"/>
+            </summary>
+        </member>
+        <member name="M:System.Buffers.ReadOnlySequence`1.TryGet(System.SequencePosition@,System.ReadOnlyMemory{`0}@,System.Boolean)">
+            <summary>
+            Tries to retrieve next segment after <paramref name="position"/> and return its contents in <paramref name="memory"/>.
+            Returns <code>false</code> if end of <see cref="T:System.Buffers.ReadOnlySequence`1"/> was reached otherwise <code>true</code>.
+            Sets <paramref name="position"/> to the beginning of next segment if <paramref name="advance"/> is set to <code>true</code>.
+            </summary>
+        </member>
+        <member name="T:System.Buffers.ReadOnlySequence`1.Enumerator">
+            <summary>
+            An enumerator over the <see cref="T:System.Buffers.ReadOnlySequence`1"/>
+            </summary>
+        </member>
+        <member name="M:System.Buffers.ReadOnlySequence`1.Enumerator.#ctor(System.Buffers.ReadOnlySequence{`0}@)">
+            <summary>Initialize the enumerator.</summary>
+            <param name="sequence">The <see cref="T:System.Buffers.ReadOnlySequence`1"/> to enumerate.</param>
+        </member>
+        <member name="P:System.Buffers.ReadOnlySequence`1.Enumerator.Current">
+            <summary>
+            The current <see cref="T:System.ReadOnlyMemory`1"/>
+            </summary>
+        </member>
+        <member name="M:System.Buffers.ReadOnlySequence`1.Enumerator.MoveNext">
+            <summary>
+            Moves to the next <see cref="T:System.ReadOnlyMemory`1"/> in the <see cref="T:System.Buffers.ReadOnlySequence`1"/>
+            </summary>
+            <returns></returns>
+        </member>
+        <member name="T:System.Buffers.ReadOnlySequenceSegment`1">
+            <summary>
+            Represents a linked list of <see cref="T:System.ReadOnlyMemory`1"/> nodes.
+            </summary>
+        </member>
+        <member name="P:System.Buffers.ReadOnlySequenceSegment`1.Memory">
+            <summary>
+            The <see cref="T:System.ReadOnlyMemory`1"/> value for current node.
+            </summary>
+        </member>
+        <member name="P:System.Buffers.ReadOnlySequenceSegment`1.Next">
+            <summary>
+            The next node.
+            </summary>
+        </member>
+        <member name="P:System.Buffers.ReadOnlySequenceSegment`1.RunningIndex">
+            <summary>
+            The sum of node length before current.
+            </summary>
+        </member>
+        <member name="T:System.Buffers.StandardFormat">
+            <summary>
+            Represents a standard formatting string without using an actual String. A StandardFormat consists of a character (such as 'G', 'D' or 'X')
+            and an optional precision ranging from 0..99, or the special value NoPrecision.
+            </summary>
+        </member>
+        <member name="F:System.Buffers.StandardFormat.NoPrecision">
+            <summary>
+            Precision values for format that don't use a precision, or for when the precision is to be unspecified.
+            </summary>
+        </member>
+        <member name="F:System.Buffers.StandardFormat.MaxPrecision">
+            <summary>
+            The maximum valid precision value.
+            </summary>
+        </member>
+        <member name="P:System.Buffers.StandardFormat.Symbol">
+            <summary>
+            The character component of the format.
+            </summary>
+        </member>
+        <member name="P:System.Buffers.StandardFormat.Precision">
+            <summary>
+            The precision component of the format. Ranges from 0..9 or the special value NoPrecision.
+            </summary>
+        </member>
+        <member name="P:System.Buffers.StandardFormat.HasPrecision">
+            <summary>
+            true if Precision is a value other than NoPrecision
+            </summary>
+        </member>
+        <member name="P:System.Buffers.StandardFormat.IsDefault">
+            <summary>
+            true if the StandardFormat == default(StandardFormat)
+            </summary>
+        </member>
+        <member name="M:System.Buffers.StandardFormat.#ctor(System.Char,System.Byte)">
+            <summary>
+            Create a StandardFormat.
+            </summary>
+            <param name="symbol">A type-specific formatting character such as 'G', 'D' or 'X'</param>
+            <param name="precision">An optional precision ranging from 0..9 or the special value NoPrecision (the default)</param>
+        </member>
+        <member name="M:System.Buffers.StandardFormat.op_Implicit(System.Char)~System.Buffers.StandardFormat">
+            <summary>
+            Converts a character to a StandardFormat using the NoPrecision precision.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.StandardFormat.Parse(System.ReadOnlySpan{System.Char})">
+            <summary>
+            Converts a classic .NET format string into a StandardFormat
+            </summary>
+        </member>
+        <member name="M:System.Buffers.StandardFormat.Parse(System.String)">
+            <summary>
+            Converts a classic .NET format string into a StandardFormat
+            </summary>
+        </member>
+        <member name="M:System.Buffers.StandardFormat.Equals(System.Object)">
+            <summary>
+            Returns true if both the Symbol and Precision are equal.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.StandardFormat.GetHashCode">
+            <summary>
+            Compute a hash code.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.StandardFormat.Equals(System.Buffers.StandardFormat)">
+            <summary>
+            Returns true if both the Symbol and Precision are equal.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.StandardFormat.ToString">
+            <summary>
+            Returns the format in classic .NET format.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.StandardFormat.op_Equality(System.Buffers.StandardFormat,System.Buffers.StandardFormat)">
+            <summary>
+            Returns true if both the Symbol and Precision are equal.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.StandardFormat.op_Inequality(System.Buffers.StandardFormat,System.Buffers.StandardFormat)">
+            <summary>
+            Returns false if both the Symbol and Precision are equal.
+            </summary>
+        </member>
+        <member name="T:System.Buffers.Text.Base64">
+            <summary>
+            Convert between binary data and UTF-8 encoded text that is represented in base 64.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Text.Base64.DecodeFromUtf8(System.ReadOnlySpan{System.Byte},System.Span{System.Byte},System.Int32@,System.Int32@,System.Boolean)">
+             <summary>
+             Decode the span of UTF-8 encoded text represented as base 64 into binary data.
+             If the input is not a multiple of 4, it will decode as much as it can, to the closest multiple of 4.
+            
+             <param name="utf8">The input span which contains UTF-8 encoded text in base 64 that needs to be decoded.</param>
+             <param name="bytes">The output span which contains the result of the operation, i.e. the decoded binary data.</param>
+             <param name="bytesConsumed">The number of input bytes consumed during the operation. This can be used to slice the input for subsequent calls, if necessary.</param>
+             <param name="bytesWritten">The number of bytes written into the output span. This can be used to slice the output for subsequent calls, if necessary.</param>
+             <param name="isFinalBlock">True (default) when the input span contains the entire data to decode. 
+             Set to false only if it is known that the input span contains partial data with more data to follow.</param>
+             <returns>It returns the OperationStatus enum values:
+             - Done - on successful processing of the entire input span
+             - DestinationTooSmall - if there is not enough space in the output span to fit the decoded input
+             - NeedMoreData - only if isFinalBlock is false and the input is not a multiple of 4, otherwise the partial input would be considered as InvalidData
+             - InvalidData - if the input contains bytes outside of the expected base 64 range, or if it contains invalid/more than two padding characters,
+               or if the input is incomplete (i.e. not a multiple of 4) and isFinalBlock is true.</returns>
+             </summary> 
+        </member>
+        <member name="M:System.Buffers.Text.Base64.GetMaxDecodedFromUtf8Length(System.Int32)">
+            <summary>
+            Returns the maximum length (in bytes) of the result if you were to deocde base 64 encoded text within a byte span of size "length".
+            </summary>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+            Thrown when the specified <paramref name="length"/> is less than 0.
+            </exception>
+        </member>
+        <member name="M:System.Buffers.Text.Base64.DecodeFromUtf8InPlace(System.Span{System.Byte},System.Int32@)">
+             <summary>
+             Decode the span of UTF-8 encoded text in base 64 (in-place) into binary data.
+             The decoded binary output is smaller than the text data contained in the input (the operation deflates the data).
+             If the input is not a multiple of 4, it will not decode any.
+            
+             <param name="buffer">The input span which contains the base 64 text data that needs to be decoded.</param>
+             <param name="bytesWritten">The number of bytes written into the buffer.</param>
+             <returns>It returns the OperationStatus enum values:
+             - Done - on successful processing of the entire input span
+             - InvalidData - if the input contains bytes outside of the expected base 64 range, or if it contains invalid/more than two padding characters, 
+               or if the input is incomplete (i.e. not a multiple of 4).
+             It does not return DestinationTooSmall since that is not possible for base 64 decoding.
+             It does not return NeedMoreData since this method tramples the data in the buffer and 
+             hence can only be called once with all the data in the buffer.</returns>
+             </summary> 
+        </member>
+        <member name="M:System.Buffers.Text.Base64.EncodeToUtf8(System.ReadOnlySpan{System.Byte},System.Span{System.Byte},System.Int32@,System.Int32@,System.Boolean)">
+             <summary>
+             Encode the span of binary data into UTF-8 encoded text represented as base 64.
+            
+             <param name="bytes">The input span which contains binary data that needs to be encoded.</param>
+             <param name="utf8">The output span which contains the result of the operation, i.e. the UTF-8 encoded text in base 64.</param>
+             <param name="bytesConsumed">The number of input bytes consumed during the operation. This can be used to slice the input for subsequent calls, if necessary.</param>
+             <param name="bytesWritten">The number of bytes written into the output span. This can be used to slice the output for subsequent calls, if necessary.</param>
+             <param name="isFinalBlock">True (default) when the input span contains the entire data to decode. 
+             Set to false only if it is known that the input span contains partial data with more data to follow.</param>
+             <returns>It returns the OperationStatus enum values:
+             - Done - on successful processing of the entire input span
+             - DestinationTooSmall - if there is not enough space in the output span to fit the encoded input
+             - NeedMoreData - only if isFinalBlock is false, otherwise the output is padded if the input is not a multiple of 3
+             It does not return InvalidData since that is not possible for base 64 encoding.</returns>
+             </summary> 
+        </member>
+        <member name="M:System.Buffers.Text.Base64.GetMaxEncodedToUtf8Length(System.Int32)">
+            <summary>
+            Returns the maximum length (in bytes) of the result if you were to encode binary data within a byte span of size "length".
+            </summary>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+            Thrown when the specified <paramref name="length"/> is less than 0 or larger than 1610612733 (since encode inflates the data by 4/3).
+            </exception>
+        </member>
+        <member name="M:System.Buffers.Text.Base64.EncodeToUtf8InPlace(System.Span{System.Byte},System.Int32,System.Int32@)">
+             <summary>
+             Encode the span of binary data (in-place) into UTF-8 encoded text represented as base 64. 
+             The encoded text output is larger than the binary data contained in the input (the operation inflates the data).
+            
+             <param name="buffer">The input span which contains binary data that needs to be encoded. 
+             It needs to be large enough to fit the result of the operation.</param>
+             <param name="dataLength">The amount of binary data contained within the buffer that needs to be encoded 
+             (and needs to be smaller than the buffer length).</param>
+             <param name="bytesWritten">The number of bytes written into the buffer.</param>
+             <returns>It returns the OperationStatus enum values:
+             - Done - on successful processing of the entire buffer
+             - DestinationTooSmall - if there is not enough space in the buffer beyond dataLength to fit the result of encoding the input
+             It does not return NeedMoreData since this method tramples the data in the buffer and hence can only be called once with all the data in the buffer.
+             It does not return InvalidData since that is not possible for base 64 encoding.</returns>
+             </summary> 
+        </member>
+        <member name="M:System.Buffers.Text.FormattingHelpers.GetSymbolOrDefault(System.Buffers.StandardFormat@,System.Char)">
+            <summary>
+            Returns the symbol contained within the standard format. If the standard format
+            has not been initialized, returns the provided fallback symbol.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Text.FormattingHelpers.FillWithAsciiZeros(System.Span{System.Byte})">
+            <summary>
+            Fills a buffer with the ASCII character '0' (0x30).
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Text.FormattingHelpers.WriteFourDecimalDigits(System.UInt32,System.Span{System.Byte},System.Int32)">
+            <summary>
+            Writes a value [ 0000 .. 9999 ] to the buffer starting at the specified offset.
+            This method performs best when the starting index is a constant literal.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Text.FormattingHelpers.WriteTwoDecimalDigits(System.UInt32,System.Span{System.Byte},System.Int32)">
+            <summary>
+            Writes a value [ 00 .. 99 ] to the buffer starting at the specified offset.
+            This method performs best when the starting index is a constant literal.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Text.FormattingHelpers.DivMod(System.UInt64,System.UInt64,System.UInt64@)">
+            <summary>
+            We don't have access to Math.DivRem, so this is a copy of the implementation.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Text.FormattingHelpers.DivMod(System.UInt32,System.UInt32,System.UInt32@)">
+            <summary>
+            We don't have access to Math.DivRem, so this is a copy of the implementation.
+            </summary>
+        </member>
+        <member name="T:System.Buffers.Text.Utf8Formatter">
+            <summary>
+            Methods to format common data types as Utf8 strings.
+            </summary>
+            <summary>
+            Methods to format common data types as Utf8 strings.
+            </summary>
+            <summary>
+            Methods to format common data types as Utf8 strings.
+            </summary>
+            <summary>
+            Methods to format common data types as Utf8 strings.
+            </summary>
+            <summary>
+            Methods to format common data types as Utf8 strings.
+            </summary>
+            <summary>
+            Methods to format common data types as Utf8 strings.
+            </summary>
+            <summary>
+            Methods to format common data types as Utf8 strings.
+            </summary>
+            <summary>
+            Methods to format common data types as Utf8 strings.
+            </summary>
+            <summary>
+            Methods to format common data types as Utf8 strings.
+            </summary>
+            <summary>
+            Methods to format common data types as Utf8 strings.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Text.Utf8Formatter.TryFormat(System.Boolean,System.Span{System.Byte},System.Int32@,System.Buffers.StandardFormat)">
+            <summary>
+            Formats a Boolean as a UTF8 string.
+            </summary>
+            <param name="value">Value to format</param>
+            <param name="destination">Buffer to write the UTF8-formatted value to</param>
+            <param name="bytesWritten">Receives the length of the formatted text in bytes</param>
+            <param name="format">The standard format to use</param>
+            <returns>
+            true for success. "bytesWritten" contains the length of the formatted text in bytes.
+            false if buffer was too short. Iteratively increase the size of the buffer and retry until it succeeds. 
+            </returns>
+            <remarks>
+            Formats supported:
+                G (default)   True/False
+                l             true/false
+            </remarks>
+            <exceptions>
+            <cref>System.FormatException</cref> if the format is not valid for this data type.
+            </exceptions>
+        </member>
+        <member name="M:System.Buffers.Text.Utf8Formatter.TryFormat(System.DateTimeOffset,System.Span{System.Byte},System.Int32@,System.Buffers.StandardFormat)">
+            <summary>
+            Formats a DateTimeOffset as a UTF8 string.
+            </summary>
+            <param name="value">Value to format</param>
+            <param name="destination">Buffer to write the UTF8-formatted value to</param>
+            <param name="bytesWritten">Receives the length of the formatted text in bytes</param>
+            <param name="format">The standard format to use</param>
+            <returns>
+            true for success. "bytesWritten" contains the length of the formatted text in bytes.
+            false if buffer was too short. Iteratively increase the size of the buffer and retry until it succeeds. 
+            </returns>
+            <exceptions>
+            <remarks>
+            Formats supported:
+                default       05/25/2017 10:30:15 -08:00
+                G             05/25/2017 10:30:15
+                R             Tue, 03 Jan 2017 08:08:05 GMT       (RFC 1123)
+                l             tue, 03 jan 2017 08:08:05 gmt       (Lowercase RFC 1123)
+                O             2017-06-12T05:30:45.7680000-07:00   (Round-trippable)
+            </remarks>
+            <cref>System.FormatException</cref> if the format is not valid for this data type.
+            </exceptions>
+        </member>
+        <member name="M:System.Buffers.Text.Utf8Formatter.TryFormat(System.DateTime,System.Span{System.Byte},System.Int32@,System.Buffers.StandardFormat)">
+            <summary>
+            Formats a DateTime as a UTF8 string.
+            </summary>
+            <param name="value">Value to format</param>
+            <param name="destination">Buffer to write the UTF8-formatted value to</param>
+            <param name="bytesWritten">Receives the length of the formatted text in bytes</param>
+            <param name="format">The standard format to use</param>
+            <returns>
+            true for success. "bytesWritten" contains the length of the formatted text in bytes.
+            false if buffer was too short. Iteratively increase the size of the buffer and retry until it succeeds. 
+            </returns>
+            <remarks>
+            Formats supported:
+                G  (default)  05/25/2017 10:30:15
+                R             Tue, 03 Jan 2017 08:08:05 GMT       (RFC 1123)
+                l             tue, 03 jan 2017 08:08:05 gmt       (Lowercase RFC 1123)
+                O             2017-06-12T05:30:45.7680000-07:00   (Round-trippable)
+            </remarks>
+            <exceptions>
+            <cref>System.FormatException</cref> if the format is not valid for this data type.
+            </exceptions>
+        </member>
+        <member name="M:System.Buffers.Text.Utf8Formatter.TryFormat(System.Decimal,System.Span{System.Byte},System.Int32@,System.Buffers.StandardFormat)">
+            <summary>
+            Formats a Decimal as a UTF8 string.
+            </summary>
+            <param name="value">Value to format</param>
+            <param name="destination">Buffer to write the UTF8-formatted value to</param>
+            <param name="bytesWritten">Receives the length of the formatted text in bytes</param>
+            <param name="format">The standard format to use</param>
+            <returns>
+            true for success. "bytesWritten" contains the length of the formatted text in bytes.
+            false if buffer was too short. Iteratively increase the size of the buffer and retry until it succeeds. 
+            </returns>
+            <remarks>
+            Formats supported:
+                G/g  (default)  
+                F/f             12.45       Fixed point
+                E/e             1.245000e1  Exponential
+            </remarks>
+            <exceptions>
+            <cref>System.FormatException</cref> if the format is not valid for this data type.
+            </exceptions>
+        </member>
+        <member name="M:System.Buffers.Text.Utf8Formatter.TryFormat(System.Double,System.Span{System.Byte},System.Int32@,System.Buffers.StandardFormat)">
+            <summary>
+            Formats a Double as a UTF8 string.
+            </summary>
+            <param name="value">Value to format</param>
+            <param name="destination">Buffer to write the UTF8-formatted value to</param>
+            <param name="bytesWritten">Receives the length of the formatted text in bytes</param>
+            <param name="format">The standard format to use</param>
+            <returns>
+            true for success. "bytesWritten" contains the length of the formatted text in bytes.
+            false if buffer was too short. Iteratively increase the size of the buffer and retry until it succeeds. 
+            </returns>
+            <remarks>
+            Formats supported:
+                G/g  (default)  
+                F/f             12.45       Fixed point
+                E/e             1.245000e1  Exponential
+            </remarks>
+            <exceptions>
+            <cref>System.FormatException</cref> if the format is not valid for this data type.
+            </exceptions>
+        </member>
+        <member name="M:System.Buffers.Text.Utf8Formatter.TryFormat(System.Single,System.Span{System.Byte},System.Int32@,System.Buffers.StandardFormat)">
+            <summary>
+            Formats a Single as a UTF8 string.
+            </summary>
+            <param name="value">Value to format</param>
+            <param name="destination">Buffer to write the UTF8-formatted value to</param>
+            <param name="bytesWritten">Receives the length of the formatted text in bytes</param>
+            <param name="format">The standard format to use</param>
+            <returns>
+            true for success. "bytesWritten" contains the length of the formatted text in bytes.
+            false if buffer was too short. Iteratively increase the size of the buffer and retry until it succeeds. 
+            </returns>
+            <remarks>
+            Formats supported:
+                G/g  (default)  
+                F/f             12.45       Fixed point
+                E/e             1.245000e1  Exponential
+            </remarks>
+            <exceptions>
+            <cref>System.FormatException</cref> if the format is not valid for this data type.
+            </exceptions>
+        </member>
+        <member name="M:System.Buffers.Text.Utf8Formatter.TryFormat(System.Guid,System.Span{System.Byte},System.Int32@,System.Buffers.StandardFormat)">
+            <summary>
+            Formats a Guid as a UTF8 string.
+            </summary>
+            <param name="value">Value to format</param>
+            <param name="destination">Buffer to write the UTF8-formatted value to</param>
+            <param name="bytesWritten">Receives the length of the formatted text in bytes</param>
+            <param name="format">The standard format to use</param>
+            <returns>
+            true for success. "bytesWritten" contains the length of the formatted text in bytes.
+            false if buffer was too short. Iteratively increase the size of the buffer and retry until it succeeds. 
+            </returns>
+            <remarks>
+            Formats supported:
+                D (default)     nnnnnnnn-nnnn-nnnn-nnnn-nnnnnnnnnnnn
+                B               {nnnnnnnn-nnnn-nnnn-nnnn-nnnnnnnnnnnn}
+                P               (nnnnnnnn-nnnn-nnnn-nnnn-nnnnnnnnnnnn)
+                N               nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+            </remarks>
+            <exceptions>
+            <cref>System.FormatException</cref> if the format is not valid for this data type.
+            </exceptions>
+        </member>
+        <member name="T:System.Buffers.Text.Utf8Formatter.DecomposedGuid">
+            <summary>
+            Used to provide access to the individual bytes of a GUID.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Text.Utf8Formatter.TryFormat(System.Byte,System.Span{System.Byte},System.Int32@,System.Buffers.StandardFormat)">
+            <summary>
+            Formats a Byte as a UTF8 string.
+            </summary>
+            <param name="value">Value to format</param>
+            <param name="destination">Buffer to write the UTF8-formatted value to</param>
+            <param name="bytesWritten">Receives the length of the formatted text in bytes</param>
+            <param name="format">The standard format to use</param>
+            <returns>
+            true for success. "bytesWritten" contains the length of the formatted text in bytes.
+            false if buffer was too short. Iteratively increase the size of the buffer and retry until it succeeds. 
+            </returns>
+            <remarks>
+            Formats supported:
+                G/g (default)
+                D/d             32767  
+                N/n             32,767       
+                X/x             7fff
+            </remarks>
+            <exceptions>
+            <cref>System.FormatException</cref> if the format is not valid for this data type.
+            </exceptions>
+        </member>
+        <member name="M:System.Buffers.Text.Utf8Formatter.TryFormat(System.SByte,System.Span{System.Byte},System.Int32@,System.Buffers.StandardFormat)">
+            <summary>
+            Formats an SByte as a UTF8 string.
+            </summary>
+            <param name="value">Value to format</param>
+            <param name="destination">Buffer to write the UTF8-formatted value to</param>
+            <param name="bytesWritten">Receives the length of the formatted text in bytes</param>
+            <param name="format">The standard format to use</param>
+            <returns>
+            true for success. "bytesWritten" contains the length of the formatted text in bytes.
+            false if buffer was too short. Iteratively increase the size of the buffer and retry until it succeeds. 
+            </returns>
+            <remarks>
+            Formats supported:
+                G/g (default)
+                D/d             32767  
+                N/n             32,767       
+                X/x             7fff
+            </remarks>
+            <exceptions>
+            <cref>System.FormatException</cref> if the format is not valid for this data type.
+            </exceptions>
+        </member>
+        <member name="M:System.Buffers.Text.Utf8Formatter.TryFormat(System.UInt16,System.Span{System.Byte},System.Int32@,System.Buffers.StandardFormat)">
+            <summary>
+            Formats a Unt16 as a UTF8 string.
+            </summary>
+            <param name="value">Value to format</param>
+            <param name="destination">Buffer to write the UTF8-formatted value to</param>
+            <param name="bytesWritten">Receives the length of the formatted text in bytes</param>
+            <param name="format">The standard format to use</param>
+            <returns>
+            true for success. "bytesWritten" contains the length of the formatted text in bytes.
+            false if buffer was too short. Iteratively increase the size of the buffer and retry until it succeeds. 
+            </returns>
+            <remarks>
+            Formats supported:
+                G/g (default)
+                D/d             32767  
+                N/n             32,767       
+                X/x             7fff
+            </remarks>
+            <exceptions>
+            <cref>System.FormatException</cref> if the format is not valid for this data type.
+            </exceptions>
+        </member>
+        <member name="M:System.Buffers.Text.Utf8Formatter.TryFormat(System.Int16,System.Span{System.Byte},System.Int32@,System.Buffers.StandardFormat)">
+            <summary>
+            Formats an Int16 as a UTF8 string.
+            </summary>
+            <param name="value">Value to format</param>
+            <param name="destination">Buffer to write the UTF8-formatted value to</param>
+            <param name="bytesWritten">Receives the length of the formatted text in bytes</param>
+            <param name="format">The standard format to use</param>
+            <returns>
+            true for success. "bytesWritten" contains the length of the formatted text in bytes.
+            false if buffer was too short. Iteratively increase the size of the buffer and retry until it succeeds. 
+            </returns>
+            <remarks>
+            Formats supported:
+                G/g (default)
+                D/d             32767  
+                N/n             32,767       
+                X/x             7fff
+            </remarks>
+            <exceptions>
+            <cref>System.FormatException</cref> if the format is not valid for this data type.
+            </exceptions>
+        </member>
+        <member name="M:System.Buffers.Text.Utf8Formatter.TryFormat(System.UInt32,System.Span{System.Byte},System.Int32@,System.Buffers.StandardFormat)">
+            <summary>
+            Formats a UInt32 as a UTF8 string.
+            </summary>
+            <param name="value">Value to format</param>
+            <param name="destination">Buffer to write the UTF8-formatted value to</param>
+            <param name="bytesWritten">Receives the length of the formatted text in bytes</param>
+            <param name="format">The standard format to use</param>
+            <returns>
+            true for success. "bytesWritten" contains the length of the formatted text in bytes.
+            false if buffer was too short. Iteratively increase the size of the buffer and retry until it succeeds. 
+            </returns>
+            <remarks>
+            Formats supported:
+                G/g (default)
+                D/d             32767  
+                N/n             32,767       
+                X/x             7fff
+            </remarks>
+            <exceptions>
+            <cref>System.FormatException</cref> if the format is not valid for this data type.
+            </exceptions>
+        </member>
+        <member name="M:System.Buffers.Text.Utf8Formatter.TryFormat(System.Int32,System.Span{System.Byte},System.Int32@,System.Buffers.StandardFormat)">
+            <summary>
+            Formats an Int32 as a UTF8 string.
+            </summary>
+            <param name="value">Value to format</param>
+            <param name="destination">Buffer to write the UTF8-formatted value to</param>
+            <param name="bytesWritten">Receives the length of the formatted text in bytes</param>
+            <param name="format">The standard format to use</param>
+            <returns>
+            true for success. "bytesWritten" contains the length of the formatted text in bytes.
+            false if buffer was too short. Iteratively increase the size of the buffer and retry until it succeeds. 
+            </returns>
+            <remarks>
+            Formats supported:
+                G/g (default)
+                D/d             32767  
+                N/n             32,767       
+                X/x             7fff
+            </remarks>
+            <exceptions>
+            <cref>System.FormatException</cref> if the format is not valid for this data type.
+            </exceptions>
+        </member>
+        <member name="M:System.Buffers.Text.Utf8Formatter.TryFormat(System.UInt64,System.Span{System.Byte},System.Int32@,System.Buffers.StandardFormat)">
+            <summary>
+            Formats a UInt64 as a UTF8 string.
+            </summary>
+            <param name="value">Value to format</param>
+            <param name="destination">Buffer to write the UTF8-formatted value to</param>
+            <param name="bytesWritten">Receives the length of the formatted text in bytes</param>
+            <param name="format">The standard format to use</param>
+            <returns>
+            true for success. "bytesWritten" contains the length of the formatted text in bytes.
+            false if buffer was too short. Iteratively increase the size of the buffer and retry until it succeeds. 
+            </returns>
+            <remarks>
+            Formats supported:
+                G/g (default)
+                D/d             32767  
+                N/n             32,767       
+                X/x             7fff
+            </remarks>
+            <exceptions>
+            <cref>System.FormatException</cref> if the format is not valid for this data type.
+            </exceptions>
+        </member>
+        <member name="M:System.Buffers.Text.Utf8Formatter.TryFormat(System.Int64,System.Span{System.Byte},System.Int32@,System.Buffers.StandardFormat)">
+            <summary>
+            Formats an Int64 as a UTF8 string.
+            </summary>
+            <param name="value">Value to format</param>
+            <param name="destination">Buffer to write the UTF8-formatted value to</param>
+            <param name="bytesWritten">Receives the length of the formatted text in bytes</param>
+            <param name="format">The standard format to use</param>
+            <returns>
+            true for success. "bytesWritten" contains the length of the formatted text in bytes.
+            false if buffer was too short. Iteratively increase the size of the buffer and retry until it succeeds. 
+            </returns>
+            <remarks>
+            Formats supported:
+                G/g (default)
+                D/d             32767  
+                N/n             32,767       
+                X/x             7fff
+            </remarks>
+            <exceptions>
+            <cref>System.FormatException</cref> if the format is not valid for this data type.
+            </exceptions>
+        </member>
+        <member name="M:System.Buffers.Text.Utf8Formatter.TryFormat(System.TimeSpan,System.Span{System.Byte},System.Int32@,System.Buffers.StandardFormat)">
+            <summary>
+            Formats a TimeSpan as a UTF8 string.
+            </summary>
+            <param name="value">Value to format</param>
+            <param name="destination">Buffer to write the UTF8-formatted value to</param>
+            <param name="bytesWritten">Receives the length of the formatted text in bytes</param>
+            <param name="format">The standard format to use</param>
+            <returns>
+            true for success. "bytesWritten" contains the length of the formatted text in bytes.
+            false if buffer was too short. Iteratively increase the size of the buffer and retry until it succeeds. 
+            </returns>
+            <remarks>
+            Formats supported:
+                c/t/T (default) [-][d.]hh:mm:ss[.fffffff]              (constant format)
+                G               [-]d:hh:mm:ss.fffffff                  (general long)
+                g               [-][d:][h]h:mm:ss[.f[f[f[f[f[f[f]]]]]] (general short)
+            </remarks>
+            <exceptions>
+            <cref>System.FormatException</cref> if the format is not valid for this data type.
+            </exceptions>
+        </member>
+        <member name="T:System.Buffers.Text.Utf8Parser">
+            <summary>
+            Methods to parse common data types to Utf8 strings.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan{System.Byte},System.Boolean@,System.Int32@,System.Char)">
+            <summary>
+            Parses a Boolean at the start of a Utf8 string.
+            </summary>
+            <param name="source">The Utf8 string to parse</param>
+            <param name="value">Receives the parsed value</param>
+            <param name="bytesConsumed">On a successful parse, receives the length in bytes of the substring that was parsed </param>
+            <param name="standardFormat">Expected format of the Utf8 string</param>
+            <returns>
+            true for success. "bytesConsumed" contains the length in bytes of the substring that was parsed.
+            false if the string was not syntactically valid or an overflow or underflow occurred. "bytesConsumed" is set to 0. 
+            </returns>
+            <remarks>
+            Formats supported:
+                G (default)   True/False
+                l             true/false
+            </remarks>
+            <exceptions>
+            <cref>System.FormatException</cref> if the format is not valid for this data type.
+            </exceptions>
+        </member>
+        <member name="M:System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan{System.Byte},System.DateTime@,System.Int32@,System.Char)">
+            <summary>
+            Parses a DateTime at the start of a Utf8 string.
+            </summary>
+            <param name="source">The Utf8 string to parse</param>
+            <param name="value">Receives the parsed value</param>
+            <param name="bytesConsumed">On a successful parse, receives the length in bytes of the substring that was parsed </param>
+            <param name="standardFormat">Expected format of the Utf8 string</param>
+            <returns>
+            true for success. "bytesConsumed" contains the length in bytes of the substring that was parsed.
+            false if the string was not syntactically valid or an overflow or underflow occurred. "bytesConsumed" is set to 0. 
+            </returns>
+            <remarks>
+            Formats supported:
+                default       05/25/2017 10:30:15 -08:00
+                G             05/25/2017 10:30:15
+                R             Tue, 03 Jan 2017 08:08:05 GMT       (RFC 1123)
+                l             tue, 03 jan 2017 08:08:05 gmt       (Lowercase RFC 1123)
+                O             2017-06-12T05:30:45.7680000-07:00   (Round-trippable)
+            </remarks>
+            <exceptions>
+            <cref>System.FormatException</cref> if the format is not valid for this data type.
+            </exceptions>
+        </member>
+        <member name="M:System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan{System.Byte},System.DateTimeOffset@,System.Int32@,System.Char)">
+            <summary>
+            Parses a DateTimeOffset at the start of a Utf8 string.
+            </summary>
+            <param name="source">The Utf8 string to parse</param>
+            <param name="value">Receives the parsed value</param>
+            <param name="bytesConsumed">On a successful parse, receives the length in bytes of the substring that was parsed </param>
+            <param name="standardFormat">Expected format of the Utf8 string</param>
+            <returns>
+            true for success. "bytesConsumed" contains the length in bytes of the substring that was parsed.
+            false if the string was not syntactically valid or an overflow or underflow occurred. "bytesConsumed" is set to 0. 
+            </returns>
+            <remarks>
+            Formats supported:
+                G  (default)  05/25/2017 10:30:15
+                R             Tue, 03 Jan 2017 08:08:05 GMT       (RFC 1123)
+                l             tue, 03 jan 2017 08:08:05 gmt       (Lowercase RFC 1123)
+                O             2017-06-12T05:30:45.7680000-07:00   (Round-trippable)
+            </remarks>
+            <exceptions>
+            <cref>System.FormatException</cref> if the format is not valid for this data type.
+            </exceptions>
+        </member>
+        <member name="M:System.Buffers.Text.Utf8Parser.TryCreateDateTimeOffset(System.DateTime,System.Boolean,System.Int32,System.Int32,System.DateTimeOffset@)">
+            <summary>
+            Overflow-safe DateTimeOffset factory.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Text.Utf8Parser.TryCreateDateTimeOffset(System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Boolean,System.Int32,System.Int32,System.DateTimeOffset@)">
+            <summary>
+            Overflow-safe DateTimeOffset factory.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Text.Utf8Parser.TryCreateDateTimeOffsetInterpretingDataAsLocalTime(System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.DateTimeOffset@)">
+            <summary>
+            Overflow-safe DateTimeOffset/Local time conversion factory.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Text.Utf8Parser.TryCreateDateTime(System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.DateTimeKind,System.DateTime@)">
+            <summary>
+            Overflow-safe DateTime factory.
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan{System.Byte},System.Decimal@,System.Int32@,System.Char)">
+            <summary>
+            Parses a Decimal at the start of a Utf8 string.
+            </summary>
+            <param name="source">The Utf8 string to parse</param>
+            <param name="value">Receives the parsed value</param>
+            <param name="bytesConsumed">On a successful parse, receives the length in bytes of the substring that was parsed </param>
+            <param name="standardFormat">Expected format of the Utf8 string</param>
+            <returns>
+            true for success. "bytesConsumed" contains the length in bytes of the substring that was parsed.
+            false if the string was not syntactically valid or an overflow or underflow occurred. "bytesConsumed" is set to 0. 
+            </returns>
+            <remarks>
+            Formats supported:
+                G/g  (default)  
+                F/f             12.45       Fixed point
+                E/e             1.245000e1  Exponential
+            </remarks>
+            <exceptions>
+            <cref>System.FormatException</cref> if the format is not valid for this data type.
+            </exceptions>
+        </member>
+        <member name="M:System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan{System.Byte},System.Single@,System.Int32@,System.Char)">
+            <summary>
+            Parses a Single at the start of a Utf8 string.
+            </summary>
+            <param name="source">The Utf8 string to parse</param>
+            <param name="value">Receives the parsed value</param>
+            <param name="bytesConsumed">On a successful parse, receives the length in bytes of the substring that was parsed </param>
+            <param name="standardFormat">Expected format of the Utf8 string</param>
+            <returns>
+            true for success. "bytesConsumed" contains the length in bytes of the substring that was parsed.
+            false if the string was not syntactically valid or an overflow or underflow occurred. "bytesConsumed" is set to 0. 
+            </returns>
+            <remarks>
+            Formats supported:
+                G/g  (default)  
+                F/f             12.45       Fixed point
+                E/e             1.245000e1  Exponential
+            </remarks>
+            <exceptions>
+            <cref>System.FormatException</cref> if the format is not valid for this data type.
+            </exceptions>
+        </member>
+        <member name="M:System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan{System.Byte},System.Double@,System.Int32@,System.Char)">
+            <summary>
+            Parses a Double at the start of a Utf8 string.
+            </summary>
+            <param name="source">The Utf8 string to parse</param>
+            <param name="value">Receives the parsed value</param>
+            <param name="bytesConsumed">On a successful parse, receives the length in bytes of the substring that was parsed </param>
+            <param name="standardFormat">Expected format of the Utf8 string</param>
+            <returns>
+            true for success. "bytesConsumed" contains the length in bytes of the substring that was parsed.
+            false if the string was not syntactically valid or an overflow or underflow occurred. "bytesConsumed" is set to 0. 
+            </returns>
+            <remarks>
+            Formats supported:
+                G/g  (default)  
+                F/f             12.45       Fixed point
+                E/e             1.245000e1  Exponential
+            </remarks>
+            <exceptions>
+            <cref>System.FormatException</cref> if the format is not valid for this data type.
+            </exceptions>
+        </member>
+        <member name="M:System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan{System.Byte},System.Guid@,System.Int32@,System.Char)">
+            <summary>
+            Parses a Guid at the start of a Utf8 string.
+            </summary>
+            <param name="source">The Utf8 string to parse</param>
+            <param name="value">Receives the parsed value</param>
+            <param name="bytesConsumed">On a successful parse, receives the length in bytes of the substring that was parsed </param>
+            <param name="standardFormat">Expected format of the Utf8 string</param>
+            <returns>
+            true for success. "bytesConsumed" contains the length in bytes of the substring that was parsed.
+            false if the string was not syntactically valid or an overflow or underflow occurred. "bytesConsumed" is set to 0. 
+            </returns>
+            <remarks>
+            Formats supported:
+                D (default)     nnnnnnnn-nnnn-nnnn-nnnn-nnnnnnnnnnnn
+                B               {nnnnnnnn-nnnn-nnnn-nnnn-nnnnnnnnnnnn}
+                P               (nnnnnnnn-nnnn-nnnn-nnnn-nnnnnnnnnnnn)
+                N               nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+            </remarks>
+            <exceptions>
+            <cref>System.FormatException</cref> if the format is not valid for this data type.
+            </exceptions>
+        </member>
+        <member name="M:System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan{System.Byte},System.SByte@,System.Int32@,System.Char)">
+            <summary>
+            Parses a SByte at the start of a Utf8 string.
+            </summary>
+            <param name="source">The Utf8 string to parse</param>
+            <param name="value">Receives the parsed value</param>
+            <param name="bytesConsumed">On a successful parse, receives the length in bytes of the substring that was parsed </param>
+            <param name="standardFormat">Expected format of the Utf8 string</param>
+            <returns>
+            true for success. "bytesConsumed" contains the length in bytes of the substring that was parsed.
+            false if the string was not syntactically valid or an overflow or underflow occurred. "bytesConsumed" is set to 0. 
+            </returns>
+            <remarks>
+            Formats supported:
+                G/g (default)
+                D/d             32767  
+                N/n             32,767       
+                X/x             7fff
+            </remarks>
+            <exceptions>
+            <cref>System.FormatException</cref> if the format is not valid for this data type.
+            </exceptions>
+        </member>
+        <member name="M:System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan{System.Byte},System.Int16@,System.Int32@,System.Char)">
+            <summary>
+            Parses an Int16 at the start of a Utf8 string.
+            </summary>
+            <param name="source">The Utf8 string to parse</param>
+            <param name="value">Receives the parsed value</param>
+            <param name="bytesConsumed">On a successful parse, receives the length in bytes of the substring that was parsed </param>
+            <param name="standardFormat">Expected format of the Utf8 string</param>
+            <returns>
+            true for success. "bytesConsumed" contains the length in bytes of the substring that was parsed.
+            false if the string was not syntactically valid or an overflow or underflow occurred. "bytesConsumed" is set to 0. 
+            </returns>
+            <remarks>
+            Formats supported:
+                G/g (default)
+                D/d             32767  
+                N/n             32,767       
+                X/x             7fff
+            </remarks>
+            <exceptions>
+            <cref>System.FormatException</cref> if the format is not valid for this data type.
+            </exceptions>
+        </member>
+        <member name="M:System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan{System.Byte},System.Int32@,System.Int32@,System.Char)">
+            <summary>
+            Parses an Int32 at the start of a Utf8 string.
+            </summary>
+            <param name="source">The Utf8 string to parse</param>
+            <param name="value">Receives the parsed value</param>
+            <param name="bytesConsumed">On a successful parse, receives the length in bytes of the substring that was parsed </param>
+            <param name="standardFormat">Expected format of the Utf8 string</param>
+            <returns>
+            true for success. "bytesConsumed" contains the length in bytes of the substring that was parsed.
+            false if the string was not syntactically valid or an overflow or underflow occurred. "bytesConsumed" is set to 0. 
+            </returns>
+            <remarks>
+            Formats supported:
+                G/g (default)
+                D/d             32767  
+                N/n             32,767       
+                X/x             7fff
+            </remarks>
+            <exceptions>
+            <cref>System.FormatException</cref> if the format is not valid for this data type.
+            </exceptions>
+        </member>
+        <member name="M:System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan{System.Byte},System.Int64@,System.Int32@,System.Char)">
+            <summary>
+            Parses an Int64 at the start of a Utf8 string.
+            </summary>
+            <param name="source">The Utf8 string to parse</param>
+            <param name="value">Receives the parsed value</param>
+            <param name="bytesConsumed">On a successful parse, receives the length in bytes of the substring that was parsed </param>
+            <param name="standardFormat">Expected format of the Utf8 string</param>
+            <returns>
+            true for success. "bytesConsumed" contains the length in bytes of the substring that was parsed.
+            false if the string was not syntactically valid or an overflow or underflow occurred. "bytesConsumed" is set to 0. 
+            </returns>
+            <remarks>
+            Formats supported:
+                G/g (default)
+                D/d             32767  
+                N/n             32,767       
+                X/x             7fff
+            </remarks>
+            <exceptions>
+            <cref>System.FormatException</cref> if the format is not valid for this data type.
+            </exceptions>
+        </member>
+        <member name="M:System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan{System.Byte},System.Byte@,System.Int32@,System.Char)">
+            <summary>
+            Parses a Byte at the start of a Utf8 string.
+            </summary>
+            <param name="source">The Utf8 string to parse</param>
+            <param name="value">Receives the parsed value</param>
+            <param name="bytesConsumed">On a successful parse, receives the length in bytes of the substring that was parsed </param>
+            <param name="standardFormat">Expected format of the Utf8 string</param>
+            <returns>
+            true for success. "bytesConsumed" contains the length in bytes of the substring that was parsed.
+            false if the string was not syntactically valid or an overflow or underflow occurred. "bytesConsumed" is set to 0. 
+            </returns>
+            <remarks>
+            Formats supported:
+                G/g (default)
+                D/d             32767  
+                N/n             32,767       
+                X/x             7fff
+            </remarks>
+            <exceptions>
+            <cref>System.FormatException</cref> if the format is not valid for this data type.
+            </exceptions>
+        </member>
+        <member name="M:System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan{System.Byte},System.UInt16@,System.Int32@,System.Char)">
+            <summary>
+            Parses a UInt16 at the start of a Utf8 string.
+            </summary>
+            <param name="source">The Utf8 string to parse</param>
+            <param name="value">Receives the parsed value</param>
+            <param name="bytesConsumed">On a successful parse, receives the length in bytes of the substring that was parsed </param>
+            <param name="standardFormat">Expected format of the Utf8 string</param>
+            <returns>
+            true for success. "bytesConsumed" contains the length in bytes of the substring that was parsed.
+            false if the string was not syntactically valid or an overflow or underflow occurred. "bytesConsumed" is set to 0. 
+            </returns>
+            <remarks>
+            Formats supported:
+                G/g (default)
+                D/d             32767  
+                N/n             32,767       
+                X/x             7fff
+            </remarks>
+            <exceptions>
+            <cref>System.FormatException</cref> if the format is not valid for this data type.
+            </exceptions>
+        </member>
+        <member name="M:System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan{System.Byte},System.UInt32@,System.Int32@,System.Char)">
+            <summary>
+            Parses a UInt32 at the start of a Utf8 string.
+            </summary>
+            <param name="source">The Utf8 string to parse</param>
+            <param name="value">Receives the parsed value</param>
+            <param name="bytesConsumed">On a successful parse, receives the length in bytes of the substring that was parsed </param>
+            <param name="standardFormat">Expected format of the Utf8 string</param>
+            <returns>
+            true for success. "bytesConsumed" contains the length in bytes of the substring that was parsed.
+            false if the string was not syntactically valid or an overflow or underflow occurred. "bytesConsumed" is set to 0. 
+            </returns>
+            <remarks>
+            Formats supported:
+                G/g (default)
+                D/d             32767  
+                N/n             32,767       
+                X/x             7fff
+            </remarks>
+            <exceptions>
+            <cref>System.FormatException</cref> if the format is not valid for this data type.
+            </exceptions>
+        </member>
+        <member name="M:System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan{System.Byte},System.UInt64@,System.Int32@,System.Char)">
+            <summary>
+            Parses a UInt64 at the start of a Utf8 string.
+            </summary>
+            <param name="source">The Utf8 string to parse</param>
+            <param name="value">Receives the parsed value</param>
+            <param name="bytesConsumed">On a successful parse, receives the length in bytes of the substring that was parsed </param>
+            <param name="standardFormat">Expected format of the Utf8 string</param>
+            <returns>
+            true for success. "bytesConsumed" contains the length in bytes of the substring that was parsed.
+            false if the string was not syntactically valid or an overflow or underflow occurred. "bytesConsumed" is set to 0. 
+            </returns>
+            <remarks>
+            Formats supported:
+                G/g (default)
+                D/d             32767  
+                N/n             32,767       
+                X/x             7fff
+            </remarks>
+            <exceptions>
+            <cref>System.FormatException</cref> if the format is not valid for this data type.
+            </exceptions>
+        </member>
+        <member name="M:System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan{System.Byte},System.TimeSpan@,System.Int32@,System.Char)">
+            <summary>
+            Parses a TimeSpan at the start of a Utf8 string.
+            </summary>
+            <param name="source">The Utf8 string to parse</param>
+            <param name="value">Receives the parsed value</param>
+            <param name="bytesConsumed">On a successful parse, receives the length in bytes of the substring that was parsed </param>
+            <param name="standardFormat">Expected format of the Utf8 string</param>
+            <returns>
+            true for success. "bytesConsumed" contains the length in bytes of the substring that was parsed.
+            false if the string was not syntactically valid or an overflow or underflow occurred. "bytesConsumed" is set to 0. 
+            </returns>
+            <remarks>
+            Formats supported:
+                c/t/T (default) [-][d.]hh:mm:ss[.fffffff]             (constant format)
+                G               [-]d:hh:mm:ss.fffffff                 (general long)
+                g               [-][d:]h:mm:ss[.f[f[f[f[f[f[f[]]]]]]] (general short)
+            </remarks>
+            <exceptions>
+            <cref>System.FormatException</cref> if the format is not valid for this data type.
+            </exceptions>
+        </member>
+        <member name="M:System.Buffers.Text.Utf8Parser.TryParseTimeSpanFraction(System.ReadOnlySpan{System.Byte},System.UInt32@,System.Int32@)">
+            <summary>
+            Parse the fraction portion of a TimeSpan. Must be 1..7 digits. If fewer than 7, zeroes are implied to the right. If more than 7, the TimeSpan
+            parser rejects the string (even if the extra digits are all zeroes.)
+            </summary>
+        </member>
+        <member name="M:System.Buffers.Text.Utf8Parser.TryCreateTimeSpan(System.Boolean,System.UInt32,System.UInt32,System.UInt32,System.UInt32,System.UInt32,System.TimeSpan@)">
+            <summary>
+            Overflow-safe TryCreateTimeSpan
+            </summary>
+        </member>
+        <member name="T:System.Memory`1">
+            <summary>
+            Memory represents a contiguous region of arbitrary memory similar to <see cref="T:System.Span`1"/>.
+            Unlike <see cref="T:System.Span`1"/>, it is not a byref-like type.
+            </summary>
+        </member>
+        <member name="M:System.Memory`1.#ctor(`0[])">
+            <summary>
+            Creates a new memory over the entirety of the target array.
+            </summary>
+            <param name="array">The target array.</param>
+            <remarks>Returns default when <paramref name="array"/> is null.</remarks>
+            <exception cref="T:System.ArrayTypeMismatchException">Thrown when <paramref name="array"/> is covariant and array's type is not exactly T[].</exception>
+        </member>
+        <member name="M:System.Memory`1.#ctor(`0[],System.Int32,System.Int32)">
+            <summary>
+            Creates a new memory over the portion of the target array beginning
+            at 'start' index and ending at 'end' index (exclusive).
+            </summary>
+            <param name="array">The target array.</param>
+            <param name="start">The index at which to begin the memory.</param>
+            <param name="length">The number of items in the memory.</param>
+            <remarks>Returns default when <paramref name="array"/> is null.</remarks>
+            <exception cref="T:System.ArrayTypeMismatchException">Thrown when <paramref name="array"/> is covariant and array's type is not exactly T[].</exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+            Thrown when the specified <paramref name="start"/> or end index is not in the range (&lt;0 or &gt;=Length).
+            </exception>
+        </member>
+        <member name="M:System.Memory`1.#ctor(System.Buffers.MemoryManager{`0},System.Int32)">
+            <summary>
+            Creates a new memory from a memory manager that provides specific method implementations beginning
+            at 0 index and ending at 'end' index (exclusive).
+            </summary>
+            <param name="manager">The memory manager.</param>
+            <param name="length">The number of items in the memory.</param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+            Thrown when the specified <paramref name="length"/> is negative.
+            </exception>
+            <remarks>For internal infrastructure only</remarks>
+        </member>
+        <member name="M:System.Memory`1.#ctor(System.Buffers.MemoryManager{`0},System.Int32,System.Int32)">
+            <summary>
+            Creates a new memory from a memory manager that provides specific method implementations beginning
+            at 'start' index and ending at 'end' index (exclusive).
+            </summary>
+            <param name="manager">The memory manager.</param>
+            <param name="start">The index at which to begin the memory.</param>
+            <param name="length">The number of items in the memory.</param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+            Thrown when the specified <paramref name="start"/> or <paramref name="length"/> is negative.
+            </exception>
+            <remarks>For internal infrastructure only</remarks>
+        </member>
+        <member name="M:System.Memory`1.op_Implicit(`0[])~System.Memory{`0}">
+            <summary>
+            Defines an implicit conversion of an array to a <see cref="T:System.Memory`1"/>
+            </summary>
+        </member>
+        <member name="M:System.Memory`1.op_Implicit(System.ArraySegment{`0})~System.Memory{`0}">
+            <summary>
+            Defines an implicit conversion of a <see cref="T:System.ArraySegment`1"/> to a <see cref="T:System.Memory`1"/>
+            </summary>
+        </member>
+        <member name="M:System.Memory`1.op_Implicit(System.Memory{`0})~System.ReadOnlyMemory{`0}">
+            <summary>
+            Defines an implicit conversion of a <see cref="T:System.Memory`1"/> to a <see cref="T:System.ReadOnlyMemory`1"/>
+            </summary>
+        </member>
+        <member name="P:System.Memory`1.Empty">
+            <summary>
+            Returns an empty <see cref="T:System.Memory`1"/>
+            </summary>
+        </member>
+        <member name="P:System.Memory`1.Length">
+            <summary>
+            The number of items in the memory.
+            </summary>
+        </member>
+        <member name="P:System.Memory`1.IsEmpty">
+            <summary>
+            Returns true if Length is 0.
+            </summary>
+        </member>
+        <member name="M:System.Memory`1.ToString">
+            <summary>
+            For <see cref="T:System.Memory`1"/>, returns a new instance of string that represents the characters pointed to by the memory.
+            Otherwise, returns a <see cref="T:System.String"/> with the name of the type and the number of elements.
+            </summary>
+        </member>
+        <member name="M:System.Memory`1.Slice(System.Int32)">
+            <summary>
+            Forms a slice out of the given memory, beginning at 'start'.
+            </summary>
+            <param name="start">The index at which to begin this slice.</param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+            Thrown when the specified <paramref name="start"/> index is not in range (&lt;0 or &gt;=Length).
+            </exception>
+        </member>
+        <member name="M:System.Memory`1.Slice(System.Int32,System.Int32)">
+            <summary>
+            Forms a slice out of the given memory, beginning at 'start', of given length
+            </summary>
+            <param name="start">The index at which to begin this slice.</param>
+            <param name="length">The desired length for the slice (exclusive).</param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+            Thrown when the specified <paramref name="start"/> or end index is not in range (&lt;0 or &gt;=Length).
+            </exception>
+        </member>
+        <member name="P:System.Memory`1.Span">
+            <summary>
+            Returns a span from the memory.
+            </summary>
+        </member>
+        <member name="M:System.Memory`1.CopyTo(System.Memory{`0})">
+             <summary>
+             Copies the contents of the memory into the destination. If the source
+             and destination overlap, this method behaves as if the original values are in
+             a temporary location before the destination is overwritten.
+            
+             <param name="destination">The Memory to copy items into.</param>
+             <exception cref="T:System.ArgumentException">
+             Thrown when the destination is shorter than the source.
+             </exception>
+             </summary>
+        </member>
+        <member name="M:System.Memory`1.TryCopyTo(System.Memory{`0})">
+             <summary>
+             Copies the contents of the memory into the destination. If the source
+             and destination overlap, this method behaves as if the original values are in
+             a temporary location before the destination is overwritten.
+            
+             <returns>If the destination is shorter than the source, this method
+             return false and no data is written to the destination.</returns>
+             </summary>
+             <param name="destination">The span to copy items into.</param>
+        </member>
+        <member name="M:System.Memory`1.Pin">
+            <summary>
+            Creates a handle for the memory.
+            The GC will not move the memory until the returned <see cref="T:System.Buffers.MemoryHandle"/>
+            is disposed, enabling taking and using the memory's address.
+            <exception cref="T:System.ArgumentException">
+            An instance with nonprimitive (non-blittable) members cannot be pinned.
+            </exception>
+            </summary>
+        </member>
+        <member name="M:System.Memory`1.ToArray">
+            <summary>
+            Copies the contents from the memory into a new array.  This heap
+            allocates, so should generally be avoided, however it is sometimes
+            necessary to bridge the gap with APIs written in terms of arrays.
+            </summary>
+        </member>
+        <member name="M:System.Memory`1.Equals(System.Object)">
+            <summary>
+            Determines whether the specified object is equal to the current object.
+            Returns true if the object is Memory or ReadOnlyMemory and if both objects point to the same array and have the same length.
+            </summary>
+        </member>
+        <member name="M:System.Memory`1.Equals(System.Memory{`0})">
+            <summary>
+            Returns true if the memory points to the same array and has the same length.  Note that
+            this does *not* check to see if the *contents* are equal.
+            </summary>
+        </member>
+        <member name="M:System.Memory`1.GetHashCode">
+            <summary>
+            Serves as the default hash function.
+            </summary>
+        </member>
+        <member name="T:System.MemoryExtensions">
+            <summary>
+            Extension methods for Span{T}, Memory{T}, and friends.
+            </summary>
+            <summary>
+            Extension methods for Span{T}, Memory{T}, and friends.
+            </summary>
+        </member>
+        <member name="M:System.MemoryExtensions.Trim(System.ReadOnlySpan{System.Char})">
+            <summary>
+            Removes all leading and trailing white-space characters from the span.
+            </summary>
+        </member>
+        <member name="M:System.MemoryExtensions.TrimStart(System.ReadOnlySpan{System.Char})">
+            <summary>
+            Removes all leading white-space characters from the span.
+            </summary>
+        </member>
+        <member name="M:System.MemoryExtensions.TrimEnd(System.ReadOnlySpan{System.Char})">
+            <summary>
+            Removes all trailing white-space characters from the span.
+            </summary>
+        </member>
+        <member name="M:System.MemoryExtensions.Trim(System.ReadOnlySpan{System.Char},System.Char)">
+            <summary>
+            Removes all leading and trailing occurrences of a specified character.
+            </summary>
+            <param name="span">The source span from which the character is removed.</param>
+            <param name="trimChar">The specified character to look for and remove.</param>
+        </member>
+        <member name="M:System.MemoryExtensions.TrimStart(System.ReadOnlySpan{System.Char},System.Char)">
+            <summary>
+            Removes all leading occurrences of a specified character.
+            </summary>
+            <param name="span">The source span from which the character is removed.</param>
+            <param name="trimChar">The specified character to look for and remove.</param>
+        </member>
+        <member name="M:System.MemoryExtensions.TrimEnd(System.ReadOnlySpan{System.Char},System.Char)">
+            <summary>
+            Removes all trailing occurrences of a specified character.
+            </summary>
+            <param name="span">The source span from which the character is removed.</param>
+            <param name="trimChar">The specified character to look for and remove.</param>
+        </member>
+        <member name="M:System.MemoryExtensions.Trim(System.ReadOnlySpan{System.Char},System.ReadOnlySpan{System.Char})">
+            <summary>
+            Removes all leading and trailing occurrences of a set of characters specified 
+            in a readonly span from the span.
+            </summary>
+            <param name="span">The source span from which the characters are removed.</param>
+            <param name="trimChars">The span which contains the set of characters to remove.</param>
+            <remarks>If <paramref name="trimChars"/> is empty, white-space characters are removed instead.</remarks>
+        </member>
+        <member name="M:System.MemoryExtensions.TrimStart(System.ReadOnlySpan{System.Char},System.ReadOnlySpan{System.Char})">
+            <summary>
+            Removes all leading occurrences of a set of characters specified 
+            in a readonly span from the span.
+            </summary>
+            <param name="span">The source span from which the characters are removed.</param>
+            <param name="trimChars">The span which contains the set of characters to remove.</param>
+            <remarks>If <paramref name="trimChars"/> is empty, white-space characters are removed instead.</remarks>
+        </member>
+        <member name="M:System.MemoryExtensions.TrimEnd(System.ReadOnlySpan{System.Char},System.ReadOnlySpan{System.Char})">
+            <summary>
+            Removes all trailing occurrences of a set of characters specified 
+            in a readonly span from the span.
+            </summary>
+            <param name="span">The source span from which the characters are removed.</param>
+            <param name="trimChars">The span which contains the set of characters to remove.</param>
+            <remarks>If <paramref name="trimChars"/> is empty, white-space characters are removed instead.</remarks>
+        </member>
+        <member name="M:System.MemoryExtensions.IsWhiteSpace(System.ReadOnlySpan{System.Char})">
+            <summary>
+            Indicates whether the specified span contains only white-space characters.
+            </summary>
+        </member>
+        <member name="M:System.MemoryExtensions.IndexOf``1(System.Span{``0},``0)">
+            <summary>
+            Searches for the specified value and returns the index of its first occurrence. If not found, returns -1. Values are compared using IEquatable{T}.Equals(T). 
+            </summary>
+            <param name="span">The span to search.</param>
+            <param name="value">The value to search for.</param>
+        </member>
+        <member name="M:System.MemoryExtensions.IndexOf``1(System.Span{``0},System.ReadOnlySpan{``0})">
+            <summary>
+            Searches for the specified sequence and returns the index of its first occurrence. If not found, returns -1. Values are compared using IEquatable{T}.Equals(T). 
+            </summary>
+            <param name="span">The span to search.</param>
+            <param name="value">The sequence to search for.</param>
+        </member>
+        <member name="M:System.MemoryExtensions.LastIndexOf``1(System.Span{``0},``0)">
+            <summary>
+            Searches for the specified value and returns the index of its last occurrence. If not found, returns -1. Values are compared using IEquatable{T}.Equals(T). 
+            </summary>
+            <param name="span">The span to search.</param>
+            <param name="value">The value to search for.</param>
+        </member>
+        <member name="M:System.MemoryExtensions.LastIndexOf``1(System.Span{``0},System.ReadOnlySpan{``0})">
+            <summary>
+            Searches for the specified sequence and returns the index of its last occurrence. If not found, returns -1. Values are compared using IEquatable{T}.Equals(T). 
+            </summary>
+            <param name="span">The span to search.</param>
+            <param name="value">The sequence to search for.</param>
+        </member>
+        <member name="M:System.MemoryExtensions.SequenceEqual``1(System.Span{``0},System.ReadOnlySpan{``0})">
+            <summary>
+            Determines whether two sequences are equal by comparing the elements using IEquatable{T}.Equals(T). 
+            </summary>
+        </member>
+        <member name="M:System.MemoryExtensions.SequenceCompareTo``1(System.Span{``0},System.ReadOnlySpan{``0})">
+            <summary>
+            Determines the relative order of the sequences being compared by comparing the elements using IComparable{T}.CompareTo(T). 
+            </summary>
+        </member>
+        <member name="M:System.MemoryExtensions.IndexOf``1(System.ReadOnlySpan{``0},``0)">
+            <summary>
+            Searches for the specified value and returns the index of its first occurrence. If not found, returns -1. Values are compared using IEquatable{T}.Equals(T). 
+            </summary>
+            <param name="span">The span to search.</param>
+            <param name="value">The value to search for.</param>
+        </member>
+        <member name="M:System.MemoryExtensions.IndexOf``1(System.ReadOnlySpan{``0},System.ReadOnlySpan{``0})">
+            <summary>
+            Searches for the specified sequence and returns the index of its first occurrence. If not found, returns -1. Values are compared using IEquatable{T}.Equals(T). 
+            </summary>
+            <param name="span">The span to search.</param>
+            <param name="value">The sequence to search for.</param>
+        </member>
+        <member name="M:System.MemoryExtensions.LastIndexOf``1(System.ReadOnlySpan{``0},``0)">
+            <summary>
+            Searches for the specified value and returns the index of its last occurrence. If not found, returns -1. Values are compared using IEquatable{T}.Equals(T). 
+            </summary>
+            <param name="span">The span to search.</param>
+            <param name="value">The value to search for.</param>
+        </member>
+        <member name="M:System.MemoryExtensions.LastIndexOf``1(System.ReadOnlySpan{``0},System.ReadOnlySpan{``0})">
+            <summary>
+            Searches for the specified sequence and returns the index of its last occurrence. If not found, returns -1. Values are compared using IEquatable{T}.Equals(T). 
+            </summary>
+            <param name="span">The span to search.</param>
+            <param name="value">The sequence to search for.</param>
+        </member>
+        <member name="M:System.MemoryExtensions.IndexOfAny``1(System.Span{``0},``0,``0)">
+            <summary>
+            Searches for the first index of any of the specified values similar to calling IndexOf several times with the logical OR operator. If not found, returns -1.
+            </summary>
+            <param name="span">The span to search.</param>
+            <param name="value0">One of the values to search for.</param>
+            <param name="value1">One of the values to search for.</param>
+        </member>
+        <member name="M:System.MemoryExtensions.IndexOfAny``1(System.Span{``0},``0,``0,``0)">
+            <summary>
+            Searches for the first index of any of the specified values similar to calling IndexOf several times with the logical OR operator. If not found, returns -1.
+            </summary>
+            <param name="span">The span to search.</param>
+            <param name="value0">One of the values to search for.</param>
+            <param name="value1">One of the values to search for.</param>
+            <param name="value2">One of the values to search for.</param>
+        </member>
+        <member name="M:System.MemoryExtensions.IndexOfAny``1(System.Span{``0},System.ReadOnlySpan{``0})">
+            <summary>
+            Searches for the first index of any of the specified values similar to calling IndexOf several times with the logical OR operator. If not found, returns -1. 
+            </summary>
+            <param name="span">The span to search.</param>
+            <param name="values">The set of values to search for.</param>
+        </member>
+        <member name="M:System.MemoryExtensions.IndexOfAny``1(System.ReadOnlySpan{``0},``0,``0)">
+            <summary>
+            Searches for the first index of any of the specified values similar to calling IndexOf several times with the logical OR operator. If not found, returns -1.
+            </summary>
+            <param name="span">The span to search.</param>
+            <param name="value0">One of the values to search for.</param>
+            <param name="value1">One of the values to search for.</param>
+        </member>
+        <member name="M:System.MemoryExtensions.IndexOfAny``1(System.ReadOnlySpan{``0},``0,``0,``0)">
+            <summary>
+            Searches for the first index of any of the specified values similar to calling IndexOf several times with the logical OR operator. If not found, returns -1. 
+            </summary>
+            <param name="span">The span to search.</param>
+            <param name="value0">One of the values to search for.</param>
+            <param name="value1">One of the values to search for.</param>
+            <param name="value2">One of the values to search for.</param>
+        </member>
+        <member name="M:System.MemoryExtensions.IndexOfAny``1(System.ReadOnlySpan{``0},System.ReadOnlySpan{``0})">
+            <summary>
+            Searches for the first index of any of the specified values similar to calling IndexOf several times with the logical OR operator. If not found, returns -1. 
+            </summary>
+            <param name="span">The span to search.</param>
+            <param name="values">The set of values to search for.</param>
+        </member>
+        <member name="M:System.MemoryExtensions.LastIndexOfAny``1(System.Span{``0},``0,``0)">
+            <summary>
+            Searches for the last index of any of the specified values similar to calling LastIndexOf several times with the logical OR operator. If not found, returns -1.
+            </summary>
+            <param name="span">The span to search.</param>
+            <param name="value0">One of the values to search for.</param>
+            <param name="value1">One of the values to search for.</param>
+        </member>
+        <member name="M:System.MemoryExtensions.LastIndexOfAny``1(System.Span{``0},``0,``0,``0)">
+            <summary>
+            Searches for the last index of any of the specified values similar to calling LastIndexOf several times with the logical OR operator. If not found, returns -1.
+            </summary>
+            <param name="span">The span to search.</param>
+            <param name="value0">One of the values to search for.</param>
+            <param name="value1">One of the values to search for.</param>
+            <param name="value2">One of the values to search for.</param>
+        </member>
+        <member name="M:System.MemoryExtensions.LastIndexOfAny``1(System.Span{``0},System.ReadOnlySpan{``0})">
+            <summary>
+            Searches for the last index of any of the specified values similar to calling LastIndexOf several times with the logical OR operator. If not found, returns -1. 
+            </summary>
+            <param name="span">The span to search.</param>
+            <param name="values">The set of values to search for.</param>
+        </member>
+        <member name="M:System.MemoryExtensions.LastIndexOfAny``1(System.ReadOnlySpan{``0},``0,``0)">
+            <summary>
+            Searches for the last index of any of the specified values similar to calling LastIndexOf several times with the logical OR operator. If not found, returns -1.
+            </summary>
+            <param name="span">The span to search.</param>
+            <param name="value0">One of the values to search for.</param>
+            <param name="value1">One of the values to search for.</param>
+        </member>
+        <member name="M:System.MemoryExtensions.LastIndexOfAny``1(System.ReadOnlySpan{``0},``0,``0,``0)">
+            <summary>
+            Searches for the last index of any of the specified values similar to calling LastIndexOf several times with the logical OR operator. If not found, returns -1. 
+            </summary>
+            <param name="span">The span to search.</param>
+            <param name="value0">One of the values to search for.</param>
+            <param name="value1">One of the values to search for.</param>
+            <param name="value2">One of the values to search for.</param>
+        </member>
+        <member name="M:System.MemoryExtensions.LastIndexOfAny``1(System.ReadOnlySpan{``0},System.ReadOnlySpan{``0})">
+            <summary>
+            Searches for the last index of any of the specified values similar to calling LastIndexOf several times with the logical OR operator. If not found, returns -1. 
+            </summary>
+            <param name="span">The span to search.</param>
+            <param name="values">The set of values to search for.</param>
+        </member>
+        <member name="M:System.MemoryExtensions.SequenceEqual``1(System.ReadOnlySpan{``0},System.ReadOnlySpan{``0})">
+            <summary>
+            Determines whether two sequences are equal by comparing the elements using IEquatable{T}.Equals(T). 
+            </summary>
+        </member>
+        <member name="M:System.MemoryExtensions.SequenceCompareTo``1(System.ReadOnlySpan{``0},System.ReadOnlySpan{``0})">
+            <summary>
+            Determines the relative order of the sequences being compared by comparing the elements using IComparable{T}.CompareTo(T). 
+            </summary>
+        </member>
+        <member name="M:System.MemoryExtensions.StartsWith``1(System.Span{``0},System.ReadOnlySpan{``0})">
+            <summary>
+            Determines whether the specified sequence appears at the start of the span.
+            </summary>
+        </member>
+        <member name="M:System.MemoryExtensions.StartsWith``1(System.ReadOnlySpan{``0},System.ReadOnlySpan{``0})">
+            <summary>
+            Determines whether the specified sequence appears at the start of the span.
+            </summary>
+        </member>
+        <member name="M:System.MemoryExtensions.EndsWith``1(System.Span{``0},System.ReadOnlySpan{``0})">
+            <summary>
+            Determines whether the specified sequence appears at the end of the span.
+            </summary>
+        </member>
+        <member name="M:System.MemoryExtensions.EndsWith``1(System.ReadOnlySpan{``0},System.ReadOnlySpan{``0})">
+            <summary>
+            Determines whether the specified sequence appears at the end of the span.
+            </summary>
+        </member>
+        <member name="M:System.MemoryExtensions.Reverse``1(System.Span{``0})">
+            <summary>
+            Reverses the sequence of the elements in the entire span.
+            </summary>
+        </member>
+        <member name="M:System.MemoryExtensions.AsSpan``1(``0[])">
+            <summary>
+            Creates a new span over the target array.
+            </summary>
+        </member>
+        <member name="M:System.MemoryExtensions.AsSpan``1(``0[],System.Int32,System.Int32)">
+            <summary>
+            Creates a new Span over the portion of the target array beginning
+            at 'start' index and ending at 'end' index (exclusive).
+            </summary>
+            <param name="array">The target array.</param>
+            <param name="start">The index at which to begin the Span.</param>
+            <param name="length">The number of items in the Span.</param>
+            <remarks>Returns default when <paramref name="array"/> is null.</remarks>
+            <exception cref="T:System.ArrayTypeMismatchException">Thrown when <paramref name="array"/> is covariant and array's type is not exactly T[].</exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+            Thrown when the specified <paramref name="start"/> or end index is not in the range (&lt;0 or &gt;=Length).
+            </exception>
+        </member>
+        <member name="M:System.MemoryExtensions.AsSpan``1(System.ArraySegment{``0})">
+            <summary>
+            Creates a new span over the portion of the target array segment.
+            </summary>
+        </member>
+        <member name="M:System.MemoryExtensions.AsSpan``1(System.ArraySegment{``0},System.Int32)">
+            <summary>
+            Creates a new Span over the portion of the target array beginning
+            at 'start' index and ending at 'end' index (exclusive).
+            </summary>
+            <param name="segment">The target array.</param>
+            <param name="start">The index at which to begin the Span.</param>
+            <remarks>Returns default when <paramref name="segment"/> is null.</remarks>
+            <exception cref="T:System.ArrayTypeMismatchException">Thrown when <paramref name="segment"/> is covariant and array's type is not exactly T[].</exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+            Thrown when the specified <paramref name="start"/> or end index is not in the range (&lt;0 or &gt;=segment.Count).
+            </exception>
+        </member>
+        <member name="M:System.MemoryExtensions.AsSpan``1(System.ArraySegment{``0},System.Int32,System.Int32)">
+            <summary>
+            Creates a new Span over the portion of the target array beginning
+            at 'start' index and ending at 'end' index (exclusive).
+            </summary>
+            <param name="segment">The target array.</param>
+            <param name="start">The index at which to begin the Span.</param>
+            <param name="length">The number of items in the Span.</param>
+            <remarks>Returns default when <paramref name="segment"/> is null.</remarks>
+            <exception cref="T:System.ArrayTypeMismatchException">Thrown when <paramref name="segment"/> is covariant and array's type is not exactly T[].</exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+            Thrown when the specified <paramref name="start"/> or end index is not in the range (&lt;0 or &gt;=segment.Count).
+            </exception>
+        </member>
+        <member name="M:System.MemoryExtensions.AsMemory``1(``0[])">
+            <summary>
+            Creates a new memory over the target array.
+            </summary>
+        </member>
+        <member name="M:System.MemoryExtensions.AsMemory``1(``0[],System.Int32)">
+            <summary>
+            Creates a new memory over the portion of the target array beginning
+            at 'start' index and ending at 'end' index (exclusive).
+            </summary>
+            <param name="array">The target array.</param>
+            <param name="start">The index at which to begin the memory.</param>
+            <remarks>Returns default when <paramref name="array"/> is null.</remarks>
+            <exception cref="T:System.ArrayTypeMismatchException">Thrown when <paramref name="array"/> is covariant and array's type is not exactly T[].</exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+            Thrown when the specified <paramref name="start"/> or end index is not in the range (&lt;0 or &gt;=array.Length).
+            </exception>
+        </member>
+        <member name="M:System.MemoryExtensions.AsMemory``1(``0[],System.Int32,System.Int32)">
+            <summary>
+            Creates a new memory over the portion of the target array beginning
+            at 'start' index and ending at 'end' index (exclusive).
+            </summary>
+            <param name="array">The target array.</param>
+            <param name="start">The index at which to begin the memory.</param>
+            <param name="length">The number of items in the memory.</param>
+            <remarks>Returns default when <paramref name="array"/> is null.</remarks>
+            <exception cref="T:System.ArrayTypeMismatchException">Thrown when <paramref name="array"/> is covariant and array's type is not exactly T[].</exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+            Thrown when the specified <paramref name="start"/> or end index is not in the range (&lt;0 or &gt;=Length).
+            </exception>
+        </member>
+        <member name="M:System.MemoryExtensions.AsMemory``1(System.ArraySegment{``0})">
+            <summary>
+            Creates a new memory over the portion of the target array.
+            </summary>
+        </member>
+        <member name="M:System.MemoryExtensions.AsMemory``1(System.ArraySegment{``0},System.Int32)">
+            <summary>
+            Creates a new memory over the portion of the target array beginning
+            at 'start' index and ending at 'end' index (exclusive).
+            </summary>
+            <param name="segment">The target array.</param>
+            <param name="start">The index at which to begin the memory.</param>
+            <remarks>Returns default when <paramref name="segment"/> is null.</remarks>
+            <exception cref="T:System.ArrayTypeMismatchException">Thrown when <paramref name="segment"/> is covariant and array's type is not exactly T[].</exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+            Thrown when the specified <paramref name="start"/> or end index is not in the range (&lt;0 or &gt;=segment.Count).
+            </exception>
+        </member>
+        <member name="M:System.MemoryExtensions.AsMemory``1(System.ArraySegment{``0},System.Int32,System.Int32)">
+            <summary>
+            Creates a new memory over the portion of the target array beginning
+            at 'start' index and ending at 'end' index (exclusive).
+            </summary>
+            <param name="segment">The target array.</param>
+            <param name="start">The index at which to begin the memory.</param>
+            <param name="length">The number of items in the memory.</param>
+            <remarks>Returns default when <paramref name="segment"/> is null.</remarks>
+            <exception cref="T:System.ArrayTypeMismatchException">Thrown when <paramref name="segment"/> is covariant and array's type is not exactly T[].</exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+            Thrown when the specified <paramref name="start"/> or end index is not in the range (&lt;0 or &gt;=segment.Count).
+            </exception>
+        </member>
+        <member name="M:System.MemoryExtensions.CopyTo``1(``0[],System.Span{``0})">
+             <summary>
+             Copies the contents of the array into the span. If the source
+             and destinations overlap, this method behaves as if the original values in
+             a temporary location before the destination is overwritten.
+             
+            <param name="source">The array to copy items from.</param>
+             <param name="destination">The span to copy items into.</param>
+             <exception cref="T:System.ArgumentException">
+             Thrown when the destination Span is shorter than the source array.
+             </exception>
+             </summary>
+        </member>
+        <member name="M:System.MemoryExtensions.CopyTo``1(``0[],System.Memory{``0})">
+             <summary>
+             Copies the contents of the array into the memory. If the source
+             and destinations overlap, this method behaves as if the original values are in
+             a temporary location before the destination is overwritten.
+             
+            <param name="source">The array to copy items from.</param>
+             <param name="destination">The memory to copy items into.</param>
+             <exception cref="T:System.ArgumentException">
+             Thrown when the destination is shorter than the source array.
+             </exception>
+             </summary>
+        </member>
+        <member name="M:System.MemoryExtensions.Overlaps``1(System.Span{``0},System.ReadOnlySpan{``0})">
+            <summary>
+            Determines whether two sequences overlap in memory.
+            </summary>
+        </member>
+        <member name="M:System.MemoryExtensions.Overlaps``1(System.Span{``0},System.ReadOnlySpan{``0},System.Int32@)">
+            <summary>
+            Determines whether two sequences overlap in memory and outputs the element offset.
+            </summary>
+        </member>
+        <member name="M:System.MemoryExtensions.Overlaps``1(System.ReadOnlySpan{``0},System.ReadOnlySpan{``0})">
+            <summary>
+            Determines whether two sequences overlap in memory.
+            </summary>
+        </member>
+        <member name="M:System.MemoryExtensions.Overlaps``1(System.ReadOnlySpan{``0},System.ReadOnlySpan{``0},System.Int32@)">
+            <summary>
+            Determines whether two sequences overlap in memory and outputs the element offset.
+            </summary>
+        </member>
+        <member name="M:System.MemoryExtensions.BinarySearch``1(System.Span{``0},System.IComparable{``0})">
+            <summary>
+            Searches an entire sorted <see cref="T:System.Span`1"/> for a value
+            using the specified <see cref="T:System.IComparable`1"/> generic interface.
+            </summary>
+            <typeparam name="T">The element type of the span.</typeparam>
+            <param name="span">The sorted <see cref="T:System.Span`1"/> to search.</param>
+            <param name="comparable">The <see cref="T:System.IComparable`1"/> to use when comparing.</param>
+            <returns>
+            The zero-based index of <paramref name="comparable"/> in the sorted <paramref name="span"/>,
+            if <paramref name="comparable"/> is found; otherwise, a negative number that is the bitwise complement
+            of the index of the next element that is larger than <paramref name="comparable"/> or, if there is
+            no larger element, the bitwise complement of <see cref="P:System.Span`1.Length"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+            <paramref name = "comparable" /> is <see langword="null"/> .
+            </exception>
+        </member>
+        <member name="M:System.MemoryExtensions.BinarySearch``2(System.Span{``0},``1)">
+            <summary>
+            Searches an entire sorted <see cref="T:System.Span`1"/> for a value
+            using the specified <typeparamref name="TComparable"/> generic type.
+            </summary>
+            <typeparam name="T">The element type of the span.</typeparam>
+            <typeparam name="TComparable">The specific type of <see cref="T:System.IComparable`1"/>.</typeparam>
+            <param name="span">The sorted <see cref="T:System.Span`1"/> to search.</param>
+            <param name="comparable">The <typeparamref name="TComparable"/> to use when comparing.</param>
+            <returns>
+            The zero-based index of <paramref name="comparable"/> in the sorted <paramref name="span"/>,
+            if <paramref name="comparable"/> is found; otherwise, a negative number that is the bitwise complement
+            of the index of the next element that is larger than <paramref name="comparable"/> or, if there is
+            no larger element, the bitwise complement of <see cref="P:System.Span`1.Length"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+            <paramref name = "comparable" /> is <see langword="null"/> .
+            </exception>
+        </member>
+        <member name="M:System.MemoryExtensions.BinarySearch``2(System.Span{``0},``0,``1)">
+            <summary>
+            Searches an entire sorted <see cref="T:System.Span`1"/> for the specified <paramref name="value"/>
+            using the specified <typeparamref name="TComparer"/> generic type.
+            </summary>
+            <typeparam name="T">The element type of the span.</typeparam>
+            <typeparam name="TComparer">The specific type of <see cref="T:System.Collections.Generic.IComparer`1"/>.</typeparam>
+            <param name="span">The sorted <see cref="T:System.Span`1"/> to search.</param>
+            <param name="value">The object to locate. The value can be null for reference types.</param>
+            <param name="comparer">The <typeparamref name="TComparer"/> to use when comparing.</param>
+            /// <returns>
+            The zero-based index of <paramref name="value"/> in the sorted <paramref name="span"/>,
+            if <paramref name="value"/> is found; otherwise, a negative number that is the bitwise complement
+            of the index of the next element that is larger than <paramref name="value"/> or, if there is
+            no larger element, the bitwise complement of <see cref="P:System.Span`1.Length"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+            <paramref name = "comparer" /> is <see langword="null"/> .
+            </exception>
+        </member>
+        <member name="M:System.MemoryExtensions.BinarySearch``1(System.ReadOnlySpan{``0},System.IComparable{``0})">
+            <summary>
+            Searches an entire sorted <see cref="T:System.ReadOnlySpan`1"/> for a value
+            using the specified <see cref="T:System.IComparable`1"/> generic interface.
+            </summary>
+            <typeparam name="T">The element type of the span.</typeparam>
+            <param name="span">The sorted <see cref="T:System.ReadOnlySpan`1"/> to search.</param>
+            <param name="comparable">The <see cref="T:System.IComparable`1"/> to use when comparing.</param>
+            <returns>
+            The zero-based index of <paramref name="comparable"/> in the sorted <paramref name="span"/>,
+            if <paramref name="comparable"/> is found; otherwise, a negative number that is the bitwise complement
+            of the index of the next element that is larger than <paramref name="comparable"/> or, if there is
+            no larger element, the bitwise complement of <see cref="P:System.ReadOnlySpan`1.Length"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+            <paramref name = "comparable" /> is <see langword="null"/> .
+            </exception>
+        </member>
+        <member name="M:System.MemoryExtensions.BinarySearch``2(System.ReadOnlySpan{``0},``1)">
+            <summary>
+            Searches an entire sorted <see cref="T:System.ReadOnlySpan`1"/> for a value
+            using the specified <typeparamref name="TComparable"/> generic type.
+            </summary>
+            <typeparam name="T">The element type of the span.</typeparam>
+            <typeparam name="TComparable">The specific type of <see cref="T:System.IComparable`1"/>.</typeparam>
+            <param name="span">The sorted <see cref="T:System.ReadOnlySpan`1"/> to search.</param>
+            <param name="comparable">The <typeparamref name="TComparable"/> to use when comparing.</param>
+            <returns>
+            The zero-based index of <paramref name="comparable"/> in the sorted <paramref name="span"/>,
+            if <paramref name="comparable"/> is found; otherwise, a negative number that is the bitwise complement
+            of the index of the next element that is larger than <paramref name="comparable"/> or, if there is
+            no larger element, the bitwise complement of <see cref="P:System.ReadOnlySpan`1.Length"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+            <paramref name = "comparable" /> is <see langword="null"/> .
+            </exception>
+        </member>
+        <member name="M:System.MemoryExtensions.BinarySearch``2(System.ReadOnlySpan{``0},``0,``1)">
+            <summary>
+            Searches an entire sorted <see cref="T:System.ReadOnlySpan`1"/> for the specified <paramref name="value"/>
+            using the specified <typeparamref name="TComparer"/> generic type.
+            </summary>
+            <typeparam name="T">The element type of the span.</typeparam>
+            <typeparam name="TComparer">The specific type of <see cref="T:System.Collections.Generic.IComparer`1"/>.</typeparam>
+            <param name="span">The sorted <see cref="T:System.ReadOnlySpan`1"/> to search.</param>
+            <param name="value">The object to locate. The value can be null for reference types.</param>
+            <param name="comparer">The <typeparamref name="TComparer"/> to use when comparing.</param>
+            /// <returns>
+            The zero-based index of <paramref name="value"/> in the sorted <paramref name="span"/>,
+            if <paramref name="value"/> is found; otherwise, a negative number that is the bitwise complement
+            of the index of the next element that is larger than <paramref name="value"/> or, if there is
+            no larger element, the bitwise complement of <see cref="P:System.ReadOnlySpan`1.Length"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+            <paramref name = "comparer" /> is <see langword="null"/> .
+            </exception>
+        </member>
+        <member name="M:System.MemoryExtensions.AsSpan``1(``0[],System.Int32)">
+            <summary>
+            Creates a new span over the portion of the target array.
+            </summary>
+        </member>
+        <member name="M:System.MemoryExtensions.Contains(System.ReadOnlySpan{System.Char},System.ReadOnlySpan{System.Char},System.StringComparison)">
+            <summary>
+            Returns a value indicating whether the specified <paramref name="value"/> occurs within the <paramref name="span"/>.
+            <param name="span">The source span.</param>
+            <param name="value">The value to seek within the source span.</param>
+            <param name="comparisonType">One of the enumeration values that determines how the <paramref name="span"/> and <paramref name="value"/> are compared.</param>
+            </summary>
+        </member>
+        <member name="M:System.MemoryExtensions.Equals(System.ReadOnlySpan{System.Char},System.ReadOnlySpan{System.Char},System.StringComparison)">
+            <summary>
+            Determines whether this <paramref name="span"/> and the specified <paramref name="other"/> span have the same characters
+            when compared using the specified <paramref name="comparisonType"/> option.
+            <param name="span">The source span.</param>
+            <param name="other">The value to compare with the source span.</param>
+            <param name="comparisonType">One of the enumeration values that determines how the <paramref name="span"/> and <paramref name="other"/> are compared.</param>
+            </summary>
+        </member>
+        <member name="M:System.MemoryExtensions.CompareTo(System.ReadOnlySpan{System.Char},System.ReadOnlySpan{System.Char},System.StringComparison)">
+            <summary>
+            Compares the specified <paramref name="span"/> and <paramref name="other"/> using the specified <paramref name="comparisonType"/>,
+            and returns an integer that indicates their relative position in the sort order.
+            <param name="span">The source span.</param>
+            <param name="other">The value to compare with the source span.</param>
+            <param name="comparisonType">One of the enumeration values that determines how the <paramref name="span"/> and <paramref name="other"/> are compared.</param>
+            </summary>
+        </member>
+        <member name="M:System.MemoryExtensions.IndexOf(System.ReadOnlySpan{System.Char},System.ReadOnlySpan{System.Char},System.StringComparison)">
+            <summary>
+            Reports the zero-based index of the first occurrence of the specified <paramref name="value"/> in the current <paramref name="span"/>.
+            <param name="span">The source span.</param>
+            <param name="value">The value to seek within the source span.</param>
+            <param name="comparisonType">One of the enumeration values that determines how the <paramref name="span"/> and <paramref name="value"/> are compared.</param>
+            </summary>
+        </member>
+        <member name="M:System.MemoryExtensions.ToLower(System.ReadOnlySpan{System.Char},System.Span{System.Char},System.Globalization.CultureInfo)">
+            <summary>
+            Copies the characters from the source span into the destination, converting each character to lowercase,
+            using the casing rules of the specified culture.
+            </summary>
+            <param name="source">The source span.</param>
+            <param name="destination">The destination span which contains the transformed characters.</param>
+            <param name="culture">An object that supplies culture-specific casing rules.</param>
+            <remarks>If the source and destinations overlap, this method behaves as if the original values are in
+            a temporary location before the destination is overwritten.</remarks>
+            <exception cref="T:System.ArgumentNullException">
+            Thrown when <paramref name="culture"/> is null.
+            </exception>
+        </member>
+        <member name="M:System.MemoryExtensions.ToLowerInvariant(System.ReadOnlySpan{System.Char},System.Span{System.Char})">
+            <summary>
+            Copies the characters from the source span into the destination, converting each character to lowercase,
+            using the casing rules of the invariant culture.
+            </summary>
+            <param name="source">The source span.</param>
+            <param name="destination">The destination span which contains the transformed characters.</param>
+            <remarks>If the source and destinations overlap, this method behaves as if the original values are in
+            a temporary location before the destination is overwritten.</remarks>
+        </member>
+        <member name="M:System.MemoryExtensions.ToUpper(System.ReadOnlySpan{System.Char},System.Span{System.Char},System.Globalization.CultureInfo)">
+            <summary>
+            Copies the characters from the source span into the destination, converting each character to uppercase,
+            using the casing rules of the specified culture.
+            </summary>
+            <param name="source">The source span.</param>
+            <param name="destination">The destination span which contains the transformed characters.</param>
+            <param name="culture">An object that supplies culture-specific casing rules.</param>
+            <remarks>If the source and destinations overlap, this method behaves as if the original values are in
+            a temporary location before the destination is overwritten.</remarks>
+            <exception cref="T:System.ArgumentNullException">
+            Thrown when <paramref name="culture"/> is null.
+            </exception>
+        </member>
+        <member name="M:System.MemoryExtensions.ToUpperInvariant(System.ReadOnlySpan{System.Char},System.Span{System.Char})">
+            <summary>
+            Copies the characters from the source span into the destination, converting each character to uppercase
+            using the casing rules of the invariant culture.
+            </summary>
+            <param name="source">The source span.</param>
+            <param name="destination">The destination span which contains the transformed characters.</param>
+            <remarks>If the source and destinations overlap, this method behaves as if the original values are in
+            a temporary location before the destination is overwritten.</remarks>
+        </member>
+        <member name="M:System.MemoryExtensions.EndsWith(System.ReadOnlySpan{System.Char},System.ReadOnlySpan{System.Char},System.StringComparison)">
+            <summary>
+            Determines whether the end of the <paramref name="span"/> matches the specified <paramref name="value"/> when compared using the specified <paramref name="comparisonType"/> option.
+            </summary>
+            <param name="span">The source span.</param>
+            <param name="value">The sequence to compare to the end of the source span.</param>
+            <param name="comparisonType">One of the enumeration values that determines how the <paramref name="span"/> and <paramref name="value"/> are compared.</param>
+        </member>
+        <member name="M:System.MemoryExtensions.StartsWith(System.ReadOnlySpan{System.Char},System.ReadOnlySpan{System.Char},System.StringComparison)">
+            <summary>
+            Determines whether the beginning of the <paramref name="span"/> matches the specified <paramref name="value"/> when compared using the specified <paramref name="comparisonType"/> option.
+            </summary>
+            <param name="span">The source span.</param>
+            <param name="value">The sequence to compare to the beginning of the source span.</param>
+            <param name="comparisonType">One of the enumeration values that determines how the <paramref name="span"/> and <paramref name="value"/> are compared.</param>
+        </member>
+        <member name="M:System.MemoryExtensions.AsSpan(System.String)">
+            <summary>
+            Creates a new readonly span over the portion of the target string.
+            </summary>
+            <param name="text">The target string.</param>
+            <remarks>Returns default when <paramref name="text"/> is null.</remarks>
+        </member>
+        <member name="M:System.MemoryExtensions.AsSpan(System.String,System.Int32)">
+            <summary>
+            Creates a new readonly span over the portion of the target string.
+            </summary>
+            <param name="text">The target string.</param>
+            <param name="start">The index at which to begin this slice.</param>
+            <remarks>Returns default when <paramref name="text"/> is null.</remarks>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+            Thrown when the specified <paramref name="start"/> index is not in range (&lt;0 or &gt;text.Length).
+            </exception>
+        </member>
+        <member name="M:System.MemoryExtensions.AsSpan(System.String,System.Int32,System.Int32)">
+            <summary>
+            Creates a new readonly span over the portion of the target string.
+            </summary>
+            <param name="text">The target string.</param>
+            <param name="start">The index at which to begin this slice.</param>
+            <param name="length">The desired length for the slice (exclusive).</param>
+            <remarks>Returns default when <paramref name="text"/> is null.</remarks>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+            Thrown when the specified <paramref name="start"/> index or <paramref name="length"/> is not in range.
+            </exception>
+        </member>
+        <member name="M:System.MemoryExtensions.AsMemory(System.String)">
+            <summary>Creates a new <see cref="T:System.ReadOnlyMemory`1"/> over the portion of the target string.</summary>
+            <param name="text">The target string.</param>
+            <remarks>Returns default when <paramref name="text"/> is null.</remarks>
+        </member>
+        <member name="M:System.MemoryExtensions.AsMemory(System.String,System.Int32)">
+            <summary>Creates a new <see cref="T:System.ReadOnlyMemory`1"/> over the portion of the target string.</summary>
+            <param name="text">The target string.</param>
+            <param name="start">The index at which to begin this slice.</param>
+            <remarks>Returns default when <paramref name="text"/> is null.</remarks>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+            Thrown when the specified <paramref name="start"/> index is not in range (&lt;0 or &gt;text.Length).
+            </exception>
+        </member>
+        <member name="M:System.MemoryExtensions.AsMemory(System.String,System.Int32,System.Int32)">
+            <summary>Creates a new <see cref="T:System.ReadOnlyMemory`1"/> over the portion of the target string.</summary>
+            <param name="text">The target string.</param>
+            <param name="start">The index at which to begin this slice.</param>
+            <param name="length">The desired length for the slice (exclusive).</param>
+            <remarks>Returns default when <paramref name="text"/> is null.</remarks>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+            Thrown when the specified <paramref name="start"/> index or <paramref name="length"/> is not in range.
+            </exception>
+        </member>
+        <member name="T:System.ReadOnlyMemory`1">
+            <summary>
+            Represents a contiguous region of memory, similar to <see cref="T:System.ReadOnlySpan`1"/>.
+            Unlike <see cref="T:System.ReadOnlySpan`1"/>, it is not a byref-like type.
+            </summary>
+        </member>
+        <member name="M:System.ReadOnlyMemory`1.#ctor(`0[])">
+            <summary>
+            Creates a new memory over the entirety of the target array.
+            </summary>
+            <param name="array">The target array.</param>
+            <remarks>Returns default when <paramref name="array"/> is null.</remarks>
+            <exception cref="T:System.ArrayTypeMismatchException">Thrown when <paramref name="array"/> is covariant and array's type is not exactly T[].</exception>
+        </member>
+        <member name="M:System.ReadOnlyMemory`1.#ctor(`0[],System.Int32,System.Int32)">
+            <summary>
+            Creates a new memory over the portion of the target array beginning
+            at 'start' index and ending at 'end' index (exclusive).
+            </summary>
+            <param name="array">The target array.</param>
+            <param name="start">The index at which to begin the memory.</param>
+            <param name="length">The number of items in the memory.</param>
+            <remarks>Returns default when <paramref name="array"/> is null.</remarks>
+            <exception cref="T:System.ArrayTypeMismatchException">Thrown when <paramref name="array"/> is covariant and array's type is not exactly T[].</exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+            Thrown when the specified <paramref name="start"/> or end index is not in the range (&lt;0 or &gt;=Length).
+            </exception>
+        </member>
+        <member name="M:System.ReadOnlyMemory`1.#ctor(System.Object,System.Int32,System.Int32)">
+            <summary>Creates a new memory over the existing object, start, and length. No validation is performed.</summary>
+            <param name="obj">The target object.</param>
+            <param name="start">The index at which to begin the memory.</param>
+            <param name="length">The number of items in the memory.</param>
+        </member>
+        <member name="M:System.ReadOnlyMemory`1.op_Implicit(`0[])~System.ReadOnlyMemory{`0}">
+            <summary>
+            Defines an implicit conversion of an array to a <see cref="T:System.ReadOnlyMemory`1"/>
+            </summary>
+        </member>
+        <member name="M:System.ReadOnlyMemory`1.op_Implicit(System.ArraySegment{`0})~System.ReadOnlyMemory{`0}">
+            <summary>
+            Defines an implicit conversion of a <see cref="T:System.ArraySegment`1"/> to a <see cref="T:System.ReadOnlyMemory`1"/>
+            </summary>
+        </member>
+        <member name="P:System.ReadOnlyMemory`1.Empty">
+            <summary>
+            Returns an empty <see cref="T:System.ReadOnlyMemory`1"/>
+            </summary>
+        </member>
+        <member name="P:System.ReadOnlyMemory`1.Length">
+            <summary>
+            The number of items in the memory.
+            </summary>
+        </member>
+        <member name="P:System.ReadOnlyMemory`1.IsEmpty">
+            <summary>
+            Returns true if Length is 0.
+            </summary>
+        </member>
+        <member name="M:System.ReadOnlyMemory`1.ToString">
+            <summary>
+            For <see cref="T:System.ReadOnlyMemory`1"/>, returns a new instance of string that represents the characters pointed to by the memory.
+            Otherwise, returns a <see cref="T:System.String"/> with the name of the type and the number of elements.
+            </summary>
+        </member>
+        <member name="M:System.ReadOnlyMemory`1.Slice(System.Int32)">
+            <summary>
+            Forms a slice out of the given memory, beginning at 'start'.
+            </summary>
+            <param name="start">The index at which to begin this slice.</param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+            Thrown when the specified <paramref name="start"/> index is not in range (&lt;0 or &gt;=Length).
+            </exception>
+        </member>
+        <member name="M:System.ReadOnlyMemory`1.Slice(System.Int32,System.Int32)">
+            <summary>
+            Forms a slice out of the given memory, beginning at 'start', of given length
+            </summary>
+            <param name="start">The index at which to begin this slice.</param>
+            <param name="length">The desired length for the slice (exclusive).</param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+            Thrown when the specified <paramref name="start"/> or end index is not in range (&lt;0 or &gt;=Length).
+            </exception>
+        </member>
+        <member name="P:System.ReadOnlyMemory`1.Span">
+            <summary>
+            Returns a span from the memory.
+            </summary>
+        </member>
+        <member name="M:System.ReadOnlyMemory`1.CopyTo(System.Memory{`0})">
+             <summary>
+             Copies the contents of the read-only memory into the destination. If the source
+             and destination overlap, this method behaves as if the original values are in
+             a temporary location before the destination is overwritten.
+            
+             <param name="destination">The Memory to copy items into.</param>
+             <exception cref="T:System.ArgumentException">
+             Thrown when the destination is shorter than the source.
+             </exception>
+             </summary>
+        </member>
+        <member name="M:System.ReadOnlyMemory`1.TryCopyTo(System.Memory{`0})">
+             <summary>
+             Copies the contents of the readonly-only memory into the destination. If the source
+             and destination overlap, this method behaves as if the original values are in
+             a temporary location before the destination is overwritten.
+            
+             <returns>If the destination is shorter than the source, this method
+             return false and no data is written to the destination.</returns>
+             </summary>
+             <param name="destination">The span to copy items into.</param>
+        </member>
+        <member name="M:System.ReadOnlyMemory`1.Pin">
+            <summary>
+            Creates a handle for the memory.
+            The GC will not move the memory until the returned <see cref="T:System.Buffers.MemoryHandle"/>
+            is disposed, enabling taking and using the memory's address.
+            <exception cref="T:System.ArgumentException">
+            An instance with nonprimitive (non-blittable) members cannot be pinned.
+            </exception>
+            </summary>
+        </member>
+        <member name="M:System.ReadOnlyMemory`1.ToArray">
+            <summary>
+            Copies the contents from the memory into a new array.  This heap
+            allocates, so should generally be avoided, however it is sometimes
+            necessary to bridge the gap with APIs written in terms of arrays.
+            </summary>
+        </member>
+        <member name="M:System.ReadOnlyMemory`1.Equals(System.Object)">
+            <summary>Determines whether the specified object is equal to the current object.</summary>
+        </member>
+        <member name="M:System.ReadOnlyMemory`1.Equals(System.ReadOnlyMemory{`0})">
+            <summary>
+            Returns true if the memory points to the same array and has the same length.  Note that
+            this does *not* check to see if the *contents* are equal.
+            </summary>
+        </member>
+        <member name="M:System.ReadOnlyMemory`1.GetHashCode">
+            <summary>Returns the hash code for this <see cref="T:System.ReadOnlyMemory`1"/></summary>
+        </member>
+        <member name="M:System.ReadOnlyMemory`1.GetObjectStartLength(System.Int32@,System.Int32@)">
+            <summary>Gets the state of the memory as individual fields.</summary>
+            <param name="start">The offset.</param>
+            <param name="length">The count.</param>
+            <returns>The object.</returns>
+        </member>
+        <member name="T:System.ReadOnlySpan`1">
+            <summary>
+            ReadOnlySpan represents a contiguous region of arbitrary memory. Unlike arrays, it can point to either managed
+            or native memory, or to memory allocated on the stack. It is type- and memory-safe.
+            </summary>
+            <summary>
+            ReadOnlySpan represents a contiguous region of arbitrary memory. Unlike arrays, it can point to either managed
+            or native memory, or to memory allocated on the stack. It is type- and memory-safe.
+            </summary>
+        </member>
+        <member name="P:System.ReadOnlySpan`1.Length">
+            <summary>
+            The number of items in the read-only span.
+            </summary>
+        </member>
+        <member name="P:System.ReadOnlySpan`1.IsEmpty">
+            <summary>
+            Returns true if Length is 0.
+            </summary>
+        </member>
+        <member name="M:System.ReadOnlySpan`1.op_Inequality(System.ReadOnlySpan{`0},System.ReadOnlySpan{`0})">
+            <summary>
+            Returns false if left and right point at the same memory and have the same length.  Note that
+            this does *not* check to see if the *contents* are equal.
+            </summary>
+        </member>
+        <member name="M:System.ReadOnlySpan`1.Equals(System.Object)">
+            <summary>
+            This method is not supported as spans cannot be boxed. To compare two spans, use operator==.
+            <exception cref="T:System.NotSupportedException">
+            Always thrown by this method.
+            </exception>
+            </summary>
+        </member>
+        <member name="M:System.ReadOnlySpan`1.GetHashCode">
+            <summary>
+            This method is not supported as spans cannot be boxed.
+            <exception cref="T:System.NotSupportedException">
+            Always thrown by this method.
+            </exception>
+            </summary>
+        </member>
+        <member name="M:System.ReadOnlySpan`1.op_Implicit(`0[])~System.ReadOnlySpan{`0}">
+            <summary>
+            Defines an implicit conversion of an array to a <see cref="T:System.ReadOnlySpan`1"/>
+            </summary>
+        </member>
+        <member name="M:System.ReadOnlySpan`1.op_Implicit(System.ArraySegment{`0})~System.ReadOnlySpan{`0}">
+            <summary>
+            Defines an implicit conversion of a <see cref="T:System.ArraySegment`1"/> to a <see cref="T:System.ReadOnlySpan`1"/>
+            </summary>
+        </member>
+        <member name="P:System.ReadOnlySpan`1.Empty">
+            <summary>
+            Returns a 0-length read-only span whose base is the null pointer.
+            </summary>
+        </member>
+        <member name="M:System.ReadOnlySpan`1.GetEnumerator">
+            <summary>Gets an enumerator for this span.</summary>
+        </member>
+        <member name="T:System.ReadOnlySpan`1.Enumerator">
+            <summary>Enumerates the elements of a <see cref="T:System.ReadOnlySpan`1"/>.</summary>
+        </member>
+        <member name="F:System.ReadOnlySpan`1.Enumerator._span">
+            <summary>The span being enumerated.</summary>
+        </member>
+        <member name="F:System.ReadOnlySpan`1.Enumerator._index">
+            <summary>The next index to yield.</summary>
+        </member>
+        <member name="M:System.ReadOnlySpan`1.Enumerator.#ctor(System.ReadOnlySpan{`0})">
+            <summary>Initialize the enumerator.</summary>
+            <param name="span">The span to enumerate.</param>
+        </member>
+        <member name="M:System.ReadOnlySpan`1.Enumerator.MoveNext">
+            <summary>Advances the enumerator to the next element of the span.</summary>
+        </member>
+        <member name="P:System.ReadOnlySpan`1.Enumerator.Current">
+            <summary>Gets the element at the current position of the enumerator.</summary>
+        </member>
+        <member name="M:System.ReadOnlySpan`1.#ctor(`0[])">
+            <summary>
+            Creates a new read-only span over the entirety of the target array.
+            </summary>
+            <param name="array">The target array.</param>
+            <remarks>Returns default when <paramref name="array"/> is null.</remarks>
+            <exception cref="T:System.ArrayTypeMismatchException">Thrown when <paramref name="array"/> is covariant and array's type is not exactly T[].</exception>
+        </member>
+        <member name="M:System.ReadOnlySpan`1.#ctor(`0[],System.Int32,System.Int32)">
+            <summary>
+            Creates a new read-only span over the portion of the target array beginning
+            at 'start' index and ending at 'end' index (exclusive).
+            </summary>
+            <param name="array">The target array.</param>
+            <param name="start">The index at which to begin the read-only span.</param>
+            <param name="length">The number of items in the read-only span.</param>
+            <remarks>Returns default when <paramref name="array"/> is null.</remarks>
+            <exception cref="T:System.ArrayTypeMismatchException">Thrown when <paramref name="array"/> is covariant and array's type is not exactly T[].</exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+            Thrown when the specified <paramref name="start"/> or end index is not in the range (&lt;0 or &gt;=Length).
+            </exception>
+        </member>
+        <member name="M:System.ReadOnlySpan`1.#ctor(System.Void*,System.Int32)">
+            <summary>
+            Creates a new read-only span over the target unmanaged buffer.  Clearly this
+            is quite dangerous, because we are creating arbitrarily typed T's
+            out of a void*-typed block of memory.  And the length is not checked.
+            But if this creation is correct, then all subsequent uses are correct.
+            </summary>
+            <param name="pointer">An unmanaged pointer to memory.</param>
+            <param name="length">The number of <typeparamref name="T"/> elements the memory contains.</param>
+            <exception cref="T:System.ArgumentException">
+            Thrown when <typeparamref name="T"/> is reference type or contains pointers and hence cannot be stored in unmanaged memory.
+            </exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+            Thrown when the specified <paramref name="length"/> is negative.
+            </exception>
+        </member>
+        <member name="P:System.ReadOnlySpan`1.Item(System.Int32)">
+            <summary>
+            Returns the specified element of the read-only span.
+            </summary>
+            <param name="index"></param>
+            <returns></returns>
+            <exception cref="T:System.IndexOutOfRangeException">
+            Thrown when index less than 0 or index greater than or equal to Length
+            </exception>
+        </member>
+        <member name="M:System.ReadOnlySpan`1.GetPinnableReference">
+            <summary>
+            Returns a reference to the 0th element of the Span. If the Span is empty, returns null reference.
+            It can be used for pinning and is required to support the use of span within a fixed statement.
+            </summary>
+        </member>
+        <member name="M:System.ReadOnlySpan`1.CopyTo(System.Span{`0})">
+             <summary>
+             Copies the contents of this read-only span into destination span. If the source
+             and destinations overlap, this method behaves as if the original values in
+             a temporary location before the destination is overwritten.
+            
+             <param name="destination">The span to copy items into.</param>
+             <exception cref="T:System.ArgumentException">
+             Thrown when the destination Span is shorter than the source Span.
+             </exception>
+             </summary>
+        </member>
+        <member name="M:System.ReadOnlySpan`1.TryCopyTo(System.Span{`0})">
+             <summary>
+             Copies the contents of this read-only span into destination span. If the source
+             and destinations overlap, this method behaves as if the original values in
+             a temporary location before the destination is overwritten.
+            
+             <returns>If the destination span is shorter than the source span, this method
+             return false and no data is written to the destination.</returns>
+             </summary>
+             <param name="destination">The span to copy items into.</param>
+        </member>
+        <member name="M:System.ReadOnlySpan`1.op_Equality(System.ReadOnlySpan{`0},System.ReadOnlySpan{`0})">
+            <summary>
+            Returns true if left and right point at the same memory and have the same length.  Note that
+            this does *not* check to see if the *contents* are equal.
+            </summary>
+        </member>
+        <member name="M:System.ReadOnlySpan`1.ToString">
+            <summary>
+            For <see cref="T:System.Span`1"/>, returns a new instance of string that represents the characters pointed to by the span.
+            Otherwise, returns a <see cref="T:System.String"/> with the name of the type and the number of elements.
+            </summary>
+        </member>
+        <member name="M:System.ReadOnlySpan`1.Slice(System.Int32)">
+            <summary>
+            Forms a slice out of the given read-only span, beginning at 'start'.
+            </summary>
+            <param name="start">The index at which to begin this slice.</param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+            Thrown when the specified <paramref name="start"/> index is not in range (&lt;0 or &gt;=Length).
+            </exception>
+        </member>
+        <member name="M:System.ReadOnlySpan`1.Slice(System.Int32,System.Int32)">
+            <summary>
+            Forms a slice out of the given read-only span, beginning at 'start', of given length
+            </summary>
+            <param name="start">The index at which to begin this slice.</param>
+            <param name="length">The desired length for the slice (exclusive).</param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+            Thrown when the specified <paramref name="start"/> or end index is not in range (&lt;0 or &gt;=Length).
+            </exception>
+        </member>
+        <member name="M:System.ReadOnlySpan`1.ToArray">
+            <summary>
+            Copies the contents of this read-only span into a new array.  This heap
+            allocates, so should generally be avoided, however it is sometimes
+            necessary to bridge the gap with APIs written in terms of arrays.
+            </summary>
+        </member>
+        <member name="M:System.ReadOnlySpan`1.DangerousGetPinnableReference">
+            <summary>
+            This method is obsolete, use System.Runtime.InteropServices.MemoryMarshal.GetReference instead.
+            Returns a reference to the 0th element of the Span. If the Span is empty, returns a reference to the location where the 0th element
+            would have been stored. Such a reference can be used for pinning but must never be dereferenced.
+            </summary>
+        </member>
+        <member name="T:System.Runtime.InteropServices.MemoryMarshal">
+            <summary>
+            Provides a collection of methods for interoperating with <see cref="T:System.Memory`1"/>, <see cref="T:System.ReadOnlyMemory`1"/>,
+            <see cref="T:System.Span`1"/>, and <see cref="T:System.ReadOnlySpan`1"/>.
+            </summary>
+            <summary>
+            Provides a collection of methods for interoperating with <see cref="T:System.Memory`1"/>, <see cref="T:System.ReadOnlyMemory`1"/>,
+            <see cref="T:System.Span`1"/>, and <see cref="T:System.ReadOnlySpan`1"/>.
+            </summary>
+        </member>
+        <member name="M:System.Runtime.InteropServices.MemoryMarshal.TryGetArray``1(System.ReadOnlyMemory{``0},System.ArraySegment{``0}@)">
+            <summary>
+            Get an array segment from the underlying memory.
+            If unable to get the array segment, return false with a default array segment.
+            </summary>
+        </member>
+        <member name="M:System.Runtime.InteropServices.MemoryMarshal.TryGetMemoryManager``2(System.ReadOnlyMemory{``0},``1@)">
+            <summary>
+            Gets an <see cref="T:System.Buffers.MemoryManager`1"/> from the underlying read-only memory.
+            If unable to get the <typeparamref name="TManager"/> type, returns false.
+            </summary>
+            <typeparam name="T">The element type of the <paramref name="memory" />.</typeparam>
+            <typeparam name="TManager">The type of <see cref="T:System.Buffers.MemoryManager`1"/> to try and retrive.</typeparam>
+            <param name="memory">The memory to get the manager for.</param>
+            <param name="manager">The returned manager of the <see cref="T:System.ReadOnlyMemory`1"/>.</param>
+            <returns>A <see cref="T:System.Boolean"/> indicating if it was successful.</returns>
+        </member>
+        <member name="M:System.Runtime.InteropServices.MemoryMarshal.TryGetMemoryManager``2(System.ReadOnlyMemory{``0},``1@,System.Int32@,System.Int32@)">
+            <summary>
+            Gets an <see cref="T:System.Buffers.MemoryManager`1"/> and <paramref name="start" />, <paramref name="length" /> from the underlying read-only memory.
+            If unable to get the <typeparamref name="TManager"/> type, returns false.
+            </summary>
+            <typeparam name="T">The element type of the <paramref name="memory" />.</typeparam>
+            <typeparam name="TManager">The type of <see cref="T:System.Buffers.MemoryManager`1"/> to try and retrive.</typeparam>
+            <param name="memory">The memory to get the manager for.</param>
+            <param name="manager">The returned manager of the <see cref="T:System.ReadOnlyMemory`1"/>.</param>
+            <param name="start">The offset from the start of the <paramref name="manager" /> that the <paramref name="memory" /> represents.</param>
+            <param name="length">The length of the <paramref name="manager" /> that the <paramref name="memory" /> represents.</param>
+            <returns>A <see cref="T:System.Boolean"/> indicating if it was successful.</returns>
+        </member>
+        <member name="M:System.Runtime.InteropServices.MemoryMarshal.ToEnumerable``1(System.ReadOnlyMemory{``0})">
+            <summary>
+            Creates an <see cref="T:System.Collections.Generic.IEnumerable`1"/> view of the given <paramref name="memory" /> to allow
+            the <paramref name="memory" /> to be used in existing APIs that take an <see cref="T:System.Collections.Generic.IEnumerable`1"/>.
+            </summary>
+            <typeparam name="T">The element type of the <paramref name="memory" />.</typeparam>
+            <param name="memory">The ReadOnlyMemory to view as an <see cref="T:System.Collections.Generic.IEnumerable`1"/></param>
+            <returns>An <see cref="T:System.Collections.Generic.IEnumerable`1"/> view of the given <paramref name="memory" /></returns>
+        </member>
+        <member name="M:System.Runtime.InteropServices.MemoryMarshal.TryGetString(System.ReadOnlyMemory{System.Char},System.String@,System.Int32@,System.Int32@)">
+            <summary>Attempts to get the underlying <see cref="T:System.String"/> from a <see cref="T:System.ReadOnlyMemory`1"/>.</summary>
+            <param name="memory">The memory that may be wrapping a <see cref="T:System.String"/> object.</param>
+            <param name="text">The string.</param>
+            <param name="start">The starting location in <paramref name="text"/>.</param>
+            <param name="length">The number of items in <paramref name="text"/>.</param>
+            <returns></returns>
+        </member>
+        <member name="M:System.Runtime.InteropServices.MemoryMarshal.Read``1(System.ReadOnlySpan{System.Byte})">
+            <summary>
+            Reads a structure of type T out of a read-only span of bytes.
+            </summary>
+        </member>
+        <member name="M:System.Runtime.InteropServices.MemoryMarshal.TryRead``1(System.ReadOnlySpan{System.Byte},``0@)">
+            <summary>
+            Reads a structure of type T out of a span of bytes.
+            <returns>If the span is too small to contain the type T, return false.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Runtime.InteropServices.MemoryMarshal.Write``1(System.Span{System.Byte},``0@)">
+            <summary>
+            Writes a structure of type T into a span of bytes.
+            </summary>
+        </member>
+        <member name="M:System.Runtime.InteropServices.MemoryMarshal.TryWrite``1(System.Span{System.Byte},``0@)">
+            <summary>
+            Writes a structure of type T into a span of bytes.
+            <returns>If the span is too small to contain the type T, return false.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Runtime.InteropServices.MemoryMarshal.CreateFromPinnedArray``1(``0[],System.Int32,System.Int32)">
+            <summary>
+            Creates a new memory over the portion of the pre-pinned target array beginning
+            at 'start' index and ending at 'end' index (exclusive).
+            </summary>
+            <param name="array">The pre-pinned target array.</param>
+            <param name="start">The index at which to begin the memory.</param>
+            <param name="length">The number of items in the memory.</param>
+            <remarks>This method should only be called on an array that is already pinned and 
+            that array should not be unpinned while the returned Memory<typeparamref name="T"/> is still in use.
+            Calling this method on an unpinned array could result in memory corruption.</remarks>
+            <remarks>Returns default when <paramref name="array"/> is null.</remarks>
+            <exception cref="T:System.ArrayTypeMismatchException">Thrown when <paramref name="array"/> is covariant and array's type is not exactly T[].</exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+            Thrown when the specified <paramref name="start"/> or end index is not in the range (&lt;0 or &gt;=Length).
+            </exception>
+        </member>
+        <member name="M:System.Runtime.InteropServices.MemoryMarshal.AsBytes``1(System.Span{``0})">
+            <summary>
+            Casts a Span of one primitive type <typeparamref name="T"/> to Span of bytes.
+            That type may not contain pointers or references. This is checked at runtime in order to preserve type safety.
+            </summary>
+            <param name="span">The source slice, of type <typeparamref name="T"/>.</param>
+            <exception cref="T:System.ArgumentException">
+            Thrown when <typeparamref name="T"/> contains pointers.
+            </exception>
+            <exception cref="T:System.OverflowException">
+            Thrown if the Length property of the new Span would exceed Int32.MaxValue.
+            </exception>
+        </member>
+        <member name="M:System.Runtime.InteropServices.MemoryMarshal.AsBytes``1(System.ReadOnlySpan{``0})">
+            <summary>
+            Casts a ReadOnlySpan of one primitive type <typeparamref name="T"/> to ReadOnlySpan of bytes.
+            That type may not contain pointers or references. This is checked at runtime in order to preserve type safety.
+            </summary>
+            <param name="span">The source slice, of type <typeparamref name="T"/>.</param>
+            <exception cref="T:System.ArgumentException">
+            Thrown when <typeparamref name="T"/> contains pointers.
+            </exception>
+            <exception cref="T:System.OverflowException">
+            Thrown if the Length property of the new Span would exceed Int32.MaxValue.
+            </exception>
+        </member>
+        <member name="M:System.Runtime.InteropServices.MemoryMarshal.AsMemory``1(System.ReadOnlyMemory{``0})">
+            <summary>Creates a <see cref="T:System.Memory`1"/> from a <see cref="T:System.ReadOnlyMemory`1"/>.</summary>
+            <param name="memory">The <see cref="T:System.ReadOnlyMemory`1"/>.</param>
+            <returns>A <see cref="T:System.Memory`1"/> representing the same memory as the <see cref="T:System.ReadOnlyMemory`1"/>, but writable.</returns>
+            <remarks>
+            <see cref="M:System.Runtime.InteropServices.MemoryMarshal.AsMemory``1(System.ReadOnlyMemory{``0})"/> must be used with extreme caution.  <see cref="T:System.ReadOnlyMemory`1"/> is used
+            to represent immutable data and other memory that is not meant to be written to; <see cref="T:System.Memory`1"/> instances created
+            by <see cref="M:System.Runtime.InteropServices.MemoryMarshal.AsMemory``1(System.ReadOnlyMemory{``0})"/> should not be written to.  The method exists to enable variables typed
+            as <see cref="T:System.Memory`1"/> but only used for reading to store a <see cref="T:System.ReadOnlyMemory`1"/>.
+            </remarks>
+        </member>
+        <member name="M:System.Runtime.InteropServices.MemoryMarshal.GetReference``1(System.Span{``0})">
+            <summary>
+            Returns a reference to the 0th element of the Span. If the Span is empty, returns a reference to the location where the 0th element
+            would have been stored. Such a reference can be used for pinning but must never be dereferenced.
+            </summary>
+        </member>
+        <member name="M:System.Runtime.InteropServices.MemoryMarshal.GetReference``1(System.ReadOnlySpan{``0})">
+            <summary>
+            Returns a reference to the 0th element of the ReadOnlySpan. If the Span is empty, returns a reference to the location where the 0th element
+            would have been stored. Such a reference can be used for pinning but must never be dereferenced.
+            </summary>
+        </member>
+        <member name="M:System.Runtime.InteropServices.MemoryMarshal.Cast``2(System.Span{``0})">
+            <summary>
+            Casts a Span of one primitive type <typeparamref name="TFrom"/> to another primitive type <typeparamref name="TTo"/>.
+            These types may not contain pointers or references. This is checked at runtime in order to preserve type safety.
+            </summary>
+            <remarks>
+            Supported only for platforms that support misaligned memory access.
+            </remarks>
+            <param name="span">The source slice, of type <typeparamref name="TFrom"/>.</param>
+            <exception cref="T:System.ArgumentException">
+            Thrown when <typeparamref name="TFrom"/> or <typeparamref name="TTo"/> contains pointers.
+            </exception>
+        </member>
+        <member name="M:System.Runtime.InteropServices.MemoryMarshal.Cast``2(System.ReadOnlySpan{``0})">
+            <summary>
+            Casts a ReadOnlySpan of one primitive type <typeparamref name="TFrom"/> to another primitive type <typeparamref name="TTo"/>.
+            These types may not contain pointers or references. This is checked at runtime in order to preserve type safety.
+            </summary>
+            <remarks>
+            Supported only for platforms that support misaligned memory access.
+            </remarks>
+            <param name="span">The source slice, of type <typeparamref name="TFrom"/>.</param>
+            <exception cref="T:System.ArgumentException">
+            Thrown when <typeparamref name="TFrom"/> or <typeparamref name="TTo"/> contains pointers.
+            </exception>
+        </member>
+        <member name="T:System.Runtime.InteropServices.SequenceMarshal">
+            <summary>
+            Provides a collection of methods for interoperating with <see cref="T:System.Buffers.ReadOnlySequence`1"/>
+            </summary>
+        </member>
+        <member name="M:System.Runtime.InteropServices.SequenceMarshal.TryGetReadOnlySequenceSegment``1(System.Buffers.ReadOnlySequence{``0},System.Buffers.ReadOnlySequenceSegment{``0}@,System.Int32@,System.Buffers.ReadOnlySequenceSegment{``0}@,System.Int32@)">
+            <summary>
+            Get <see cref="T:System.Buffers.ReadOnlySequenceSegment`1"/> from the underlying <see cref="T:System.Buffers.ReadOnlySequence`1"/>.
+            If unable to get the <see cref="T:System.Buffers.ReadOnlySequenceSegment`1"/>, return false.
+            </summary>
+        </member>
+        <member name="M:System.Runtime.InteropServices.SequenceMarshal.TryGetArray``1(System.Buffers.ReadOnlySequence{``0},System.ArraySegment{``0}@)">
+            <summary>
+            Get an array segment from the underlying <see cref="T:System.Buffers.ReadOnlySequence`1"/>.
+            If unable to get the array segment, return false with a default array segment.
+            </summary>
+        </member>
+        <member name="M:System.Runtime.InteropServices.SequenceMarshal.TryGetReadOnlyMemory``1(System.Buffers.ReadOnlySequence{``0},System.ReadOnlyMemory{``0}@)">
+            <summary>
+            Get <see cref="T:System.ReadOnlyMemory`1"/> from the underlying <see cref="T:System.Buffers.ReadOnlySequence`1"/>.
+            If unable to get the <see cref="T:System.ReadOnlyMemory`1"/>, return false.
+            </summary>
+        </member>
+        <member name="M:System.Runtime.InteropServices.SequenceMarshal.TryGetString(System.Buffers.ReadOnlySequence{System.Char},System.String@,System.Int32@,System.Int32@)">
+            <summary>
+            Get <see cref="T:System.String"/> from the underlying <see cref="T:System.Buffers.ReadOnlySequence`1"/>.
+            If unable to get the <see cref="T:System.String"/>, return false.
+            </summary>
+        </member>
+        <member name="T:System.SequencePosition">
+            <summary>
+            Represents position in non-contiguous set of memory.
+            Properties of this type should not be interpreted by anything but the type that created it.
+            </summary>
+        </member>
+        <member name="M:System.SequencePosition.#ctor(System.Object,System.Int32)">
+            <summary>
+            Creates new <see cref="T:System.SequencePosition"/>
+            </summary>
+        </member>
+        <member name="M:System.SequencePosition.GetObject">
+            <summary>
+            Returns object part of this <see cref="T:System.SequencePosition"/>
+            </summary>
+        </member>
+        <member name="M:System.SequencePosition.GetInteger">
+            <summary>
+            Returns integer part of this <see cref="T:System.SequencePosition"/>
+            </summary>
+        </member>
+        <member name="M:System.SequencePosition.Equals(System.SequencePosition)">
+            <summary>
+            Indicates whether the current <see cref="T:System.SequencePosition"/> is equal to another <see cref="T:System.SequencePosition"/>.
+            <see cref="T:System.SequencePosition"/> equality does not guarantee that they point to the same location in <see cref="T:System.Buffers.ReadOnlySequence`1" />
+            </summary>
+        </member>
+        <member name="M:System.SequencePosition.Equals(System.Object)">
+            <summary>
+            Indicates whether the current <see cref="T:System.SequencePosition"/> is equal to another <see cref="T:System.Object"/>.
+            <see cref="T:System.SequencePosition"/> equality does not guarantee that they point to the same location in <see cref="T:System.Buffers.ReadOnlySequence`1" />
+            </summary>
+        </member>
+        <member name="M:System.SequencePosition.GetHashCode">
+            <inheritdoc />
+        </member>
+        <member name="T:System.Span`1">
+            <summary>
+            Span represents a contiguous region of arbitrary memory. Unlike arrays, it can point to either managed
+            or native memory, or to memory allocated on the stack. It is type- and memory-safe.
+            </summary>
+            <summary>
+            Span represents a contiguous region of arbitrary memory. Unlike arrays, it can point to either managed
+            or native memory, or to memory allocated on the stack. It is type- and memory-safe.
+            </summary>
+        </member>
+        <member name="P:System.Span`1.Length">
+            <summary>
+            The number of items in the span.
+            </summary>
+        </member>
+        <member name="P:System.Span`1.IsEmpty">
+            <summary>
+            Returns true if Length is 0.
+            </summary>
+        </member>
+        <member name="M:System.Span`1.op_Inequality(System.Span{`0},System.Span{`0})">
+            <summary>
+            Returns false if left and right point at the same memory and have the same length.  Note that
+            this does *not* check to see if the *contents* are equal.
+            </summary>
+        </member>
+        <member name="M:System.Span`1.Equals(System.Object)">
+            <summary>
+            This method is not supported as spans cannot be boxed. To compare two spans, use operator==.
+            <exception cref="T:System.NotSupportedException">
+            Always thrown by this method.
+            </exception>
+            </summary>
+        </member>
+        <member name="M:System.Span`1.GetHashCode">
+            <summary>
+            This method is not supported as spans cannot be boxed.
+            <exception cref="T:System.NotSupportedException">
+            Always thrown by this method.
+            </exception>
+            </summary>
+        </member>
+        <member name="M:System.Span`1.op_Implicit(`0[])~System.Span{`0}">
+            <summary>
+            Defines an implicit conversion of an array to a <see cref="T:System.Span`1"/>
+            </summary>
+        </member>
+        <member name="M:System.Span`1.op_Implicit(System.ArraySegment{`0})~System.Span{`0}">
+            <summary>
+            Defines an implicit conversion of a <see cref="T:System.ArraySegment`1"/> to a <see cref="T:System.Span`1"/>
+            </summary>
+        </member>
+        <member name="P:System.Span`1.Empty">
+            <summary>
+            Returns an empty <see cref="T:System.Span`1"/>
+            </summary>
+        </member>
+        <member name="M:System.Span`1.GetEnumerator">
+            <summary>Gets an enumerator for this span.</summary>
+        </member>
+        <member name="T:System.Span`1.Enumerator">
+            <summary>Enumerates the elements of a <see cref="T:System.Span`1"/>.</summary>
+        </member>
+        <member name="F:System.Span`1.Enumerator._span">
+            <summary>The span being enumerated.</summary>
+        </member>
+        <member name="F:System.Span`1.Enumerator._index">
+            <summary>The next index to yield.</summary>
+        </member>
+        <member name="M:System.Span`1.Enumerator.#ctor(System.Span{`0})">
+            <summary>Initialize the enumerator.</summary>
+            <param name="span">The span to enumerate.</param>
+        </member>
+        <member name="M:System.Span`1.Enumerator.MoveNext">
+            <summary>Advances the enumerator to the next element of the span.</summary>
+        </member>
+        <member name="P:System.Span`1.Enumerator.Current">
+            <summary>Gets the element at the current position of the enumerator.</summary>
+        </member>
+        <member name="M:System.Span`1.#ctor(`0[])">
+            <summary>
+            Creates a new span over the entirety of the target array.
+            </summary>
+            <param name="array">The target array.</param>
+            <remarks>Returns default when <paramref name="array"/> is null.</remarks>
+            <exception cref="T:System.ArrayTypeMismatchException">Thrown when <paramref name="array"/> is covariant and array's type is not exactly T[].</exception>
+        </member>
+        <member name="M:System.Span`1.#ctor(`0[],System.Int32,System.Int32)">
+            <summary>
+            Creates a new span over the portion of the target array beginning
+            at 'start' index and ending at 'end' index (exclusive).
+            </summary>
+            <param name="array">The target array.</param>
+            <param name="start">The index at which to begin the span.</param>
+            <param name="length">The number of items in the span.</param>
+            <remarks>Returns default when <paramref name="array"/> is null.</remarks>
+            <exception cref="T:System.ArrayTypeMismatchException">Thrown when <paramref name="array"/> is covariant and array's type is not exactly T[].</exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+            Thrown when the specified <paramref name="start"/> or end index is not in the range (&lt;0 or &gt;=Length).
+            </exception>
+        </member>
+        <member name="M:System.Span`1.#ctor(System.Void*,System.Int32)">
+            <summary>
+            Creates a new span over the target unmanaged buffer.  Clearly this
+            is quite dangerous, because we are creating arbitrarily typed T's
+            out of a void*-typed block of memory.  And the length is not checked.
+            But if this creation is correct, then all subsequent uses are correct.
+            </summary>
+            <param name="pointer">An unmanaged pointer to memory.</param>
+            <param name="length">The number of <typeparamref name="T"/> elements the memory contains.</param>
+            <exception cref="T:System.ArgumentException">
+            Thrown when <typeparamref name="T"/> is reference type or contains pointers and hence cannot be stored in unmanaged memory.
+            </exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+            Thrown when the specified <paramref name="length"/> is negative.
+            </exception>
+        </member>
+        <member name="P:System.Span`1.Item(System.Int32)">
+            <summary>
+            Returns a reference to specified element of the Span.
+            </summary>
+            <param name="index"></param>
+            <returns></returns>
+            <exception cref="T:System.IndexOutOfRangeException">
+            Thrown when index less than 0 or index greater than or equal to Length
+            </exception>
+        </member>
+        <member name="M:System.Span`1.GetPinnableReference">
+            <summary>
+            Returns a reference to the 0th element of the Span. If the Span is empty, returns null reference.
+            It can be used for pinning and is required to support the use of span within a fixed statement.
+            </summary>
+        </member>
+        <member name="M:System.Span`1.Clear">
+            <summary>
+            Clears the contents of this span.
+            </summary>
+        </member>
+        <member name="M:System.Span`1.Fill(`0)">
+            <summary>
+            Fills the contents of this span with the given value.
+            </summary>
+        </member>
+        <member name="M:System.Span`1.CopyTo(System.Span{`0})">
+             <summary>
+             Copies the contents of this span into destination span. If the source
+             and destinations overlap, this method behaves as if the original values in
+             a temporary location before the destination is overwritten.
+            
+             <param name="destination">The span to copy items into.</param>
+             <exception cref="T:System.ArgumentException">
+             Thrown when the destination Span is shorter than the source Span.
+             </exception>
+             </summary>
+        </member>
+        <member name="M:System.Span`1.TryCopyTo(System.Span{`0})">
+             <summary>
+             Copies the contents of this span into destination span. If the source
+             and destinations overlap, this method behaves as if the original values in
+             a temporary location before the destination is overwritten.
+            
+             <returns>If the destination span is shorter than the source span, this method
+             return false and no data is written to the destination.</returns>
+             </summary>
+             <param name="destination">The span to copy items into.</param>
+        </member>
+        <member name="M:System.Span`1.op_Equality(System.Span{`0},System.Span{`0})">
+            <summary>
+            Returns true if left and right point at the same memory and have the same length.  Note that
+            this does *not* check to see if the *contents* are equal.
+            </summary>
+        </member>
+        <member name="M:System.Span`1.op_Implicit(System.Span{`0})~System.ReadOnlySpan{`0}">
+            <summary>
+            Defines an implicit conversion of a <see cref="T:System.Span`1"/> to a <see cref="T:System.ReadOnlySpan`1"/>
+            </summary>
+        </member>
+        <member name="M:System.Span`1.ToString">
+            <summary>
+            For <see cref="T:System.Span`1"/>, returns a new instance of string that represents the characters pointed to by the span.
+            Otherwise, returns a <see cref="T:System.String"/> with the name of the type and the number of elements.
+            </summary>
+        </member>
+        <member name="M:System.Span`1.Slice(System.Int32)">
+            <summary>
+            Forms a slice out of the given span, beginning at 'start'.
+            </summary>
+            <param name="start">The index at which to begin this slice.</param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+            Thrown when the specified <paramref name="start"/> index is not in range (&lt;0 or &gt;=Length).
+            </exception>
+        </member>
+        <member name="M:System.Span`1.Slice(System.Int32,System.Int32)">
+            <summary>
+            Forms a slice out of the given span, beginning at 'start', of given length
+            </summary>
+            <param name="start">The index at which to begin this slice.</param>
+            <param name="length">The desired length for the slice (exclusive).</param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+            Thrown when the specified <paramref name="start"/> or end index is not in range (&lt;0 or &gt;=Length).
+            </exception>
+        </member>
+        <member name="M:System.Span`1.ToArray">
+            <summary>
+            Copies the contents of this span into a new array.  This heap
+            allocates, so should generally be avoided, however it is sometimes
+            necessary to bridge the gap with APIs written in terms of arrays.
+            </summary>
+        </member>
+        <member name="M:System.Span`1.DangerousGetPinnableReference">
+            <summary>
+            This method is obsolete, use System.Runtime.InteropServices.MemoryMarshal.GetReference instead.
+            Returns a reference to the 0th element of the Span. If the Span is empty, returns a reference to the location where the 0th element
+            would have been stored. Such a reference can be used for pinning but must never be dereferenced.
+            </summary>
+        </member>
+        <member name="M:System.SpanHelpers.CopyTo``1(``0@,System.Int32,``0@,System.Int32)">
+             <summary>
+             Implements the copy functionality used by Span and ReadOnlySpan.
+            
+             NOTE: Fast span implements TryCopyTo in corelib and therefore this implementation
+                   is only used by portable span. The code must live in code that only compiles
+                   for portable span which means either each individual span implementation
+                   of this shared code file. Other shared SpanHelper.X.cs files are compiled
+                   for both portable and fast span implementations.
+             </summary>
+        </member>
+        <member name="M:System.SpanHelpers.Add``1(System.IntPtr,System.Int32)">
+             <summary>
+             Computes "start + index * sizeof(T)", using the unsigned IntPtr-sized multiplication for 32 and 64 bits.
+            
+             Assumptions:
+                 Start and index are non-negative, and already pre-validated to be within the valid range of their containing Span.
+            
+                 If the byte length (Span.Length * sizeof(T)) does an unsigned overflow (i.e. the buffer wraps or is too big to fit within the address space),
+                 the behavior is undefined.
+            
+             </summary>
+        </member>
+        <member name="M:System.SpanHelpers.IsReferenceOrContainsReferences``1">
+            <summary>
+            Determine if a type is eligible for storage in unmanaged memory.
+            Portable equivalent of RuntimeHelpers.IsReferenceOrContainsReferences{T}()
+            </summary>
+        </member>
+        <member name="P:System.SR.NotSupported_CannotCallEqualsOnSpan">
+            <summary>Equals() on Span and ReadOnlySpan is not supported. Use operator== instead.</summary>
+        </member>
+        <member name="P:System.SR.NotSupported_CannotCallGetHashCodeOnSpan">
+            <summary>GetHashCode() on Span and ReadOnlySpan is not supported.</summary>
+        </member>
+        <member name="P:System.SR.Argument_InvalidTypeWithPointersNotSupported">
+            <summary>Cannot use type '{0}'. Only value types without pointers or references are supported.</summary>
+        </member>
+        <member name="P:System.SR.Argument_DestinationTooShort">
+            <summary>Destination is too short.</summary>
+        </member>
+        <member name="P:System.SR.MemoryDisposed">
+            <summary>Memory&lt;T&gt; has been disposed.</summary>
+        </member>
+        <member name="P:System.SR.OutstandingReferences">
+            <summary>Release all references before disposing this instance.</summary>
+        </member>
+        <member name="P:System.SR.Argument_BadFormatSpecifier">
+            <summary>Format specifier was invalid.</summary>
+        </member>
+        <member name="P:System.SR.Argument_GWithPrecisionNotSupported">
+            <summary>The 'G' format combined with a precision is not supported.</summary>
+        </member>
+        <member name="P:System.SR.Argument_CannotParsePrecision">
+            <summary>Characters following the format symbol must be a number of {0} or less.</summary>
+        </member>
+        <member name="P:System.SR.Argument_PrecisionTooLarge">
+            <summary>Precision cannot be larger than {0}.</summary>
+        </member>
+        <member name="P:System.SR.Argument_OverlapAlignmentMismatch">
+            <summary>Overlapping spans have mismatching alignment.</summary>
+        </member>
+        <member name="P:System.SR.EndPositionNotReached">
+            <summary>End position was not reached during enumeration.</summary>
+        </member>
+        <member name="P:System.SR.UnexpectedSegmentType">
+            <summary>Unexpected segment type.</summary>
+        </member>
+    </members>
+</doc>

--- a/src/System.Net.WebSockets.WebSocketProtocol/src/System.Net.WebSockets.WebSocketProtocol.xml
+++ b/src/System.Net.WebSockets.WebSocketProtocol/src/System.Net.WebSockets.WebSocketProtocol.xml
@@ -1,0 +1,347 @@
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>System.Net.WebSockets.WebSocketProtocol</name>
+    </assembly>
+    <members>
+        <member name="T:System.Net.WebSockets.ManagedWebSocket">
+            <summary>A managed implementation of a web socket that sends and receives data via a <see cref="T:System.IO.Stream"/>.</summary>
+            <remarks>
+            Thread-safety:
+            - It's acceptable to call ReceiveAsync and SendAsync in parallel.  One of each may run concurrently.
+            - It's acceptable to have a pending ReceiveAsync while CloseOutputAsync or CloseAsync is called.
+            - Attempting to invoke any other operations in parallel may corrupt the instance.  Attempting to invoke
+              a send operation while another is in progress or a receive operation while another is in progress will
+              result in an exception.
+            </remarks>
+        </member>
+        <member name="M:System.Net.WebSockets.ManagedWebSocket.CreateFromConnectedStream(System.IO.Stream,System.Boolean,System.String,System.TimeSpan)">
+            <summary>Creates a <see cref="T:System.Net.WebSockets.ManagedWebSocket"/> from a <see cref="T:System.IO.Stream"/> connected to a websocket endpoint.</summary>
+            <param name="stream">The connected Stream.</param>
+            <param name="isServer">true if this is the server-side of the connection; false if this is the client-side of the connection.</param>
+            <param name="subprotocol">The agreed upon subprotocol for the connection.</param>
+            <param name="keepAliveInterval">The interval to use for keep-alive pings.</param>
+            <returns>The created <see cref="T:System.Net.WebSockets.ManagedWebSocket"/> instance.</returns>
+        </member>
+        <member name="F:System.Net.WebSockets.ManagedWebSocket.s_random">
+            <summary>Thread-safe random number generator used to generate masks for each send.</summary>
+        </member>
+        <member name="F:System.Net.WebSockets.ManagedWebSocket.s_textEncoding">
+            <summary>Encoding for the payload of text messages: UTF8 encoding that throws if invalid bytes are discovered, per the RFC.</summary>
+        </member>
+        <member name="F:System.Net.WebSockets.ManagedWebSocket.s_validSendStates">
+            <summary>Valid states to be in when calling SendAsync.</summary>
+        </member>
+        <member name="F:System.Net.WebSockets.ManagedWebSocket.s_validReceiveStates">
+            <summary>Valid states to be in when calling ReceiveAsync.</summary>
+        </member>
+        <member name="F:System.Net.WebSockets.ManagedWebSocket.s_validCloseOutputStates">
+            <summary>Valid states to be in when calling CloseOutputAsync.</summary>
+        </member>
+        <member name="F:System.Net.WebSockets.ManagedWebSocket.s_validCloseStates">
+            <summary>Valid states to be in when calling CloseAsync.</summary>
+        </member>
+        <member name="F:System.Net.WebSockets.ManagedWebSocket.s_cachedCloseTask">
+            <summary>Successfully completed task representing a close message.</summary>
+        </member>
+        <member name="F:System.Net.WebSockets.ManagedWebSocket.MaxMessageHeaderLength">
+            <summary>The maximum size in bytes of a message frame header that includes mask bytes.</summary>
+        </member>
+        <member name="F:System.Net.WebSockets.ManagedWebSocket.MaxControlPayloadLength">
+            <summary>The maximum size of a control message payload.</summary>
+        </member>
+        <member name="F:System.Net.WebSockets.ManagedWebSocket.MaskLength">
+            <summary>Length of the mask XOR'd with the payload data.</summary>
+        </member>
+        <member name="F:System.Net.WebSockets.ManagedWebSocket._stream">
+            <summary>The stream used to communicate with the remote server.</summary>
+        </member>
+        <member name="F:System.Net.WebSockets.ManagedWebSocket._isServer">
+            <summary>
+            true if this is the server-side of the connection; false if it's client.
+            This impacts masking behavior: clients always mask payloads they send and
+            expect to always receive unmasked payloads, whereas servers always send
+            unmasked payloads and expect to always receive masked payloads.
+            </summary>
+        </member>
+        <member name="F:System.Net.WebSockets.ManagedWebSocket._subprotocol">
+            <summary>The agreed upon subprotocol with the server.</summary>
+        </member>
+        <member name="F:System.Net.WebSockets.ManagedWebSocket._keepAliveTimer">
+            <summary>Timer used to send periodic pings to the server, at the interval specified</summary>
+        </member>
+        <member name="F:System.Net.WebSockets.ManagedWebSocket._abortSource">
+            <summary>CancellationTokenSource used to abort all current and future operations when anything is canceled or any error occurs.</summary>
+        </member>
+        <member name="F:System.Net.WebSockets.ManagedWebSocket._receiveBuffer">
+            <summary>Buffer used for reading data from the network.</summary>
+        </member>
+        <member name="F:System.Net.WebSockets.ManagedWebSocket._utf8TextState">
+            <summary>
+            Tracks the state of the validity of the UTF8 encoding of text payloads.  Text may be split across fragments.
+            </summary>
+        </member>
+        <member name="F:System.Net.WebSockets.ManagedWebSocket._sendFrameAsyncLock">
+            <summary>
+            Semaphore used to ensure that calls to SendFrameAsync don't run concurrently.
+            </summary>
+        </member>
+        <member name="F:System.Net.WebSockets.ManagedWebSocket._state">
+            <summary>The current state of the web socket in the protocol.</summary>
+        </member>
+        <member name="F:System.Net.WebSockets.ManagedWebSocket._disposed">
+            <summary>true if Dispose has been called; otherwise, false.</summary>
+        </member>
+        <member name="F:System.Net.WebSockets.ManagedWebSocket._sentCloseFrame">
+            <summary>Whether we've ever sent a close frame.</summary>
+        </member>
+        <member name="F:System.Net.WebSockets.ManagedWebSocket._receivedCloseFrame">
+            <summary>Whether we've ever received a close frame.</summary>
+        </member>
+        <member name="F:System.Net.WebSockets.ManagedWebSocket._closeStatus">
+            <summary>The reason for the close, as sent by the server, or null if not yet closed.</summary>
+        </member>
+        <member name="F:System.Net.WebSockets.ManagedWebSocket._closeStatusDescription">
+            <summary>A description of the close reason as sent by the server, or null if not yet closed.</summary>
+        </member>
+        <member name="F:System.Net.WebSockets.ManagedWebSocket._lastReceiveHeader">
+            <summary>
+            The last header received in a ReceiveAsync.  If ReceiveAsync got a header but then
+            returned fewer bytes than was indicated in the header, subsequent ReceiveAsync calls
+            will use the data from the header to construct the subsequent receive results, and
+            the payload length in this header will be decremented to indicate the number of bytes
+            remaining to be received for that header.  As a result, between fragments, the payload
+            length in this header should be 0.
+            </summary>
+        </member>
+        <member name="F:System.Net.WebSockets.ManagedWebSocket._receiveBufferOffset">
+            <summary>The offset of the next available byte in the _receiveBuffer.</summary>
+        </member>
+        <member name="F:System.Net.WebSockets.ManagedWebSocket._receiveBufferCount">
+            <summary>The number of bytes available in the _receiveBuffer.</summary>
+        </member>
+        <member name="F:System.Net.WebSockets.ManagedWebSocket._receivedMaskOffsetOffset">
+            <summary>
+            When dealing with partially read fragments of binary/text messages, a mask previously received may still
+            apply, and the first new byte received may not correspond to the 0th position in the mask.  This value is
+            the next offset into the mask that should be applied.
+            </summary>
+        </member>
+        <member name="F:System.Net.WebSockets.ManagedWebSocket._sendBuffer">
+            <summary>
+            Temporary send buffer.  This should be released back to the ArrayPool once it's
+            no longer needed for the current send operation.  It is stored as an instance
+            field to minimize needing to pass it around and to avoid it becoming a field on
+            various async state machine objects.
+            </summary>
+        </member>
+        <member name="F:System.Net.WebSockets.ManagedWebSocket._lastSendWasFragment">
+            <summary>
+            Whether the last SendAsync had endOfMessage==false. We need to track this so that we
+            can send the subsequent message with a continuation opcode if the last message was a fragment.
+            </summary>
+        </member>
+        <member name="F:System.Net.WebSockets.ManagedWebSocket._lastReceiveAsync">
+            <summary>
+            The task returned from the last ReceiveAsync(ArraySegment, ...) operation to not complete synchronously.
+            If this is not null and not completed when a subsequent ReceiveAsync is issued, an exception occurs.
+            </summary>
+        </member>
+        <member name="P:System.Net.WebSockets.ManagedWebSocket.StateUpdateLock">
+            <summary>Lock used to protect update and check-and-update operations on _state.</summary>
+        </member>
+        <member name="P:System.Net.WebSockets.ManagedWebSocket.ReceiveAsyncLock">
+            <summary>
+            We need to coordinate between receives and close operations happening concurrently, as a ReceiveAsync may
+            be pending while a Close{Output}Async is issued, which itself needs to loop until a close frame is received.
+            As such, we need thread-safety in the management of <see cref="F:System.Net.WebSockets.ManagedWebSocket._lastReceiveAsync"/>.
+            </summary>
+        </member>
+        <member name="M:System.Net.WebSockets.ManagedWebSocket.#ctor(System.IO.Stream,System.Boolean,System.String,System.TimeSpan)">
+            <summary>Initializes the websocket.</summary>
+            <param name="stream">The connected Stream.</param>
+            <param name="isServer">true if this is the server-side of the connection; false if this is the client-side of the connection.</param>
+            <param name="subprotocol">The agreed upon subprotocol for the connection.</param>
+            <param name="keepAliveInterval">The interval to use for keep-alive pings.</param>
+        </member>
+        <member name="M:System.Net.WebSockets.ManagedWebSocket.SendFrameAsync(System.Net.WebSockets.ManagedWebSocket.MessageOpcode,System.Boolean,System.ReadOnlyMemory{System.Byte},System.Threading.CancellationToken)">
+            <summary>Sends a websocket frame to the network.</summary>
+            <param name="opcode">The opcode for the message.</param>
+            <param name="endOfMessage">The value of the FIN bit for the message.</param>
+            <param name="payloadBuffer">The buffer containing the payload data fro the message.</param>
+            <param name="cancellationToken">The CancellationToken to use to cancel the websocket.</param>
+        </member>
+        <member name="M:System.Net.WebSockets.ManagedWebSocket.SendFrameLockAcquiredNonCancelableAsync(System.Net.WebSockets.ManagedWebSocket.MessageOpcode,System.Boolean,System.ReadOnlyMemory{System.Byte})">
+            <summary>Sends a websocket frame to the network. The caller must hold the sending lock.</summary>
+            <param name="opcode">The opcode for the message.</param>
+            <param name="endOfMessage">The value of the FIN bit for the message.</param>
+            <param name="payloadBuffer">The buffer containing the payload data fro the message.</param>
+        </member>
+        <member name="M:System.Net.WebSockets.ManagedWebSocket.WriteFrameToSendBuffer(System.Net.WebSockets.ManagedWebSocket.MessageOpcode,System.Boolean,System.ReadOnlySpan{System.Byte})">
+            <summary>Writes a frame into the send buffer, which can then be sent over the network.</summary>
+        </member>
+        <member name="M:System.Net.WebSockets.ManagedWebSocket.WriteRandomMask(System.Byte[],System.Int32)">
+            <summary>Writes a 4-byte random mask to the specified buffer at the specified offset.</summary>
+            <param name="buffer">The buffer to which to write the mask.</param>
+            <param name="offset">The offset into the buffer at which to write the mask.</param>
+        </member>
+        <member name="M:System.Net.WebSockets.ManagedWebSocket.ReceiveAsyncPrivate``2(System.Memory{System.Byte},System.Threading.CancellationToken,``0)">
+            <summary>
+            Receive the next text, binary, continuation, or close message, returning information about it and
+            writing its payload into the supplied buffer.  Other control messages may be consumed and processed
+            as part of this operation, but data about them will not be returned.
+            </summary>
+            <param name="payloadBuffer">The buffer into which payload data should be written.</param>
+            <param name="cancellationToken">The CancellationToken used to cancel the websocket.</param>
+            <param name="resultGetter">Used to get the result.  Allows the same method to be used with both WebSocketReceiveResult and ValueWebSocketReceiveResult.</param>
+            <returns>Information about the received message.</returns>
+        </member>
+        <member name="M:System.Net.WebSockets.ManagedWebSocket.HandleReceivedCloseAsync(System.Net.WebSockets.ManagedWebSocket.MessageHeader,System.Threading.CancellationToken)">
+            <summary>Processes a received close message.</summary>
+            <param name="header">The message header.</param>
+            <param name="cancellationToken">The CancellationToken used to cancel the websocket operation.</param>
+            <returns>The received result message.</returns>
+        </member>
+        <member name="M:System.Net.WebSockets.ManagedWebSocket.WaitForServerToCloseConnectionAsync(System.Threading.CancellationToken)">
+            <summary>Issues a read on the stream to wait for EOF.</summary>
+        </member>
+        <member name="M:System.Net.WebSockets.ManagedWebSocket.HandleReceivedPingPongAsync(System.Net.WebSockets.ManagedWebSocket.MessageHeader,System.Threading.CancellationToken)">
+            <summary>Processes a received ping or pong message.</summary>
+            <param name="header">The message header.</param>
+            <param name="cancellationToken">The CancellationToken used to cancel the websocket operation.</param>
+        </member>
+        <member name="M:System.Net.WebSockets.ManagedWebSocket.IsValidCloseStatus(System.Net.WebSockets.WebSocketCloseStatus)">
+            <summary>Check whether a close status is valid according to the RFC.</summary>
+            <param name="closeStatus">The status to validate.</param>
+            <returns>true if the status if valid; otherwise, false.</returns>
+        </member>
+        <member name="M:System.Net.WebSockets.ManagedWebSocket.CloseWithReceiveErrorAndThrowAsync(System.Net.WebSockets.WebSocketCloseStatus,System.Net.WebSockets.WebSocketError,System.String,System.Exception)">
+            <summary>Send a close message to the server and throw an exception, in response to getting bad data from the server.</summary>
+            <param name="closeStatus">The close status code to use.</param>
+            <param name="error">The error reason.</param>
+            <param name="errorMessage">An optional error message to include in the thrown exception.</param>
+            <param name="innerException">An optional inner exception to include in the thrown exception.</param>
+        </member>
+        <member name="M:System.Net.WebSockets.ManagedWebSocket.TryParseMessageHeaderFromReceiveBuffer(System.Net.WebSockets.ManagedWebSocket.MessageHeader@)">
+            <summary>Parses a message header from the buffer.  This assumes the header is in the buffer.</summary>
+            <param name="resultHeader">The read header.</param>
+            <returns>null if a valid header was read; non-null containing the string error message to use if the header was invalid.</returns>
+        </member>
+        <member name="M:System.Net.WebSockets.ManagedWebSocket.CloseAsyncPrivate(System.Net.WebSockets.WebSocketCloseStatus,System.String,System.Threading.CancellationToken)">
+            <summary>Send a close message, then receive until we get a close response message.</summary>
+            <param name="closeStatus">The close status to send.</param>
+            <param name="statusDescription">The close status description to send.</param>
+            <param name="cancellationToken">The CancellationToken to use to cancel the websocket.</param>
+        </member>
+        <member name="M:System.Net.WebSockets.ManagedWebSocket.SendCloseFrameAsync(System.Net.WebSockets.WebSocketCloseStatus,System.String,System.Threading.CancellationToken)">
+            <summary>Sends a close message to the server.</summary>
+            <param name="closeStatus">The close status to send.</param>
+            <param name="closeStatusDescription">The close status description to send.</param>
+            <param name="cancellationToken">The CancellationToken to use to cancel the websocket.</param>
+        </member>
+        <member name="M:System.Net.WebSockets.ManagedWebSocket.AllocateSendBuffer(System.Int32)">
+            <summary>Gets a send buffer from the pool.</summary>
+        </member>
+        <member name="M:System.Net.WebSockets.ManagedWebSocket.ReleaseSendBuffer">
+            <summary>Releases the send buffer to the pool.</summary>
+        </member>
+        <member name="M:System.Net.WebSockets.ManagedWebSocket.ApplyMask(System.Span{System.Byte},System.Byte[],System.Int32,System.Int32)">
+            <summary>Applies a mask to a portion of a byte array.</summary>
+            <param name="toMask">The buffer to which the mask should be applied.</param>
+            <param name="mask">The array containing the mask to apply.</param>
+            <param name="maskOffset">The offset into <paramref name="mask"/> of the mask to apply of length <see cref="F:System.Net.WebSockets.ManagedWebSocket.MaskLength"/>.</param>
+            <param name="maskOffsetIndex">The next position offset from <paramref name="maskOffset"/> of which by to apply next from the mask.</param>
+            <returns>The updated maskOffsetOffset value.</returns>
+        </member>
+        <member name="M:System.Net.WebSockets.ManagedWebSocket.ApplyMask(System.Span{System.Byte},System.Int32,System.Int32)">
+            <summary>Applies a mask to a portion of a byte array.</summary>
+            <param name="toMask">The buffer to which the mask should be applied.</param>
+            <param name="mask">The four-byte mask, stored as an Int32.</param>
+            <param name="maskIndex">The index into the mask.</param>
+            <returns>The next index into the mask to be used for future applications of the mask.</returns>
+        </member>
+        <member name="M:System.Net.WebSockets.ManagedWebSocket.ThrowIfOperationInProgress(System.Boolean,System.String)">
+            <summary>Aborts the websocket and throws an exception if an existing operation is in progress.</summary>
+        </member>
+        <member name="M:System.Net.WebSockets.ManagedWebSocket.CreateOperationCanceledException(System.Exception,System.Threading.CancellationToken)">
+            <summary>Creates an OperationCanceledException instance, using a default message and the specified inner exception and token.</summary>
+        </member>
+        <member name="T:System.Net.WebSockets.ManagedWebSocket.IWebSocketReceiveResultGetter`1">
+            <summary>
+            Interface used by <see cref="M:System.Net.WebSockets.ManagedWebSocket.ReceiveAsyncPrivate``2(System.Memory{System.Byte},System.Threading.CancellationToken,``0)"/> to enable it to return
+            different result types in an efficient manner.
+            </summary>
+            <typeparam name="TResult">The type of the result</typeparam>
+        </member>
+        <member name="T:System.Net.WebSockets.ManagedWebSocket.WebSocketReceiveResultGetter">
+            <summary><see cref="T:System.Net.WebSockets.ManagedWebSocket.IWebSocketReceiveResultGetter`1"/> implementation for <see cref="T:System.Net.WebSockets.WebSocketReceiveResult"/>.</summary>
+        </member>
+        <member name="M:System.Numerics.BitOperations.RotateRight(System.UInt32,System.Int32)">
+            <summary>
+            Rotates the specified value right by the specified number of bits.
+            Similar in behavior to the x86 instruction ROR.
+            </summary>
+            <param name="value">The value to rotate.</param>
+            <param name="offset">The number of bits to rotate by.
+            Any value outside the range [0..31] is treated as congruent mod 32.</param>
+            <returns>The rotated value.</returns>
+        </member>
+        <member name="P:System.SR.net_WebSockets_InvalidEmptySubProtocol">
+            <summary>Empty string is not a valid subprotocol value. Please use \"null\" to specify no value.</summary>
+        </member>
+        <member name="P:System.SR.net_WebSockets_InvalidState">
+            <summary>The WebSocket is in an invalid state ('{0}') for this operation. Valid states are: '{1}'</summary>
+        </member>
+        <member name="P:System.SR.net_WebSockets_InvalidCharInProtocolString">
+            <summary>The WebSocket protocol '{0}' is invalid because it contains the invalid character '{1}'.</summary>
+        </member>
+        <member name="P:System.SR.net_WebSockets_ReasonNotNull">
+            <summary>The close status description '{0}' is invalid. When using close status code '{1}' the description must be null.</summary>
+        </member>
+        <member name="P:System.SR.net_WebSockets_InvalidCloseStatusCode">
+            <summary>The close status code '{0}' is reserved for system use only and cannot be specified when calling this method.</summary>
+        </member>
+        <member name="P:System.SR.net_WebSockets_InvalidCloseStatusDescription">
+            <summary>The close status description '{0}' is too long. The UTF8-representation of the status description must not be longer than {1} bytes.</summary>
+        </member>
+        <member name="P:System.SR.net_WebSockets_UnsupportedPlatform">
+            <summary>The WebSocket protocol is not supported on this platform.</summary>
+        </member>
+        <member name="P:System.SR.net_WebSockets_Argument_InvalidMessageType">
+            <summary>The message type '{0}' is not allowed for the '{1}' operation. Valid message types are: '{2}, {3}'. To close the WebSocket, use the '{4}' operation instead.</summary>
+        </member>
+        <member name="P:System.SR.net_Websockets_AlreadyOneOutstandingOperation">
+            <summary>There is already one outstanding '{0}' call for this WebSocket instance. ReceiveAsync and SendAsync can be called simultaneously, but at most one outstanding operation for each of them is allowed at the same time.</summary>
+        </member>
+        <member name="P:System.SR.NotReadableStream">
+            <summary>The base stream is not readable.</summary>
+        </member>
+        <member name="P:System.SR.NotWriteableStream">
+            <summary>The base stream is not writeable.</summary>
+        </member>
+        <member name="P:System.SR.net_WebSockets_ArgumentOutOfRange_TooSmall">
+            <summary>The argument must be a value greater than {0}.</summary>
+        </member>
+        <member name="P:System.SR.net_Websockets_ReservedBitsSet">
+            <summary>The WebSocket received a frame with one or more reserved bits set.</summary>
+        </member>
+        <member name="P:System.SR.net_Websockets_ClientReceivedMaskedFrame">
+            <summary>The WebSocket server sent a masked frame.</summary>
+        </member>
+        <member name="P:System.SR.net_Websockets_ContinuationFromFinalFrame">
+            <summary>The WebSocket received a continuation frame from a previous final message.</summary>
+        </member>
+        <member name="P:System.SR.net_Websockets_NonContinuationAfterNonFinalFrame">
+            <summary>The WebSocket expected a continuation frame after having received a previous non-final frame.</summary>
+        </member>
+        <member name="P:System.SR.net_Websockets_InvalidControlMessage">
+            <summary>The WebSocket received an invalid control message.</summary>
+        </member>
+        <member name="P:System.SR.net_Websockets_UnknownOpcode">
+            <summary>The WebSocket received a frame with an unknown opcode: '0x{0}'.</summary>
+        </member>
+        <member name="P:System.SR.net_Websockets_InvalidPayloadLength">
+            <summary>The WebSocket received a frame with an invalid payload length.</summary>
+        </member>
+    </members>
+</doc>

--- a/src/System.Numerics.Vectors/src/System.Numerics.Vectors.xml
+++ b/src/System.Numerics.Vectors/src/System.Numerics.Vectors.xml
@@ -1,0 +1,3451 @@
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>System.Numerics.Vectors</name>
+    </assembly>
+    <members>
+        <member name="T:System.Numerics.Matrix3x2">
+            <summary>
+            A structure encapsulating a 3x2 matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix3x2.M11">
+            <summary>
+            The first element of the first row
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix3x2.M12">
+            <summary>
+            The second element of the first row
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix3x2.M21">
+            <summary>
+            The first element of the second row
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix3x2.M22">
+            <summary>
+            The second element of the second row
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix3x2.M31">
+            <summary>
+            The first element of the third row
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix3x2.M32">
+            <summary>
+            The second element of the third row
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Matrix3x2.Identity">
+            <summary>
+            Returns the multiplicative identity matrix.
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Matrix3x2.IsIdentity">
+            <summary>
+            Returns whether the matrix is the identity matrix.
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Matrix3x2.Translation">
+            <summary>
+            Gets or sets the translation component of this matrix.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.#ctor(System.Single,System.Single,System.Single,System.Single,System.Single,System.Single)">
+            <summary>
+            Constructs a Matrix3x2 from the given components.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.CreateTranslation(System.Numerics.Vector2)">
+            <summary>
+            Creates a translation matrix from the given vector.
+            </summary>
+            <param name="position">The translation position.</param>
+            <returns>A translation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.CreateTranslation(System.Single,System.Single)">
+            <summary>
+            Creates a translation matrix from the given X and Y components.
+            </summary>
+            <param name="xPosition">The X position.</param>
+            <param name="yPosition">The Y position.</param>
+            <returns>A translation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.CreateScale(System.Single,System.Single)">
+            <summary>
+            Creates a scale matrix from the given X and Y components.
+            </summary>
+            <param name="xScale">Value to scale by on the X-axis.</param>
+            <param name="yScale">Value to scale by on the Y-axis.</param>
+            <returns>A scaling matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.CreateScale(System.Single,System.Single,System.Numerics.Vector2)">
+            <summary>
+            Creates a scale matrix that is offset by a given center point.
+            </summary>
+            <param name="xScale">Value to scale by on the X-axis.</param>
+            <param name="yScale">Value to scale by on the Y-axis.</param>
+            <param name="centerPoint">The center point.</param>
+            <returns>A scaling matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.CreateScale(System.Numerics.Vector2)">
+            <summary>
+            Creates a scale matrix from the given vector scale.
+            </summary>
+            <param name="scales">The scale to use.</param>
+            <returns>A scaling matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.CreateScale(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Creates a scale matrix from the given vector scale with an offset from the given center point.
+            </summary>
+            <param name="scales">The scale to use.</param>
+            <param name="centerPoint">The center offset.</param>
+            <returns>A scaling matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.CreateScale(System.Single)">
+            <summary>
+            Creates a scale matrix that scales uniformly with the given scale.
+            </summary>
+            <param name="scale">The uniform scale to use.</param>
+            <returns>A scaling matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.CreateScale(System.Single,System.Numerics.Vector2)">
+            <summary>
+            Creates a scale matrix that scales uniformly with the given scale with an offset from the given center.
+            </summary>
+            <param name="scale">The uniform scale to use.</param>
+            <param name="centerPoint">The center offset.</param>
+            <returns>A scaling matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.CreateSkew(System.Single,System.Single)">
+            <summary>
+            Creates a skew matrix from the given angles in radians.
+            </summary>
+            <param name="radiansX">The X angle, in radians.</param>
+            <param name="radiansY">The Y angle, in radians.</param>
+            <returns>A skew matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.CreateSkew(System.Single,System.Single,System.Numerics.Vector2)">
+            <summary>
+            Creates a skew matrix from the given angles in radians and a center point.
+            </summary>
+            <param name="radiansX">The X angle, in radians.</param>
+            <param name="radiansY">The Y angle, in radians.</param>
+            <param name="centerPoint">The center point.</param>
+            <returns>A skew matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.CreateRotation(System.Single)">
+            <summary>
+            Creates a rotation matrix using the given rotation in radians.
+            </summary>
+            <param name="radians">The amount of rotation, in radians.</param>
+            <returns>A rotation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.CreateRotation(System.Single,System.Numerics.Vector2)">
+            <summary>
+            Creates a rotation matrix using the given rotation in radians and a center point.
+            </summary>
+            <param name="radians">The amount of rotation, in radians.</param>
+            <param name="centerPoint">The center point.</param>
+            <returns>A rotation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.GetDeterminant">
+            <summary>
+            Calculates the determinant for this matrix. 
+            The determinant is calculated by expanding the matrix with a third column whose values are (0,0,1).
+            </summary>
+            <returns>The determinant.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.Invert(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2@)">
+            <summary>
+            Attempts to invert the given matrix. If the operation succeeds, the inverted matrix is stored in the result parameter.
+            </summary>
+            <param name="matrix">The source matrix.</param>
+            <param name="result">The output matrix.</param>
+            <returns>True if the operation succeeded, False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.Lerp(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2,System.Single)">
+            <summary>
+            Linearly interpolates from matrix1 to matrix2, based on the third parameter.
+            </summary>
+            <param name="matrix1">The first source matrix.</param>
+            <param name="matrix2">The second source matrix.</param>
+            <param name="amount">The relative weighting of matrix2.</param>
+            <returns>The interpolated matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.Negate(System.Numerics.Matrix3x2)">
+            <summary>
+            Negates the given matrix by multiplying all values by -1.
+            </summary>
+            <param name="value">The source matrix.</param>
+            <returns>The negated matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.Add(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
+            <summary>
+            Adds each matrix element in value1 with its corresponding element in value2.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>The matrix containing the summed values.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.Subtract(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
+            <summary>
+            Subtracts each matrix element in value2 from its corresponding element in value1.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>The matrix containing the resulting values.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.Multiply(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
+            <summary>
+            Multiplies two matrices together and returns the resulting matrix.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>The product matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.Multiply(System.Numerics.Matrix3x2,System.Single)">
+            <summary>
+            Scales all elements in a matrix by the given scalar factor.
+            </summary>
+            <param name="value1">The source matrix.</param>
+            <param name="value2">The scaling value to use.</param>
+            <returns>The resulting matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.op_UnaryNegation(System.Numerics.Matrix3x2)">
+            <summary>
+            Negates the given matrix by multiplying all values by -1.
+            </summary>
+            <param name="value">The source matrix.</param>
+            <returns>The negated matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.op_Addition(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
+            <summary>
+            Adds each matrix element in value1 with its corresponding element in value2.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>The matrix containing the summed values.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.op_Subtraction(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
+            <summary>
+            Subtracts each matrix element in value2 from its corresponding element in value1.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>The matrix containing the resulting values.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.op_Multiply(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
+            <summary>
+            Multiplies two matrices together and returns the resulting matrix.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>The product matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.op_Multiply(System.Numerics.Matrix3x2,System.Single)">
+            <summary>
+            Scales all elements in a matrix by the given scalar factor.
+            </summary>
+            <param name="value1">The source matrix.</param>
+            <param name="value2">The scaling value to use.</param>
+            <returns>The resulting matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.op_Equality(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
+            <summary>
+            Returns a boolean indicating whether the given matrices are equal.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>True if the matrices are equal; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.op_Inequality(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
+            <summary>
+            Returns a boolean indicating whether the given matrices are not equal.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>True if the matrices are not equal; False if they are equal.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.Equals(System.Numerics.Matrix3x2)">
+            <summary>
+            Returns a boolean indicating whether the matrix is equal to the other given matrix.
+            </summary>
+            <param name="other">The other matrix to test equality against.</param>
+            <returns>True if this matrix is equal to other; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.Equals(System.Object)">
+            <summary>
+            Returns a boolean indicating whether the given Object is equal to this matrix instance.
+            </summary>
+            <param name="obj">The Object to compare against.</param>
+            <returns>True if the Object is equal to this matrix; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.ToString">
+            <summary>
+            Returns a String representing this matrix instance.
+            </summary>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.GetHashCode">
+            <summary>
+            Returns the hash code for this instance.
+            </summary>
+            <returns>The hash code.</returns>
+        </member>
+        <member name="T:System.Numerics.Matrix4x4">
+            <summary>
+            A structure encapsulating a 4x4 matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M11">
+            <summary>
+            Value at row 1, column 1 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M12">
+            <summary>
+            Value at row 1, column 2 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M13">
+            <summary>
+            Value at row 1, column 3 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M14">
+            <summary>
+            Value at row 1, column 4 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M21">
+            <summary>
+            Value at row 2, column 1 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M22">
+            <summary>
+            Value at row 2, column 2 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M23">
+            <summary>
+            Value at row 2, column 3 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M24">
+            <summary>
+            Value at row 2, column 4 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M31">
+            <summary>
+            Value at row 3, column 1 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M32">
+            <summary>
+            Value at row 3, column 2 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M33">
+            <summary>
+            Value at row 3, column 3 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M34">
+            <summary>
+            Value at row 3, column 4 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M41">
+            <summary>
+            Value at row 4, column 1 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M42">
+            <summary>
+            Value at row 4, column 2 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M43">
+            <summary>
+            Value at row 4, column 3 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M44">
+            <summary>
+            Value at row 4, column 4 of the matrix.
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Matrix4x4.Identity">
+            <summary>
+            Returns the multiplicative identity matrix.
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Matrix4x4.IsIdentity">
+            <summary>
+            Returns whether the matrix is the identity matrix.
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Matrix4x4.Translation">
+            <summary>
+            Gets or sets the translation component of this matrix.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.#ctor(System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single)">
+            <summary>
+            Constructs a Matrix4x4 from the given components.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.#ctor(System.Numerics.Matrix3x2)">
+            <summary>
+            Constructs a Matrix4x4 from the given Matrix3x2.
+            </summary>
+            <param name="value">The source Matrix3x2.</param>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateBillboard(System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Creates a spherical billboard that rotates around a specified object position.
+            </summary>
+            <param name="objectPosition">Position of the object the billboard will rotate around.</param>
+            <param name="cameraPosition">Position of the camera.</param>
+            <param name="cameraUpVector">The up vector of the camera.</param>
+            <param name="cameraForwardVector">The forward vector of the camera.</param>
+            <returns>The created billboard matrix</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateConstrainedBillboard(System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Creates a cylindrical billboard that rotates around a specified axis.
+            </summary>
+            <param name="objectPosition">Position of the object the billboard will rotate around.</param>
+            <param name="cameraPosition">Position of the camera.</param>
+            <param name="rotateAxis">Axis to rotate the billboard around.</param>
+            <param name="cameraForwardVector">Forward vector of the camera.</param>
+            <param name="objectForwardVector">Forward vector of the object.</param>
+            <returns>The created billboard matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateTranslation(System.Numerics.Vector3)">
+            <summary>
+            Creates a translation matrix.
+            </summary>
+            <param name="position">The amount to translate in each axis.</param>
+            <returns>The translation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateTranslation(System.Single,System.Single,System.Single)">
+            <summary>
+            Creates a translation matrix.
+            </summary>
+            <param name="xPosition">The amount to translate on the X-axis.</param>
+            <param name="yPosition">The amount to translate on the Y-axis.</param>
+            <param name="zPosition">The amount to translate on the Z-axis.</param>
+            <returns>The translation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateScale(System.Single,System.Single,System.Single)">
+            <summary>
+            Creates a scaling matrix.
+            </summary>
+            <param name="xScale">Value to scale by on the X-axis.</param>
+            <param name="yScale">Value to scale by on the Y-axis.</param>
+            <param name="zScale">Value to scale by on the Z-axis.</param>
+            <returns>The scaling matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateScale(System.Single,System.Single,System.Single,System.Numerics.Vector3)">
+            <summary>
+            Creates a scaling matrix with a center point.
+            </summary>
+            <param name="xScale">Value to scale by on the X-axis.</param>
+            <param name="yScale">Value to scale by on the Y-axis.</param>
+            <param name="zScale">Value to scale by on the Z-axis.</param>
+            <param name="centerPoint">The center point.</param>
+            <returns>The scaling matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateScale(System.Numerics.Vector3)">
+            <summary>
+            Creates a scaling matrix.
+            </summary>
+            <param name="scales">The vector containing the amount to scale by on each axis.</param>
+            <returns>The scaling matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateScale(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Creates a scaling matrix with a center point.
+            </summary>
+            <param name="scales">The vector containing the amount to scale by on each axis.</param>
+            <param name="centerPoint">The center point.</param>
+            <returns>The scaling matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateScale(System.Single)">
+            <summary>
+            Creates a uniform scaling matrix that scales equally on each axis.
+            </summary>
+            <param name="scale">The uniform scaling factor.</param>
+            <returns>The scaling matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateScale(System.Single,System.Numerics.Vector3)">
+            <summary>
+            Creates a uniform scaling matrix that scales equally on each axis with a center point.
+            </summary>
+            <param name="scale">The uniform scaling factor.</param>
+            <param name="centerPoint">The center point.</param>
+            <returns>The scaling matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateRotationX(System.Single)">
+            <summary>
+            Creates a matrix for rotating points around the X-axis.
+            </summary>
+            <param name="radians">The amount, in radians, by which to rotate around the X-axis.</param>
+            <returns>The rotation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateRotationX(System.Single,System.Numerics.Vector3)">
+            <summary>
+            Creates a matrix for rotating points around the X-axis, from a center point.
+            </summary>
+            <param name="radians">The amount, in radians, by which to rotate around the X-axis.</param>
+            <param name="centerPoint">The center point.</param>
+            <returns>The rotation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateRotationY(System.Single)">
+            <summary>
+            Creates a matrix for rotating points around the Y-axis.
+            </summary>
+            <param name="radians">The amount, in radians, by which to rotate around the Y-axis.</param>
+            <returns>The rotation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateRotationY(System.Single,System.Numerics.Vector3)">
+            <summary>
+            Creates a matrix for rotating points around the Y-axis, from a center point.
+            </summary>
+            <param name="radians">The amount, in radians, by which to rotate around the Y-axis.</param>
+            <param name="centerPoint">The center point.</param>
+            <returns>The rotation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateRotationZ(System.Single)">
+            <summary>
+            Creates a matrix for rotating points around the Z-axis.
+            </summary>
+            <param name="radians">The amount, in radians, by which to rotate around the Z-axis.</param>
+            <returns>The rotation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateRotationZ(System.Single,System.Numerics.Vector3)">
+            <summary>
+            Creates a matrix for rotating points around the Z-axis, from a center point.
+            </summary>
+            <param name="radians">The amount, in radians, by which to rotate around the Z-axis.</param>
+            <param name="centerPoint">The center point.</param>
+            <returns>The rotation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateFromAxisAngle(System.Numerics.Vector3,System.Single)">
+            <summary>
+            Creates a matrix that rotates around an arbitrary vector.
+            </summary>
+            <param name="axis">The axis to rotate around.</param>
+            <param name="angle">The angle to rotate around the given axis, in radians.</param>
+            <returns>The rotation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreatePerspectiveFieldOfView(System.Single,System.Single,System.Single,System.Single)">
+            <summary>
+            Creates a perspective projection matrix based on a field of view, aspect ratio, and near and far view plane distances. 
+            </summary>
+            <param name="fieldOfView">Field of view in the y direction, in radians.</param>
+            <param name="aspectRatio">Aspect ratio, defined as view space width divided by height.</param>
+            <param name="nearPlaneDistance">Distance to the near view plane.</param>
+            <param name="farPlaneDistance">Distance to the far view plane.</param>
+            <returns>The perspective projection matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreatePerspective(System.Single,System.Single,System.Single,System.Single)">
+            <summary>
+            Creates a perspective projection matrix from the given view volume dimensions.
+            </summary>
+            <param name="width">Width of the view volume at the near view plane.</param>
+            <param name="height">Height of the view volume at the near view plane.</param>
+            <param name="nearPlaneDistance">Distance to the near view plane.</param>
+            <param name="farPlaneDistance">Distance to the far view plane.</param>
+            <returns>The perspective projection matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreatePerspectiveOffCenter(System.Single,System.Single,System.Single,System.Single,System.Single,System.Single)">
+            <summary>
+            Creates a customized, perspective projection matrix.
+            </summary>
+            <param name="left">Minimum x-value of the view volume at the near view plane.</param>
+            <param name="right">Maximum x-value of the view volume at the near view plane.</param>
+            <param name="bottom">Minimum y-value of the view volume at the near view plane.</param>
+            <param name="top">Maximum y-value of the view volume at the near view plane.</param>
+            <param name="nearPlaneDistance">Distance to the near view plane.</param>
+            <param name="farPlaneDistance">Distance to of the far view plane.</param>
+            <returns>The perspective projection matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateOrthographic(System.Single,System.Single,System.Single,System.Single)">
+            <summary>
+            Creates an orthographic perspective matrix from the given view volume dimensions.
+            </summary>
+            <param name="width">Width of the view volume.</param>
+            <param name="height">Height of the view volume.</param>
+            <param name="zNearPlane">Minimum Z-value of the view volume.</param>
+            <param name="zFarPlane">Maximum Z-value of the view volume.</param>
+            <returns>The orthographic projection matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateOrthographicOffCenter(System.Single,System.Single,System.Single,System.Single,System.Single,System.Single)">
+            <summary>
+            Builds a customized, orthographic projection matrix.
+            </summary>
+            <param name="left">Minimum X-value of the view volume.</param>
+            <param name="right">Maximum X-value of the view volume.</param>
+            <param name="bottom">Minimum Y-value of the view volume.</param>
+            <param name="top">Maximum Y-value of the view volume.</param>
+            <param name="zNearPlane">Minimum Z-value of the view volume.</param>
+            <param name="zFarPlane">Maximum Z-value of the view volume.</param>
+            <returns>The orthographic projection matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateLookAt(System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Creates a view matrix.
+            </summary>
+            <param name="cameraPosition">The position of the camera.</param>
+            <param name="cameraTarget">The target towards which the camera is pointing.</param>
+            <param name="cameraUpVector">The direction that is "up" from the camera's point of view.</param>
+            <returns>The view matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateWorld(System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Creates a world matrix with the specified parameters.
+            </summary>
+            <param name="position">The position of the object; used in translation operations.</param>
+            <param name="forward">Forward direction of the object.</param>
+            <param name="up">Upward direction of the object; usually [0, 1, 0].</param>
+            <returns>The world matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateFromQuaternion(System.Numerics.Quaternion)">
+            <summary>
+            Creates a rotation matrix from the given Quaternion rotation value.
+            </summary>
+            <param name="quaternion">The source Quaternion.</param>
+            <returns>The rotation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateFromYawPitchRoll(System.Single,System.Single,System.Single)">
+            <summary>
+            Creates a rotation matrix from the specified yaw, pitch, and roll.
+            </summary>
+            <param name="yaw">Angle of rotation, in radians, around the Y-axis.</param>
+            <param name="pitch">Angle of rotation, in radians, around the X-axis.</param>
+            <param name="roll">Angle of rotation, in radians, around the Z-axis.</param>
+            <returns>The rotation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateShadow(System.Numerics.Vector3,System.Numerics.Plane)">
+            <summary>
+            Creates a Matrix that flattens geometry into a specified Plane as if casting a shadow from a specified light source.
+            </summary>
+            <param name="lightDirection">The direction from which the light that will cast the shadow is coming.</param>
+            <param name="plane">The Plane onto which the new matrix should flatten geometry so as to cast a shadow.</param>
+            <returns>A new Matrix that can be used to flatten geometry onto the specified plane from the specified direction.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateReflection(System.Numerics.Plane)">
+            <summary>
+            Creates a Matrix that reflects the coordinate system about a specified Plane.
+            </summary>
+            <param name="value">The Plane about which to create a reflection.</param>
+            <returns>A new matrix expressing the reflection.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.GetDeterminant">
+            <summary>
+            Calculates the determinant of the matrix.
+            </summary>
+            <returns>The determinant of the matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.Invert(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4@)">
+            <summary>
+            Attempts to calculate the inverse of the given matrix. If successful, result will contain the inverted matrix.
+            </summary>
+            <param name="matrix">The source matrix to invert.</param>
+            <param name="result">If successful, contains the inverted matrix.</param>
+            <returns>True if the source matrix could be inverted; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.Decompose(System.Numerics.Matrix4x4,System.Numerics.Vector3@,System.Numerics.Quaternion@,System.Numerics.Vector3@)">
+            <summary>
+            Attempts to extract the scale, translation, and rotation components from the given scale/rotation/translation matrix.
+            If successful, the out parameters will contained the extracted values.
+            </summary>
+            <param name="matrix">The source matrix.</param>
+            <param name="scale">The scaling component of the transformation matrix.</param>
+            <param name="rotation">The rotation component of the transformation matrix.</param>
+            <param name="translation">The translation component of the transformation matrix</param>
+            <returns>True if the source matrix was successfully decomposed; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.Transform(System.Numerics.Matrix4x4,System.Numerics.Quaternion)">
+            <summary>
+            Transforms the given matrix by applying the given Quaternion rotation.
+            </summary>
+            <param name="value">The source matrix to transform.</param>
+            <param name="rotation">The rotation to apply.</param>
+            <returns>The transformed matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.Transpose(System.Numerics.Matrix4x4)">
+            <summary>
+            Transposes the rows and columns of a matrix.
+            </summary>
+            <param name="matrix">The source matrix.</param>
+            <returns>The transposed matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.Lerp(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4,System.Single)">
+            <summary>
+            Linearly interpolates between the corresponding values of two matrices.
+            </summary>
+            <param name="matrix1">The first source matrix.</param>
+            <param name="matrix2">The second source matrix.</param>
+            <param name="amount">The relative weight of the second source matrix.</param>
+            <returns>The interpolated matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.Negate(System.Numerics.Matrix4x4)">
+            <summary>
+            Returns a new matrix with the negated elements of the given matrix.
+            </summary>
+            <param name="value">The source matrix.</param>
+            <returns>The negated matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.Add(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
+            <summary>
+            Adds two matrices together.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>The resulting matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.Subtract(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
+            <summary>
+            Subtracts the second matrix from the first.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>The result of the subtraction.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.Multiply(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
+            <summary>
+            Multiplies a matrix by another matrix.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>The result of the multiplication.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.Multiply(System.Numerics.Matrix4x4,System.Single)">
+            <summary>
+            Multiplies a matrix by a scalar value.
+            </summary>
+            <param name="value1">The source matrix.</param>
+            <param name="value2">The scaling factor.</param>
+            <returns>The scaled matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.op_UnaryNegation(System.Numerics.Matrix4x4)">
+            <summary>
+            Returns a new matrix with the negated elements of the given matrix.
+            </summary>
+            <param name="value">The source matrix.</param>
+            <returns>The negated matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.op_Addition(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
+            <summary>
+            Adds two matrices together.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>The resulting matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.op_Subtraction(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
+            <summary>
+            Subtracts the second matrix from the first.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>The result of the subtraction.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.op_Multiply(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
+            <summary>
+            Multiplies a matrix by another matrix.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>The result of the multiplication.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.op_Multiply(System.Numerics.Matrix4x4,System.Single)">
+            <summary>
+            Multiplies a matrix by a scalar value.
+            </summary>
+            <param name="value1">The source matrix.</param>
+            <param name="value2">The scaling factor.</param>
+            <returns>The scaled matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.op_Equality(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
+            <summary>
+            Returns a boolean indicating whether the given two matrices are equal.
+            </summary>
+            <param name="value1">The first matrix to compare.</param>
+            <param name="value2">The second matrix to compare.</param>
+            <returns>True if the given matrices are equal; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.op_Inequality(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
+            <summary>
+            Returns a boolean indicating whether the given two matrices are not equal.
+            </summary>
+            <param name="value1">The first matrix to compare.</param>
+            <param name="value2">The second matrix to compare.</param>
+            <returns>True if the given matrices are not equal; False if they are equal.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.Equals(System.Numerics.Matrix4x4)">
+            <summary>
+            Returns a boolean indicating whether this matrix instance is equal to the other given matrix.
+            </summary>
+            <param name="other">The matrix to compare this instance to.</param>
+            <returns>True if the matrices are equal; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.Equals(System.Object)">
+            <summary>
+            Returns a boolean indicating whether the given Object is equal to this matrix instance.
+            </summary>
+            <param name="obj">The Object to compare against.</param>
+            <returns>True if the Object is equal to this matrix; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.ToString">
+            <summary>
+            Returns a String representing this matrix instance.
+            </summary>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.GetHashCode">
+            <summary>
+            Returns the hash code for this instance.
+            </summary>
+            <returns>The hash code.</returns>
+        </member>
+        <member name="T:System.Numerics.Plane">
+            <summary>
+            A structure encapsulating a 3D Plane
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Plane.Normal">
+            <summary>
+            The normal vector of the Plane.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Plane.D">
+            <summary>
+            The distance of the Plane along its normal from the origin.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Plane.#ctor(System.Single,System.Single,System.Single,System.Single)">
+            <summary>
+            Constructs a Plane from the X, Y, and Z components of its normal, and its distance from the origin on that normal.
+            </summary>
+            <param name="x">The X-component of the normal.</param>
+            <param name="y">The Y-component of the normal.</param>
+            <param name="z">The Z-component of the normal.</param>
+            <param name="d">The distance of the Plane along its normal from the origin.</param>
+        </member>
+        <member name="M:System.Numerics.Plane.#ctor(System.Numerics.Vector3,System.Single)">
+            <summary>
+            Constructs a Plane from the given normal and distance along the normal from the origin.
+            </summary>
+            <param name="normal">The Plane's normal vector.</param>
+            <param name="d">The Plane's distance from the origin along its normal vector.</param>
+        </member>
+        <member name="M:System.Numerics.Plane.#ctor(System.Numerics.Vector4)">
+            <summary>
+            Constructs a Plane from the given Vector4.
+            </summary>
+            <param name="value">A vector whose first 3 elements describe the normal vector, 
+            and whose W component defines the distance along that normal from the origin.</param>
+        </member>
+        <member name="M:System.Numerics.Plane.CreateFromVertices(System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Creates a Plane that contains the three given points.
+            </summary>
+            <param name="point1">The first point defining the Plane.</param>
+            <param name="point2">The second point defining the Plane.</param>
+            <param name="point3">The third point defining the Plane.</param>
+            <returns>The Plane containing the three points.</returns>
+        </member>
+        <member name="M:System.Numerics.Plane.Normalize(System.Numerics.Plane)">
+            <summary>
+            Creates a new Plane whose normal vector is the source Plane's normal vector normalized.
+            </summary>
+            <param name="value">The source Plane.</param>
+            <returns>The normalized Plane.</returns>
+        </member>
+        <member name="M:System.Numerics.Plane.Transform(System.Numerics.Plane,System.Numerics.Matrix4x4)">
+            <summary>
+            Transforms a normalized Plane by a Matrix.
+            </summary>
+            <param name="plane"> The normalized Plane to transform. 
+            This Plane must already be normalized, so that its Normal vector is of unit length, before this method is called.</param>
+            <param name="matrix">The transformation matrix to apply to the Plane.</param>
+            <returns>The transformed Plane.</returns>
+        </member>
+        <member name="M:System.Numerics.Plane.Transform(System.Numerics.Plane,System.Numerics.Quaternion)">
+            <summary>
+             Transforms a normalized Plane by a Quaternion rotation.
+            </summary>
+            <param name="plane"> The normalized Plane to transform.
+            This Plane must already be normalized, so that its Normal vector is of unit length, before this method is called.</param>
+            <param name="rotation">The Quaternion rotation to apply to the Plane.</param>
+            <returns>A new Plane that results from applying the rotation.</returns>
+        </member>
+        <member name="M:System.Numerics.Plane.Dot(System.Numerics.Plane,System.Numerics.Vector4)">
+            <summary>
+            Calculates the dot product of a Plane and Vector4.
+            </summary>
+            <param name="plane">The Plane.</param>
+            <param name="value">The Vector4.</param>
+            <returns>The dot product.</returns>
+        </member>
+        <member name="M:System.Numerics.Plane.DotCoordinate(System.Numerics.Plane,System.Numerics.Vector3)">
+            <summary>
+            Returns the dot product of a specified Vector3 and the normal vector of this Plane plus the distance (D) value of the Plane.
+            </summary>
+            <param name="plane">The plane.</param>
+            <param name="value">The Vector3.</param>
+            <returns>The resulting value.</returns>
+        </member>
+        <member name="M:System.Numerics.Plane.DotNormal(System.Numerics.Plane,System.Numerics.Vector3)">
+            <summary>
+            Returns the dot product of a specified Vector3 and the Normal vector of this Plane.
+            </summary>
+            <param name="plane">The plane.</param>
+            <param name="value">The Vector3.</param>
+            <returns>The resulting dot product.</returns>
+        </member>
+        <member name="M:System.Numerics.Plane.op_Equality(System.Numerics.Plane,System.Numerics.Plane)">
+            <summary>
+            Returns a boolean indicating whether the two given Planes are equal.
+            </summary>
+            <param name="value1">The first Plane to compare.</param>
+            <param name="value2">The second Plane to compare.</param>
+            <returns>True if the Planes are equal; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Plane.op_Inequality(System.Numerics.Plane,System.Numerics.Plane)">
+            <summary>
+            Returns a boolean indicating whether the two given Planes are not equal.
+            </summary>
+            <param name="value1">The first Plane to compare.</param>
+            <param name="value2">The second Plane to compare.</param>
+            <returns>True if the Planes are not equal; False if they are equal.</returns>
+        </member>
+        <member name="M:System.Numerics.Plane.Equals(System.Numerics.Plane)">
+            <summary>
+            Returns a boolean indicating whether the given Plane is equal to this Plane instance.
+            </summary>
+            <param name="other">The Plane to compare this instance to.</param>
+            <returns>True if the other Plane is equal to this instance; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Plane.Equals(System.Object)">
+            <summary>
+            Returns a boolean indicating whether the given Object is equal to this Plane instance.
+            </summary>
+            <param name="obj">The Object to compare against.</param>
+            <returns>True if the Object is equal to this Plane; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Plane.ToString">
+            <summary>
+            Returns a String representing this Plane instance.
+            </summary>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Plane.GetHashCode">
+            <summary>
+            Returns the hash code for this instance.
+            </summary>
+            <returns>The hash code.</returns>
+        </member>
+        <member name="T:System.Numerics.Quaternion">
+            <summary>
+            A structure encapsulating a four-dimensional vector (x,y,z,w), 
+            which is used to efficiently rotate an object about the (x,y,z) vector by the angle theta, where w = cos(theta/2).
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Quaternion.X">
+            <summary>
+            Specifies the X-value of the vector component of the Quaternion.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Quaternion.Y">
+            <summary>
+            Specifies the Y-value of the vector component of the Quaternion.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Quaternion.Z">
+            <summary>
+            Specifies the Z-value of the vector component of the Quaternion.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Quaternion.W">
+            <summary>
+            Specifies the rotation component of the Quaternion.
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Quaternion.Identity">
+            <summary>
+            Returns a Quaternion representing no rotation. 
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Quaternion.IsIdentity">
+            <summary>
+            Returns whether the Quaternion is the identity Quaternion.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Quaternion.#ctor(System.Single,System.Single,System.Single,System.Single)">
+            <summary>
+            Constructs a Quaternion from the given components.
+            </summary>
+            <param name="x">The X component of the Quaternion.</param>
+            <param name="y">The Y component of the Quaternion.</param>
+            <param name="z">The Z component of the Quaternion.</param>
+            <param name="w">The W component of the Quaternion.</param>
+        </member>
+        <member name="M:System.Numerics.Quaternion.#ctor(System.Numerics.Vector3,System.Single)">
+            <summary>
+            Constructs a Quaternion from the given vector and rotation parts.
+            </summary>
+            <param name="vectorPart">The vector part of the Quaternion.</param>
+            <param name="scalarPart">The rotation part of the Quaternion.</param>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Length">
+            <summary>
+            Calculates the length of the Quaternion.
+            </summary>
+            <returns>The computed length of the Quaternion.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.LengthSquared">
+            <summary>
+            Calculates the length squared of the Quaternion. This operation is cheaper than Length().
+            </summary>
+            <returns>The length squared of the Quaternion.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Normalize(System.Numerics.Quaternion)">
+            <summary>
+            Divides each component of the Quaternion by the length of the Quaternion.
+            </summary>
+            <param name="value">The source Quaternion.</param>
+            <returns>The normalized Quaternion.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Conjugate(System.Numerics.Quaternion)">
+            <summary>
+            Creates the conjugate of a specified Quaternion.
+            </summary>
+            <param name="value">The Quaternion of which to return the conjugate.</param>
+            <returns>A new Quaternion that is the conjugate of the specified one.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Inverse(System.Numerics.Quaternion)">
+            <summary>
+            Returns the inverse of a Quaternion.
+            </summary>
+            <param name="value">The source Quaternion.</param>
+            <returns>The inverted Quaternion.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.CreateFromAxisAngle(System.Numerics.Vector3,System.Single)">
+            <summary>
+            Creates a Quaternion from a normalized vector axis and an angle to rotate about the vector.
+            </summary>
+            <param name="axis">The unit vector to rotate around.
+            This vector must be normalized before calling this function or the resulting Quaternion will be incorrect.</param>
+            <param name="angle">The angle, in radians, to rotate around the vector.</param>
+            <returns>The created Quaternion.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.CreateFromYawPitchRoll(System.Single,System.Single,System.Single)">
+            <summary>
+            Creates a new Quaternion from the given yaw, pitch, and roll, in radians.
+            </summary>
+            <param name="yaw">The yaw angle, in radians, around the Y-axis.</param>
+            <param name="pitch">The pitch angle, in radians, around the X-axis.</param>
+            <param name="roll">The roll angle, in radians, around the Z-axis.</param>
+            <returns></returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.CreateFromRotationMatrix(System.Numerics.Matrix4x4)">
+            <summary>
+            Creates a Quaternion from the given rotation matrix.
+            </summary>
+            <param name="matrix">The rotation matrix.</param>
+            <returns>The created Quaternion.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Dot(System.Numerics.Quaternion,System.Numerics.Quaternion)">
+            <summary>
+            Calculates the dot product of two Quaternions.
+            </summary>
+            <param name="quaternion1">The first source Quaternion.</param>
+            <param name="quaternion2">The second source Quaternion.</param>
+            <returns>The dot product of the Quaternions.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Slerp(System.Numerics.Quaternion,System.Numerics.Quaternion,System.Single)">
+            <summary>
+            Interpolates between two quaternions, using spherical linear interpolation.
+            </summary>
+            <param name="quaternion1">The first source Quaternion.</param>
+            <param name="quaternion2">The second source Quaternion.</param>
+            <param name="amount">The relative weight of the second source Quaternion in the interpolation.</param>
+            <returns>The interpolated Quaternion.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Lerp(System.Numerics.Quaternion,System.Numerics.Quaternion,System.Single)">
+            <summary>
+             Linearly interpolates between two quaternions.
+            </summary>
+            <param name="quaternion1">The first source Quaternion.</param>
+            <param name="quaternion2">The second source Quaternion.</param>
+            <param name="amount">The relative weight of the second source Quaternion in the interpolation.</param>
+            <returns>The interpolated Quaternion.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Concatenate(System.Numerics.Quaternion,System.Numerics.Quaternion)">
+            <summary>
+            Concatenates two Quaternions; the result represents the value1 rotation followed by the value2 rotation.
+            </summary>
+            <param name="value1">The first Quaternion rotation in the series.</param>
+            <param name="value2">The second Quaternion rotation in the series.</param>
+            <returns>A new Quaternion representing the concatenation of the value1 rotation followed by the value2 rotation.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Negate(System.Numerics.Quaternion)">
+            <summary>
+            Flips the sign of each component of the quaternion.
+            </summary>
+            <param name="value">The source Quaternion.</param>
+            <returns>The negated Quaternion.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Add(System.Numerics.Quaternion,System.Numerics.Quaternion)">
+            <summary>
+            Adds two Quaternions element-by-element.
+            </summary>
+            <param name="value1">The first source Quaternion.</param>
+            <param name="value2">The second source Quaternion.</param>
+            <returns>The result of adding the Quaternions.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Subtract(System.Numerics.Quaternion,System.Numerics.Quaternion)">
+            <summary>
+            Subtracts one Quaternion from another.
+            </summary>
+            <param name="value1">The first source Quaternion.</param>
+            <param name="value2">The second Quaternion, to be subtracted from the first.</param>
+            <returns>The result of the subtraction.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Multiply(System.Numerics.Quaternion,System.Numerics.Quaternion)">
+            <summary>
+            Multiplies two Quaternions together.
+            </summary>
+            <param name="value1">The Quaternion on the left side of the multiplication.</param>
+            <param name="value2">The Quaternion on the right side of the multiplication.</param>
+            <returns>The result of the multiplication.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Multiply(System.Numerics.Quaternion,System.Single)">
+            <summary>
+            Multiplies a Quaternion by a scalar value.
+            </summary>
+            <param name="value1">The source Quaternion.</param>
+            <param name="value2">The scalar value.</param>
+            <returns>The result of the multiplication.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Divide(System.Numerics.Quaternion,System.Numerics.Quaternion)">
+            <summary>
+            Divides a Quaternion by another Quaternion.
+            </summary>
+            <param name="value1">The source Quaternion.</param>
+            <param name="value2">The divisor.</param>
+            <returns>The result of the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.op_UnaryNegation(System.Numerics.Quaternion)">
+            <summary>
+            Flips the sign of each component of the quaternion.
+            </summary>
+            <param name="value">The source Quaternion.</param>
+            <returns>The negated Quaternion.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.op_Addition(System.Numerics.Quaternion,System.Numerics.Quaternion)">
+            <summary>
+            Adds two Quaternions element-by-element.
+            </summary>
+            <param name="value1">The first source Quaternion.</param>
+            <param name="value2">The second source Quaternion.</param>
+            <returns>The result of adding the Quaternions.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.op_Subtraction(System.Numerics.Quaternion,System.Numerics.Quaternion)">
+            <summary>
+            Subtracts one Quaternion from another.
+            </summary>
+            <param name="value1">The first source Quaternion.</param>
+            <param name="value2">The second Quaternion, to be subtracted from the first.</param>
+            <returns>The result of the subtraction.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.op_Multiply(System.Numerics.Quaternion,System.Numerics.Quaternion)">
+            <summary>
+            Multiplies two Quaternions together.
+            </summary>
+            <param name="value1">The Quaternion on the left side of the multiplication.</param>
+            <param name="value2">The Quaternion on the right side of the multiplication.</param>
+            <returns>The result of the multiplication.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.op_Multiply(System.Numerics.Quaternion,System.Single)">
+            <summary>
+            Multiplies a Quaternion by a scalar value.
+            </summary>
+            <param name="value1">The source Quaternion.</param>
+            <param name="value2">The scalar value.</param>
+            <returns>The result of the multiplication.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.op_Division(System.Numerics.Quaternion,System.Numerics.Quaternion)">
+            <summary>
+            Divides a Quaternion by another Quaternion.
+            </summary>
+            <param name="value1">The source Quaternion.</param>
+            <param name="value2">The divisor.</param>
+            <returns>The result of the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.op_Equality(System.Numerics.Quaternion,System.Numerics.Quaternion)">
+            <summary>
+            Returns a boolean indicating whether the two given Quaternions are equal.
+            </summary>
+            <param name="value1">The first Quaternion to compare.</param>
+            <param name="value2">The second Quaternion to compare.</param>
+            <returns>True if the Quaternions are equal; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.op_Inequality(System.Numerics.Quaternion,System.Numerics.Quaternion)">
+            <summary>
+            Returns a boolean indicating whether the two given Quaternions are not equal.
+            </summary>
+            <param name="value1">The first Quaternion to compare.</param>
+            <param name="value2">The second Quaternion to compare.</param>
+            <returns>True if the Quaternions are not equal; False if they are equal.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Equals(System.Numerics.Quaternion)">
+            <summary>
+            Returns a boolean indicating whether the given Quaternion is equal to this Quaternion instance.
+            </summary>
+            <param name="other">The Quaternion to compare this instance to.</param>
+            <returns>True if the other Quaternion is equal to this instance; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Equals(System.Object)">
+            <summary>
+            Returns a boolean indicating whether the given Object is equal to this Quaternion instance.
+            </summary>
+            <param name="obj">The Object to compare against.</param>
+            <returns>True if the Object is equal to this Quaternion; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.ToString">
+            <summary>
+            Returns a String representing this Quaternion instance.
+            </summary>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.GetHashCode">
+            <summary>
+            Returns the hash code for this instance.
+            </summary>
+            <returns>The hash code.</returns>
+        </member>
+        <member name="T:System.Numerics.Register">
+            <summary>
+            A structure describing the layout of an SSE2-sized register.
+            Contains overlapping fields representing the set of valid numeric types.
+            Allows the generic Vector'T struct to contain an explicit field layout.
+            </summary>
+        </member>
+        <member name="T:System.Numerics.Vector`1">
+            <summary>
+            A structure that represents a single Vector. The count of this Vector is fixed but CPU register dependent.
+            This struct only supports numerical types. This type is intended to be used as a building block for vectorizing
+            large algorithms. This type is immutable, individual elements cannot be modified.
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector`1.Count">
+            <summary>
+            Returns the number of elements stored in the vector. This value is hardware dependent.
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector`1.Zero">
+            <summary>
+            Returns a vector containing all zeroes.
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector`1.One">
+            <summary>
+            Returns a vector containing all ones.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector`1.#ctor(`0)">
+            <summary>
+            Constructs a vector whose components are all <code>value</code>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector`1.#ctor(`0[])">
+            <summary>
+            Constructs a vector from the given array. The size of the given array must be at least Vector'T.Count.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector`1.#ctor(`0[],System.Int32)">
+            <summary>
+            Constructs a vector from the given array, starting from the given index.
+            The array must contain at least Vector'T.Count from the given index.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector`1.CopyTo(`0[])">
+            <summary>
+            Copies the vector to the given destination array. The destination array must be at least size Vector'T.Count.
+            </summary>
+            <param name="destination">The destination array which the values are copied into</param>
+            <exception cref="T:System.ArgumentNullException">If the destination array is null</exception>
+            <exception cref="T:System.ArgumentException">If number of elements in source vector is greater than those available in destination array</exception>
+        </member>
+        <member name="M:System.Numerics.Vector`1.CopyTo(`0[],System.Int32)">
+            <summary>
+            Copies the vector to the given destination array. The destination array must be at least size Vector'T.Count.
+            </summary>
+            <param name="destination">The destination array which the values are copied into</param>
+            <param name="startIndex">The index to start copying to</param>
+            <exception cref="T:System.ArgumentNullException">If the destination array is null</exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">If index is greater than end of the array or index is less than zero</exception>
+            <exception cref="T:System.ArgumentException">If number of elements in source vector is greater than those available in destination array</exception>
+        </member>
+        <member name="P:System.Numerics.Vector`1.Item(System.Int32)">
+            <summary>
+            Returns the element at the given index.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector`1.Equals(System.Object)">
+            <summary>
+            Returns a boolean indicating whether the given Object is equal to this vector instance.
+            </summary>
+            <param name="obj">The Object to compare against.</param>
+            <returns>True if the Object is equal to this vector; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.Equals(System.Numerics.Vector{`0})">
+            <summary>
+            Returns a boolean indicating whether the given vector is equal to this vector instance.
+            </summary>
+            <param name="other">The vector to compare this instance to.</param>
+            <returns>True if the other vector is equal to this instance; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.GetHashCode">
+            <summary>
+            Returns the hash code for this instance.
+            </summary>
+            <returns>The hash code.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.ToString">
+            <summary>
+            Returns a String representing this vector.
+            </summary>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.ToString(System.String)">
+            <summary>
+            Returns a String representing this vector, using the specified format string to format individual elements.
+            </summary>
+            <param name="format">The format of individual elements.</param>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.ToString(System.String,System.IFormatProvider)">
+            <summary>
+            Returns a String representing this vector, using the specified format string to format individual elements
+            and the given IFormatProvider.
+            </summary>
+            <param name="format">The format of individual elements.</param>
+            <param name="formatProvider">The format provider to use when formatting elements.</param>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Addition(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
+            <summary>
+            Adds two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The summed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Subtraction(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
+            <summary>
+            Subtracts the second vector from the first.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The difference vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Multiply(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
+            <summary>
+            Multiplies two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The product vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Multiply(System.Numerics.Vector{`0},`0)">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="value">The source vector.</param>
+            <param name="factor">The scalar value.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Multiply(`0,System.Numerics.Vector{`0})">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="factor">The scalar value.</param>
+            <param name="value">The source vector.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Division(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
+            <summary>
+            Divides the first vector by the second.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The vector resulting from the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_UnaryNegation(System.Numerics.Vector{`0})">
+            <summary>
+            Negates a given vector.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The negated vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_BitwiseAnd(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
+            <summary>
+            Returns a new vector by performing a bitwise-and operation on each of the elements in the given vectors.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_BitwiseOr(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
+            <summary>
+            Returns a new vector by performing a bitwise-or operation on each of the elements in the given vectors.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_ExclusiveOr(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
+            <summary>
+            Returns a new vector by performing a bitwise-exclusive-or operation on each of the elements in the given vectors.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_OnesComplement(System.Numerics.Vector{`0})">
+            <summary>
+            Returns a new vector whose elements are obtained by taking the one's complement of the given vector's elements.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The one's complement vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Equality(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
+            <summary>
+            Returns a boolean indicating whether each pair of elements in the given vectors are equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The first vector to compare.</param>
+            <returns>True if all elements are equal; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Inequality(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
+            <summary>
+            Returns a boolean indicating whether any single pair of elements in the given vectors are not equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if left and right are not equal; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{`0})~System.Numerics.Vector{System.Byte}">
+            <summary>
+            Reinterprets the bits of the given vector into those of another type.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{`0})~System.Numerics.Vector{System.SByte}">
+            <summary>
+            Reinterprets the bits of the given vector into those of another type.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{`0})~System.Numerics.Vector{System.UInt16}">
+            <summary>
+            Reinterprets the bits of the given vector into those of another type.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{`0})~System.Numerics.Vector{System.Int16}">
+            <summary>
+            Reinterprets the bits of the given vector into those of another type.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{`0})~System.Numerics.Vector{System.UInt32}">
+            <summary>
+            Reinterprets the bits of the given vector into those of another type.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{`0})~System.Numerics.Vector{System.Int32}">
+            <summary>
+            Reinterprets the bits of the given vector into those of another type.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{`0})~System.Numerics.Vector{System.UInt64}">
+            <summary>
+            Reinterprets the bits of the given vector into those of another type.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{`0})~System.Numerics.Vector{System.Int64}">
+            <summary>
+            Reinterprets the bits of the given vector into those of another type.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{`0})~System.Numerics.Vector{System.Single}">
+            <summary>
+            Reinterprets the bits of the given vector into those of another type.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{`0})~System.Numerics.Vector{System.Double}">
+            <summary>
+            Reinterprets the bits of the given vector into those of another type.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="T:System.Numerics.Vector">
+            <summary>
+            Contains various methods useful for creating, manipulating, combining, and converting generic vectors with one another.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Widen(System.Numerics.Vector{System.Byte},System.Numerics.Vector{System.UInt16}@,System.Numerics.Vector{System.UInt16}@)">
+            <summary>
+            Widens a Vector{Byte} into two Vector{UInt16}'s.
+            <param name="source">The source vector whose elements are widened into the outputs.</param>
+            <param name="low">The first output vector, whose elements will contain the widened elements from lower indices in the source vector.</param>
+            <param name="high">The second output vector, whose elements will contain the widened elements from higher indices in the source vector.</param>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Widen(System.Numerics.Vector{System.UInt16},System.Numerics.Vector{System.UInt32}@,System.Numerics.Vector{System.UInt32}@)">
+            <summary>
+            Widens a Vector{UInt16} into two Vector{UInt32}'s.
+            <param name="source">The source vector whose elements are widened into the outputs.</param>
+            <param name="low">The first output vector, whose elements will contain the widened elements from lower indices in the source vector.</param>
+            <param name="high">The second output vector, whose elements will contain the widened elements from higher indices in the source vector.</param>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Widen(System.Numerics.Vector{System.UInt32},System.Numerics.Vector{System.UInt64}@,System.Numerics.Vector{System.UInt64}@)">
+            <summary>
+            Widens a Vector{UInt32} into two Vector{UInt64}'s.
+            <param name="source">The source vector whose elements are widened into the outputs.</param>
+            <param name="low">The first output vector, whose elements will contain the widened elements from lower indices in the source vector.</param>
+            <param name="high">The second output vector, whose elements will contain the widened elements from higher indices in the source vector.</param>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Widen(System.Numerics.Vector{System.SByte},System.Numerics.Vector{System.Int16}@,System.Numerics.Vector{System.Int16}@)">
+            <summary>
+            Widens a Vector{SByte} into two Vector{Int16}'s.
+            <param name="source">The source vector whose elements are widened into the outputs.</param>
+            <param name="low">The first output vector, whose elements will contain the widened elements from lower indices in the source vector.</param>
+            <param name="high">The second output vector, whose elements will contain the widened elements from higher indices in the source vector.</param>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Widen(System.Numerics.Vector{System.Int16},System.Numerics.Vector{System.Int32}@,System.Numerics.Vector{System.Int32}@)">
+            <summary>
+            Widens a Vector{Int16} into two Vector{Int32}'s.
+            <param name="source">The source vector whose elements are widened into the outputs.</param>
+            <param name="low">The first output vector, whose elements will contain the widened elements from lower indices in the source vector.</param>
+            <param name="high">The second output vector, whose elements will contain the widened elements from higher indices in the source vector.</param>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Widen(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Int64}@,System.Numerics.Vector{System.Int64}@)">
+            <summary>
+            Widens a Vector{Int32} into two Vector{Int64}'s.
+            <param name="source">The source vector whose elements are widened into the outputs.</param>
+            <param name="low">The first output vector, whose elements will contain the widened elements from lower indices in the source vector.</param>
+            <param name="high">The second output vector, whose elements will contain the widened elements from higher indices in the source vector.</param>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Widen(System.Numerics.Vector{System.Single},System.Numerics.Vector{System.Double}@,System.Numerics.Vector{System.Double}@)">
+            <summary>
+            Widens a Vector{Single} into two Vector{Double}'s.
+            <param name="source">The source vector whose elements are widened into the outputs.</param>
+            <param name="low">The first output vector, whose elements will contain the widened elements from lower indices in the source vector.</param>
+            <param name="high">The second output vector, whose elements will contain the widened elements from higher indices in the source vector.</param>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Narrow(System.Numerics.Vector{System.UInt16},System.Numerics.Vector{System.UInt16})">
+            <summary>
+            Narrows two Vector{UInt16}'s into one Vector{Byte}.
+            <param name="low">The first source vector, whose elements become the lower-index elements of the return value.</param>
+            <param name="high">The second source vector, whose elements become the higher-index elements of the return value.</param>
+            <returns>A Vector{Byte} containing elements narrowed from the source vectors.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Narrow(System.Numerics.Vector{System.UInt32},System.Numerics.Vector{System.UInt32})">
+            <summary>
+            Narrows two Vector{UInt32}'s into one Vector{UInt16}.
+            <param name="low">The first source vector, whose elements become the lower-index elements of the return value.</param>
+            <param name="high">The second source vector, whose elements become the higher-index elements of the return value.</param>
+            <returns>A Vector{UInt16} containing elements narrowed from the source vectors.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Narrow(System.Numerics.Vector{System.UInt64},System.Numerics.Vector{System.UInt64})">
+            <summary>
+            Narrows two Vector{UInt64}'s into one Vector{UInt32}.
+            <param name="low">The first source vector, whose elements become the lower-index elements of the return value.</param>
+            <param name="high">The second source vector, whose elements become the higher-index elements of the return value.</param>
+            <returns>A Vector{UInt32} containing elements narrowed from the source vectors.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Narrow(System.Numerics.Vector{System.Int16},System.Numerics.Vector{System.Int16})">
+            <summary>
+            Narrows two Vector{Int16}'s into one Vector{SByte}.
+            <param name="low">The first source vector, whose elements become the lower-index elements of the return value.</param>
+            <param name="high">The second source vector, whose elements become the higher-index elements of the return value.</param>
+            <returns>A Vector{SByte} containing elements narrowed from the source vectors.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Narrow(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Int32})">
+            <summary>
+            Narrows two Vector{Int32}'s into one Vector{Int16}.
+            <param name="low">The first source vector, whose elements become the lower-index elements of the return value.</param>
+            <param name="high">The second source vector, whose elements become the higher-index elements of the return value.</param>
+            <returns>A Vector{Int16} containing elements narrowed from the source vectors.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Narrow(System.Numerics.Vector{System.Int64},System.Numerics.Vector{System.Int64})">
+            <summary>
+            Narrows two Vector{Int64}'s into one Vector{Int32}.
+            <param name="low">The first source vector, whose elements become the lower-index elements of the return value.</param>
+            <param name="high">The second source vector, whose elements become the higher-index elements of the return value.</param>
+            <returns>A Vector{Int32} containing elements narrowed from the source vectors.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Narrow(System.Numerics.Vector{System.Double},System.Numerics.Vector{System.Double})">
+            <summary>
+            Narrows two Vector{Double}'s into one Vector{Single}.
+            <param name="low">The first source vector, whose elements become the lower-index elements of the return value.</param>
+            <param name="high">The second source vector, whose elements become the higher-index elements of the return value.</param>
+            <returns>A Vector{Single} containing elements narrowed from the source vectors.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.ConvertToSingle(System.Numerics.Vector{System.Int32})">
+            <summary>
+            Converts a Vector{Int32} to a Vector{Single}.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The converted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.ConvertToSingle(System.Numerics.Vector{System.UInt32})">
+            <summary>
+            Converts a Vector{UInt32} to a Vector{Single}.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The converted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.ConvertToDouble(System.Numerics.Vector{System.Int64})">
+            <summary>
+            Converts a Vector{Int64} to a Vector{Double}.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The converted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.ConvertToDouble(System.Numerics.Vector{System.UInt64})">
+            <summary>
+            Converts a Vector{UInt64} to a Vector{Double}.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The converted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.ConvertToInt32(System.Numerics.Vector{System.Single})">
+            <summary>
+            Converts a Vector{Single} to a Vector{Int32}.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The converted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.ConvertToUInt32(System.Numerics.Vector{System.Single})">
+            <summary>
+            Converts a Vector{Single} to a Vector{UInt32}.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The converted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.ConvertToInt64(System.Numerics.Vector{System.Double})">
+            <summary>
+            Converts a Vector{Double} to a Vector{Int64}.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The converted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.ConvertToUInt64(System.Numerics.Vector{System.Double})">
+            <summary>
+            Converts a Vector{Double} to a Vector{UInt64}.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The converted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.ConditionalSelect(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Single},System.Numerics.Vector{System.Single})">
+            <summary>
+            Creates a new vector with elements selected between the two given source vectors, and based on a mask vector.
+            </summary>
+            <param name="condition">The integral mask vector used to drive selection.</param>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The new vector with elements selected based on the mask.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.ConditionalSelect(System.Numerics.Vector{System.Int64},System.Numerics.Vector{System.Double},System.Numerics.Vector{System.Double})">
+            <summary>
+            Creates a new vector with elements selected between the two given source vectors, and based on a mask vector.
+            </summary>
+            <param name="condition">The integral mask vector used to drive selection.</param>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The new vector with elements selected based on the mask.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.ConditionalSelect``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Creates a new vector with elements selected between the two given source vectors, and based on a mask vector.
+            </summary>
+            <param name="condition">The mask vector used to drive selection.</param>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The new vector with elements selected based on the mask.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Equals``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left and right were equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Equals(System.Numerics.Vector{System.Single},System.Numerics.Vector{System.Single})">
+            <summary>
+            Returns an integral vector whose elements signal whether elements in the left and right floating point vectors were equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Equals(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Int32})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left and right were equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Equals(System.Numerics.Vector{System.Double},System.Numerics.Vector{System.Double})">
+            <summary>
+            Returns an integral vector whose elements signal whether elements in the left and right floating point vectors were equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Equals(System.Numerics.Vector{System.Int64},System.Numerics.Vector{System.Int64})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left and right were equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.EqualsAll``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a boolean indicating whether each pair of elements in the given vectors are equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The first vector to compare.</param>
+            <returns>True if all elements are equal; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.EqualsAny``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a boolean indicating whether any single pair of elements in the given vectors are equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if any element pairs are equal; False if no element pairs are equal.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThan``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left were less than their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThan(System.Numerics.Vector{System.Single},System.Numerics.Vector{System.Single})">
+            <summary>
+            Returns an integral vector whose elements signal whether the elements in left were less than their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant integral vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThan(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Int32})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left were less than their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThan(System.Numerics.Vector{System.Double},System.Numerics.Vector{System.Double})">
+            <summary>
+            Returns an integral vector whose elements signal whether the elements in left were less than their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant integral vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThan(System.Numerics.Vector{System.Int64},System.Numerics.Vector{System.Int64})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left were less than their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThanAll``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a boolean indicating whether all of the elements in left are less than their corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if all elements in left are less than their corresponding elements in right; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThanAny``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a boolean indicating whether any element in left is less than its corresponding element in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if any elements in left are less than their corresponding elements in right; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThanOrEqual``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left were less than or equal to their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThanOrEqual(System.Numerics.Vector{System.Single},System.Numerics.Vector{System.Single})">
+            <summary>
+            Returns an integral vector whose elements signal whether the elements in left were less than or equal to their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant integral vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThanOrEqual(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Int32})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left were less than or equal to their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThanOrEqual(System.Numerics.Vector{System.Int64},System.Numerics.Vector{System.Int64})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left were less than or equal to their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThanOrEqual(System.Numerics.Vector{System.Double},System.Numerics.Vector{System.Double})">
+            <summary>
+            Returns an integral vector whose elements signal whether the elements in left were less than or equal to their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant integral vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThanOrEqualAll``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a boolean indicating whether all elements in left are less than or equal to their corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if all elements in left are less than or equal to their corresponding elements in right; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThanOrEqualAny``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a boolean indicating whether any element in left is less than or equal to its corresponding element in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if any elements in left are less than their corresponding elements in right; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThan``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left were greater than their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThan(System.Numerics.Vector{System.Single},System.Numerics.Vector{System.Single})">
+            <summary>
+            Returns an integral vector whose elements signal whether the elements in left were greater than their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant integral vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThan(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Int32})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left were greater than their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThan(System.Numerics.Vector{System.Double},System.Numerics.Vector{System.Double})">
+            <summary>
+            Returns an integral vector whose elements signal whether the elements in left were greater than their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant integral vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThan(System.Numerics.Vector{System.Int64},System.Numerics.Vector{System.Int64})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left were greater than their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThanAll``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a boolean indicating whether all elements in left are greater than the corresponding elements in right.
+            elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if all elements in left are greater than their corresponding elements in right; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThanAny``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a boolean indicating whether any element in left is greater than its corresponding element in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if any elements in left are greater than their corresponding elements in right; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThanOrEqual``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left were greater than or equal to their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThanOrEqual(System.Numerics.Vector{System.Single},System.Numerics.Vector{System.Single})">
+            <summary>
+            Returns an integral vector whose elements signal whether the elements in left were greater than or equal to their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant integral vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThanOrEqual(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Int32})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left were greater than or equal to their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThanOrEqual(System.Numerics.Vector{System.Int64},System.Numerics.Vector{System.Int64})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left were greater than or equal to their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThanOrEqual(System.Numerics.Vector{System.Double},System.Numerics.Vector{System.Double})">
+            <summary>
+            Returns an integral vector whose elements signal whether the elements in left were greater than or equal to 
+            their corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant integral vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThanOrEqualAll``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a boolean indicating whether all of the elements in left are greater than or equal to 
+            their corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if all elements in left are greater than or equal to their corresponding elements in right; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThanOrEqualAny``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a boolean indicating whether any element in left is greater than or equal to its corresponding element in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if any elements in left are greater than or equal to their corresponding elements in right; False otherwise.</returns>
+        </member>
+        <member name="P:System.Numerics.Vector.IsHardwareAccelerated">
+            <summary>
+            Returns whether or not vector operations are subject to hardware acceleration through JIT intrinsic support.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Abs``1(System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector whose elements are the absolute values of the given vector's elements.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The absolute value vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Min``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector whose elements are the minimum of each pair of elements in the two given vectors.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The minimum vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Max``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector whose elements are the maximum of each pair of elements in the two given vectors.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The maximum vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Dot``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns the dot product of two vectors.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The dot product.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.SquareRoot``1(System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector whose elements are the square roots of the given vector's elements.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The square root vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Add``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Creates a new vector whose values are the sum of each pair of elements from the two given vectors.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The summed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Subtract``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Creates a new vector whose values are the difference between each pairs of elements in the given vectors.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The difference vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Multiply``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Creates a new vector whose values are the product of each pair of elements from the two given vectors.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The summed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Multiply``1(System.Numerics.Vector{``0},``0)">
+            <summary>
+            Returns a new vector whose values are the values of the given vector each multiplied by a scalar value.
+            </summary>
+            <param name="left">The source vector.</param>
+            <param name="right">The scalar factor.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Multiply``1(``0,System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector whose values are the values of the given vector each multiplied by a scalar value.
+            </summary>
+            <param name="left">The scalar factor.</param>
+            <param name="right">The source vector.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Divide``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector whose values are the result of dividing the first vector's elements 
+            by the corresponding elements in the second vector.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The divided vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Negate``1(System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector whose elements are the given vector's elements negated.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The negated vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.BitwiseAnd``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector by performing a bitwise-and operation on each of the elements in the given vectors.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.BitwiseOr``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector by performing a bitwise-or operation on each of the elements in the given vectors.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.OnesComplement``1(System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector whose elements are obtained by taking the one's complement of the given vector's elements.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The one's complement vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Xor``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector by performing a bitwise-exclusive-or operation on each of the elements in the given vectors.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.AndNot``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector by performing a bitwise-and-not operation on each of the elements in the given vectors.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.AsVectorByte``1(System.Numerics.Vector{``0})">
+            <summary>
+            Reinterprets the bits of the given vector into those of a vector of unsigned bytes.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.AsVectorSByte``1(System.Numerics.Vector{``0})">
+            <summary>
+            Reinterprets the bits of the given vector into those of a vector of signed bytes.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.AsVectorUInt16``1(System.Numerics.Vector{``0})">
+            <summary>
+            Reinterprets the bits of the given vector into those of a vector of 16-bit integers.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.AsVectorInt16``1(System.Numerics.Vector{``0})">
+            <summary>
+            Reinterprets the bits of the given vector into those of a vector of signed 16-bit integers.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.AsVectorUInt32``1(System.Numerics.Vector{``0})">
+            <summary>
+            Reinterprets the bits of the given vector into those of a vector of unsigned 32-bit integers.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.AsVectorInt32``1(System.Numerics.Vector{``0})">
+            <summary>
+            Reinterprets the bits of the given vector into those of a vector of signed 32-bit integers.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.AsVectorUInt64``1(System.Numerics.Vector{``0})">
+            <summary>
+            Reinterprets the bits of the given vector into those of a vector of unsigned 64-bit integers.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.AsVectorInt64``1(System.Numerics.Vector{``0})">
+            <summary>
+            Reinterprets the bits of the given vector into those of a vector of signed 64-bit integers.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.AsVectorSingle``1(System.Numerics.Vector{``0})">
+            <summary>
+            Reinterprets the bits of the given vector into those of a vector of 32-bit floating point numbers.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.AsVectorDouble``1(System.Numerics.Vector{``0})">
+            <summary>
+            Reinterprets the bits of the given vector into those of a vector of 64-bit floating point numbers.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="T:System.Numerics.Vector2">
+            <summary>
+            A structure encapsulating two single precision floating point values and provides hardware accelerated methods.
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector2.Zero">
+            <summary>
+            Returns the vector (0,0).
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector2.One">
+            <summary>
+            Returns the vector (1,1).
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector2.UnitX">
+            <summary>
+            Returns the vector (1,0).
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector2.UnitY">
+            <summary>
+            Returns the vector (0,1).
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector2.GetHashCode">
+            <summary>
+            Returns the hash code for this instance.
+            </summary>
+            <returns>The hash code.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Equals(System.Object)">
+            <summary>
+            Returns a boolean indicating whether the given Object is equal to this Vector2 instance.
+            </summary>
+            <param name="obj">The Object to compare against.</param>
+            <returns>True if the Object is equal to this Vector2; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.ToString">
+            <summary>
+            Returns a String representing this Vector2 instance.
+            </summary>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.ToString(System.String)">
+            <summary>
+            Returns a String representing this Vector2 instance, using the specified format to format individual elements.
+            </summary>
+            <param name="format">The format of individual elements.</param>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.ToString(System.String,System.IFormatProvider)">
+            <summary>
+            Returns a String representing this Vector2 instance, using the specified format to format individual elements 
+            and the given IFormatProvider.
+            </summary>
+            <param name="format">The format of individual elements.</param>
+            <param name="formatProvider">The format provider to use when formatting elements.</param>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Length">
+            <summary>
+            Returns the length of the vector.
+            </summary>
+            <returns>The vector's length.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.LengthSquared">
+            <summary>
+            Returns the length of the vector squared. This operation is cheaper than Length().
+            </summary>
+            <returns>The vector's length squared.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Distance(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Returns the Euclidean distance between the two given points.
+            </summary>
+            <param name="value1">The first point.</param>
+            <param name="value2">The second point.</param>
+            <returns>The distance.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.DistanceSquared(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Returns the Euclidean distance squared between the two given points.
+            </summary>
+            <param name="value1">The first point.</param>
+            <param name="value2">The second point.</param>
+            <returns>The distance squared.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Normalize(System.Numerics.Vector2)">
+            <summary>
+            Returns a vector with the same direction as the given vector, but with a length of 1.
+            </summary>
+            <param name="value">The vector to normalize.</param>
+            <returns>The normalized vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Reflect(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Returns the reflection of a vector off a surface that has the specified normal.
+            </summary>
+            <param name="vector">The source vector.</param>
+            <param name="normal">The normal of the surface being reflected off.</param>
+            <returns>The reflected vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Clamp(System.Numerics.Vector2,System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Restricts a vector between a min and max value.
+            </summary>
+            <param name="value1">The source vector.</param>
+            <param name="min">The minimum value.</param>
+            <param name="max">The maximum value.</param>
+        </member>
+        <member name="M:System.Numerics.Vector2.Lerp(System.Numerics.Vector2,System.Numerics.Vector2,System.Single)">
+            <summary>
+            Linearly interpolates between two vectors based on the given weighting.
+            </summary>
+            <param name="value1">The first source vector.</param>
+            <param name="value2">The second source vector.</param>
+            <param name="amount">Value between 0 and 1 indicating the weight of the second source vector.</param>
+            <returns>The interpolated vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Transform(System.Numerics.Vector2,System.Numerics.Matrix3x2)">
+            <summary>
+            Transforms a vector by the given matrix.
+            </summary>
+            <param name="position">The source vector.</param>
+            <param name="matrix">The transformation matrix.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Transform(System.Numerics.Vector2,System.Numerics.Matrix4x4)">
+            <summary>
+            Transforms a vector by the given matrix.
+            </summary>
+            <param name="position">The source vector.</param>
+            <param name="matrix">The transformation matrix.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.TransformNormal(System.Numerics.Vector2,System.Numerics.Matrix3x2)">
+            <summary>
+            Transforms a vector normal by the given matrix.
+            </summary>
+            <param name="normal">The source vector.</param>
+            <param name="matrix">The transformation matrix.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.TransformNormal(System.Numerics.Vector2,System.Numerics.Matrix4x4)">
+            <summary>
+            Transforms a vector normal by the given matrix.
+            </summary>
+            <param name="normal">The source vector.</param>
+            <param name="matrix">The transformation matrix.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Transform(System.Numerics.Vector2,System.Numerics.Quaternion)">
+            <summary>
+            Transforms a vector by the given Quaternion rotation value.
+            </summary>
+            <param name="value">The source vector to be rotated.</param>
+            <param name="rotation">The rotation to apply.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Add(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Adds two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The summed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Subtract(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Subtracts the second vector from the first.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The difference vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Multiply(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Multiplies two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The product vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Multiply(System.Numerics.Vector2,System.Single)">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="left">The source vector.</param>
+            <param name="right">The scalar value.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Multiply(System.Single,System.Numerics.Vector2)">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="left">The scalar value.</param>
+            <param name="right">The source vector.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Divide(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Divides the first vector by the second.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The vector resulting from the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Divide(System.Numerics.Vector2,System.Single)">
+            <summary>
+            Divides the vector by the given scalar.
+            </summary>
+            <param name="left">The source vector.</param>
+            <param name="divisor">The scalar value.</param>
+            <returns>The result of the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Negate(System.Numerics.Vector2)">
+            <summary>
+            Negates a given vector.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The negated vector.</returns>
+        </member>
+        <member name="F:System.Numerics.Vector2.X">
+            <summary>
+            The X component of the vector.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Vector2.Y">
+            <summary>
+            The Y component of the vector.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector2.#ctor(System.Single)">
+            <summary>
+            Constructs a vector whose elements are all the single specified value.
+            </summary>
+            <param name="value">The element to fill the vector with.</param>
+        </member>
+        <member name="M:System.Numerics.Vector2.#ctor(System.Single,System.Single)">
+            <summary>
+            Constructs a vector with the given individual elements.
+            </summary>
+            <param name="x">The X component.</param>
+            <param name="y">The Y component.</param>
+        </member>
+        <member name="M:System.Numerics.Vector2.CopyTo(System.Single[])">
+            <summary>
+            Copies the contents of the vector into the given array.
+            </summary>
+            <param name="array">The destination array.</param>
+        </member>
+        <member name="M:System.Numerics.Vector2.CopyTo(System.Single[],System.Int32)">
+            <summary>
+            Copies the contents of the vector into the given array, starting from the given index.
+            </summary>
+            <exception cref="T:System.ArgumentNullException">If array is null.</exception>
+            <exception cref="T:System.RankException">If array is multidimensional.</exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">If index is greater than end of the array or index is less than zero.</exception>
+            <exception cref="T:System.ArgumentException">If number of elements in source vector is greater than those available in destination array
+            or if there are not enough elements to copy.</exception>
+        </member>
+        <member name="M:System.Numerics.Vector2.Equals(System.Numerics.Vector2)">
+            <summary>
+            Returns a boolean indicating whether the given Vector2 is equal to this Vector2 instance.
+            </summary>
+            <param name="other">The Vector2 to compare this instance to.</param>
+            <returns>True if the other Vector2 is equal to this instance; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Dot(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Returns the dot product of two vectors.
+            </summary>
+            <param name="value1">The first vector.</param>
+            <param name="value2">The second vector.</param>
+            <returns>The dot product.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Min(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Returns a vector whose elements are the minimum of each of the pairs of elements in the two source vectors.
+            </summary>
+            <param name="value1">The first source vector.</param>
+            <param name="value2">The second source vector.</param>
+            <returns>The minimized vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Max(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Returns a vector whose elements are the maximum of each of the pairs of elements in the two source vectors
+            </summary>
+            <param name="value1">The first source vector</param>
+            <param name="value2">The second source vector</param>
+            <returns>The maximized vector</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Abs(System.Numerics.Vector2)">
+            <summary>
+            Returns a vector whose elements are the absolute values of each of the source vector's elements.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The absolute value vector.</returns>        
+        </member>
+        <member name="M:System.Numerics.Vector2.SquareRoot(System.Numerics.Vector2)">
+            <summary>
+            Returns a vector whose elements are the square root of each of the source vector's elements.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The square root vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.op_Addition(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Adds two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The summed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.op_Subtraction(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Subtracts the second vector from the first.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The difference vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.op_Multiply(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Multiplies two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The product vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.op_Multiply(System.Single,System.Numerics.Vector2)">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="left">The scalar value.</param>
+            <param name="right">The source vector.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.op_Multiply(System.Numerics.Vector2,System.Single)">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="left">The source vector.</param>
+            <param name="right">The scalar value.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.op_Division(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Divides the first vector by the second.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The vector resulting from the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.op_Division(System.Numerics.Vector2,System.Single)">
+            <summary>
+            Divides the vector by the given scalar.
+            </summary>
+            <param name="value1">The source vector.</param>
+            <param name="value2">The scalar value.</param>
+            <returns>The result of the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.op_UnaryNegation(System.Numerics.Vector2)">
+            <summary>
+            Negates a given vector.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The negated vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.op_Equality(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Returns a boolean indicating whether the two given vectors are equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if the vectors are equal; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.op_Inequality(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Returns a boolean indicating whether the two given vectors are not equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if the vectors are not equal; False if they are equal.</returns>
+        </member>
+        <member name="T:System.Numerics.Vector3">
+            <summary>
+            A structure encapsulating three single precision floating point values and provides hardware accelerated methods.
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector3.Zero">
+            <summary>
+            Returns the vector (0,0,0).
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector3.One">
+            <summary>
+            Returns the vector (1,1,1).
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector3.UnitX">
+            <summary>
+            Returns the vector (1,0,0).
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector3.UnitY">
+            <summary>
+            Returns the vector (0,1,0).
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector3.UnitZ">
+            <summary>
+            Returns the vector (0,0,1).
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector3.GetHashCode">
+            <summary>
+            Returns the hash code for this instance.
+            </summary>
+            <returns>The hash code.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Equals(System.Object)">
+            <summary>
+            Returns a boolean indicating whether the given Object is equal to this Vector3 instance.
+            </summary>
+            <param name="obj">The Object to compare against.</param>
+            <returns>True if the Object is equal to this Vector3; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.ToString">
+            <summary>
+            Returns a String representing this Vector3 instance.
+            </summary>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.ToString(System.String)">
+            <summary>
+            Returns a String representing this Vector3 instance, using the specified format to format individual elements.
+            </summary>
+            <param name="format">The format of individual elements.</param>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.ToString(System.String,System.IFormatProvider)">
+            <summary>
+            Returns a String representing this Vector3 instance, using the specified format to format individual elements 
+            and the given IFormatProvider.
+            </summary>
+            <param name="format">The format of individual elements.</param>
+            <param name="formatProvider">The format provider to use when formatting elements.</param>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Length">
+            <summary>
+            Returns the length of the vector.
+            </summary>
+            <returns>The vector's length.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.LengthSquared">
+            <summary>
+            Returns the length of the vector squared. This operation is cheaper than Length().
+            </summary>
+            <returns>The vector's length squared.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Distance(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Returns the Euclidean distance between the two given points.
+            </summary>
+            <param name="value1">The first point.</param>
+            <param name="value2">The second point.</param>
+            <returns>The distance.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.DistanceSquared(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Returns the Euclidean distance squared between the two given points.
+            </summary>
+            <param name="value1">The first point.</param>
+            <param name="value2">The second point.</param>
+            <returns>The distance squared.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Normalize(System.Numerics.Vector3)">
+            <summary>
+            Returns a vector with the same direction as the given vector, but with a length of 1.
+            </summary>
+            <param name="value">The vector to normalize.</param>
+            <returns>The normalized vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Cross(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Computes the cross product of two vectors.
+            </summary>
+            <param name="vector1">The first vector.</param>
+            <param name="vector2">The second vector.</param>
+            <returns>The cross product.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Reflect(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Returns the reflection of a vector off a surface that has the specified normal.
+            </summary>
+            <param name="vector">The source vector.</param>
+            <param name="normal">The normal of the surface being reflected off.</param>
+            <returns>The reflected vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Clamp(System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Restricts a vector between a min and max value.
+            </summary>
+            <param name="value1">The source vector.</param>
+            <param name="min">The minimum value.</param>
+            <param name="max">The maximum value.</param>
+            <returns>The restricted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Lerp(System.Numerics.Vector3,System.Numerics.Vector3,System.Single)">
+            <summary>
+            Linearly interpolates between two vectors based on the given weighting.
+            </summary>
+            <param name="value1">The first source vector.</param>
+            <param name="value2">The second source vector.</param>
+            <param name="amount">Value between 0 and 1 indicating the weight of the second source vector.</param>
+            <returns>The interpolated vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Transform(System.Numerics.Vector3,System.Numerics.Matrix4x4)">
+            <summary>
+            Transforms a vector by the given matrix.
+            </summary>
+            <param name="position">The source vector.</param>
+            <param name="matrix">The transformation matrix.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.TransformNormal(System.Numerics.Vector3,System.Numerics.Matrix4x4)">
+            <summary>
+            Transforms a vector normal by the given matrix.
+            </summary>
+            <param name="normal">The source vector.</param>
+            <param name="matrix">The transformation matrix.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Transform(System.Numerics.Vector3,System.Numerics.Quaternion)">
+            <summary>
+            Transforms a vector by the given Quaternion rotation value.
+            </summary>
+            <param name="value">The source vector to be rotated.</param>
+            <param name="rotation">The rotation to apply.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Add(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Adds two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The summed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Subtract(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Subtracts the second vector from the first.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The difference vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Multiply(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Multiplies two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The product vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Multiply(System.Numerics.Vector3,System.Single)">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="left">The source vector.</param>
+            <param name="right">The scalar value.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Multiply(System.Single,System.Numerics.Vector3)">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="left">The scalar value.</param>
+            <param name="right">The source vector.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Divide(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Divides the first vector by the second.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The vector resulting from the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Divide(System.Numerics.Vector3,System.Single)">
+            <summary>
+            Divides the vector by the given scalar.
+            </summary>
+            <param name="left">The source vector.</param>
+            <param name="divisor">The scalar value.</param>
+            <returns>The result of the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Negate(System.Numerics.Vector3)">
+            <summary>
+            Negates a given vector.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The negated vector.</returns>
+        </member>
+        <member name="F:System.Numerics.Vector3.X">
+            <summary>
+            The X component of the vector.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Vector3.Y">
+            <summary>
+            The Y component of the vector.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Vector3.Z">
+            <summary>
+            The Z component of the vector.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector3.#ctor(System.Single)">
+            <summary>
+            Constructs a vector whose elements are all the single specified value.
+            </summary>
+            <param name="value">The element to fill the vector with.</param>
+        </member>
+        <member name="M:System.Numerics.Vector3.#ctor(System.Numerics.Vector2,System.Single)">
+            <summary>
+            Constructs a Vector3 from the given Vector2 and a third value.
+            </summary>
+            <param name="value">The Vector to extract X and Y components from.</param>
+            <param name="z">The Z component.</param>
+        </member>
+        <member name="M:System.Numerics.Vector3.#ctor(System.Single,System.Single,System.Single)">
+            <summary>
+            Constructs a vector with the given individual elements.
+            </summary>
+            <param name="x">The X component.</param>
+            <param name="y">The Y component.</param>
+            <param name="z">The Z component.</param>
+        </member>
+        <member name="M:System.Numerics.Vector3.CopyTo(System.Single[])">
+            <summary>
+            Copies the contents of the vector into the given array.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector3.CopyTo(System.Single[],System.Int32)">
+            <summary>
+            Copies the contents of the vector into the given array, starting from index.
+            </summary>
+            <exception cref="T:System.ArgumentNullException">If array is null.</exception>
+            <exception cref="T:System.RankException">If array is multidimensional.</exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">If index is greater than end of the array or index is less than zero.</exception>
+            <exception cref="T:System.ArgumentException">If number of elements in source vector is greater than those available in destination array.</exception>
+        </member>
+        <member name="M:System.Numerics.Vector3.Equals(System.Numerics.Vector3)">
+            <summary>
+            Returns a boolean indicating whether the given Vector3 is equal to this Vector3 instance.
+            </summary>
+            <param name="other">The Vector3 to compare this instance to.</param>
+            <returns>True if the other Vector3 is equal to this instance; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Dot(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Returns the dot product of two vectors.
+            </summary>
+            <param name="vector1">The first vector.</param>
+            <param name="vector2">The second vector.</param>
+            <returns>The dot product.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Min(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Returns a vector whose elements are the minimum of each of the pairs of elements in the two source vectors.
+            </summary>
+            <param name="value1">The first source vector.</param>
+            <param name="value2">The second source vector.</param>
+            <returns>The minimized vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Max(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Returns a vector whose elements are the maximum of each of the pairs of elements in the two source vectors.
+            </summary>
+            <param name="value1">The first source vector.</param>
+            <param name="value2">The second source vector.</param>
+            <returns>The maximized vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Abs(System.Numerics.Vector3)">
+            <summary>
+            Returns a vector whose elements are the absolute values of each of the source vector's elements.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The absolute value vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.SquareRoot(System.Numerics.Vector3)">
+            <summary>
+            Returns a vector whose elements are the square root of each of the source vector's elements.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The square root vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.op_Addition(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Adds two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The summed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.op_Subtraction(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Subtracts the second vector from the first.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The difference vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.op_Multiply(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Multiplies two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The product vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.op_Multiply(System.Numerics.Vector3,System.Single)">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="left">The source vector.</param>
+            <param name="right">The scalar value.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.op_Multiply(System.Single,System.Numerics.Vector3)">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="left">The scalar value.</param>
+            <param name="right">The source vector.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.op_Division(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Divides the first vector by the second.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The vector resulting from the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.op_Division(System.Numerics.Vector3,System.Single)">
+            <summary>
+            Divides the vector by the given scalar.
+            </summary>
+            <param name="value1">The source vector.</param>
+            <param name="value2">The scalar value.</param>
+            <returns>The result of the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.op_UnaryNegation(System.Numerics.Vector3)">
+            <summary>
+            Negates a given vector.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The negated vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.op_Equality(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Returns a boolean indicating whether the two given vectors are equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if the vectors are equal; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.op_Inequality(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Returns a boolean indicating whether the two given vectors are not equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if the vectors are not equal; False if they are equal.</returns>
+        </member>
+        <member name="T:System.Numerics.Vector4">
+            <summary>
+            A structure encapsulating four single precision floating point values and provides hardware accelerated methods.
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector4.Zero">
+            <summary>
+            Returns the vector (0,0,0,0).
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector4.One">
+            <summary>
+            Returns the vector (1,1,1,1).
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector4.UnitX">
+            <summary>
+            Returns the vector (1,0,0,0).
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector4.UnitY">
+            <summary>
+            Returns the vector (0,1,0,0).
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector4.UnitZ">
+            <summary>
+            Returns the vector (0,0,1,0).
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector4.UnitW">
+            <summary>
+            Returns the vector (0,0,0,1).
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector4.GetHashCode">
+            <summary>
+            Returns the hash code for this instance.
+            </summary>
+            <returns>The hash code.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Equals(System.Object)">
+            <summary>
+            Returns a boolean indicating whether the given Object is equal to this Vector4 instance.
+            </summary>
+            <param name="obj">The Object to compare against.</param>
+            <returns>True if the Object is equal to this Vector4; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.ToString">
+            <summary>
+            Returns a String representing this Vector4 instance.
+            </summary>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.ToString(System.String)">
+            <summary>
+            Returns a String representing this Vector4 instance, using the specified format to format individual elements.
+            </summary>
+            <param name="format">The format of individual elements.</param>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.ToString(System.String,System.IFormatProvider)">
+            <summary>
+            Returns a String representing this Vector4 instance, using the specified format to format individual elements 
+            and the given IFormatProvider.
+            </summary>
+            <param name="format">The format of individual elements.</param>
+            <param name="formatProvider">The format provider to use when formatting elements.</param>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Length">
+            <summary>
+            Returns the length of the vector. This operation is cheaper than Length().
+            </summary>
+            <returns>The vector's length.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.LengthSquared">
+            <summary>
+            Returns the length of the vector squared.
+            </summary>
+            <returns>The vector's length squared.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Distance(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Returns the Euclidean distance between the two given points.
+            </summary>
+            <param name="value1">The first point.</param>
+            <param name="value2">The second point.</param>
+            <returns>The distance.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.DistanceSquared(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Returns the Euclidean distance squared between the two given points.
+            </summary>
+            <param name="value1">The first point.</param>
+            <param name="value2">The second point.</param>
+            <returns>The distance squared.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Normalize(System.Numerics.Vector4)">
+            <summary>
+            Returns a vector with the same direction as the given vector, but with a length of 1.
+            </summary>
+            <param name="vector">The vector to normalize.</param>
+            <returns>The normalized vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Clamp(System.Numerics.Vector4,System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Restricts a vector between a min and max value.
+            </summary>
+            <param name="value1">The source vector.</param>
+            <param name="min">The minimum value.</param>
+            <param name="max">The maximum value.</param>
+            <returns>The restricted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Lerp(System.Numerics.Vector4,System.Numerics.Vector4,System.Single)">
+            <summary>
+            Linearly interpolates between two vectors based on the given weighting.
+            </summary>
+            <param name="value1">The first source vector.</param>
+            <param name="value2">The second source vector.</param>
+            <param name="amount">Value between 0 and 1 indicating the weight of the second source vector.</param>
+            <returns>The interpolated vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Transform(System.Numerics.Vector2,System.Numerics.Matrix4x4)">
+            <summary>
+            Transforms a vector by the given matrix.
+            </summary>
+            <param name="position">The source vector.</param>
+            <param name="matrix">The transformation matrix.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Transform(System.Numerics.Vector3,System.Numerics.Matrix4x4)">
+            <summary>
+            Transforms a vector by the given matrix.
+            </summary>
+            <param name="position">The source vector.</param>
+            <param name="matrix">The transformation matrix.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Transform(System.Numerics.Vector4,System.Numerics.Matrix4x4)">
+            <summary>
+            Transforms a vector by the given matrix.
+            </summary>
+            <param name="vector">The source vector.</param>
+            <param name="matrix">The transformation matrix.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Transform(System.Numerics.Vector2,System.Numerics.Quaternion)">
+            <summary>
+            Transforms a vector by the given Quaternion rotation value.
+            </summary>
+            <param name="value">The source vector to be rotated.</param>
+            <param name="rotation">The rotation to apply.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Transform(System.Numerics.Vector3,System.Numerics.Quaternion)">
+            <summary>
+            Transforms a vector by the given Quaternion rotation value.
+            </summary>
+            <param name="value">The source vector to be rotated.</param>
+            <param name="rotation">The rotation to apply.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Transform(System.Numerics.Vector4,System.Numerics.Quaternion)">
+            <summary>
+            Transforms a vector by the given Quaternion rotation value.
+            </summary>
+            <param name="value">The source vector to be rotated.</param>
+            <param name="rotation">The rotation to apply.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Add(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Adds two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The summed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Subtract(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Subtracts the second vector from the first.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The difference vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Multiply(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Multiplies two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The product vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Multiply(System.Numerics.Vector4,System.Single)">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="left">The source vector.</param>
+            <param name="right">The scalar value.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Multiply(System.Single,System.Numerics.Vector4)">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="left">The scalar value.</param>
+            <param name="right">The source vector.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Divide(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Divides the first vector by the second.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The vector resulting from the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Divide(System.Numerics.Vector4,System.Single)">
+            <summary>
+            Divides the vector by the given scalar.
+            </summary>
+            <param name="left">The source vector.</param>
+            <param name="divisor">The scalar value.</param>
+            <returns>The result of the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Negate(System.Numerics.Vector4)">
+            <summary>
+            Negates a given vector.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The negated vector.</returns>
+        </member>
+        <member name="F:System.Numerics.Vector4.X">
+            <summary>
+            The X component of the vector.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Vector4.Y">
+            <summary>
+            The Y component of the vector.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Vector4.Z">
+            <summary>
+            The Z component of the vector.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Vector4.W">
+            <summary>
+            The W component of the vector.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector4.#ctor(System.Single)">
+            <summary>
+            Constructs a vector whose elements are all the single specified value.
+            </summary>
+            <param name="value">The element to fill the vector with.</param>
+        </member>
+        <member name="M:System.Numerics.Vector4.#ctor(System.Single,System.Single,System.Single,System.Single)">
+            <summary>
+            Constructs a vector with the given individual elements.
+            </summary>
+            <param name="w">W component.</param>
+            <param name="x">X component.</param>
+            <param name="y">Y component.</param>
+            <param name="z">Z component.</param>
+        </member>
+        <member name="M:System.Numerics.Vector4.#ctor(System.Numerics.Vector2,System.Single,System.Single)">
+            <summary>
+            Constructs a Vector4 from the given Vector2 and a Z and W component.
+            </summary>
+            <param name="value">The vector to use as the X and Y components.</param>
+            <param name="z">The Z component.</param>
+            <param name="w">The W component.</param>
+        </member>
+        <member name="M:System.Numerics.Vector4.#ctor(System.Numerics.Vector3,System.Single)">
+            <summary>
+            Constructs a Vector4 from the given Vector3 and a W component.
+            </summary>
+            <param name="value">The vector to use as the X, Y, and Z components.</param>
+            <param name="w">The W component.</param>
+        </member>
+        <member name="M:System.Numerics.Vector4.CopyTo(System.Single[])">
+            <summary>
+            Copies the contents of the vector into the given array.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector4.CopyTo(System.Single[],System.Int32)">
+            <summary>
+            Copies the contents of the vector into the given array, starting from index.
+            </summary>
+            <exception cref="T:System.ArgumentNullException">If array is null.</exception>
+            <exception cref="T:System.RankException">If array is multidimensional.</exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">If index is greater than end of the array or index is less than zero.</exception>
+            <exception cref="T:System.ArgumentException">If number of elements in source vector is greater than those available in destination array.</exception>
+        </member>
+        <member name="M:System.Numerics.Vector4.Equals(System.Numerics.Vector4)">
+            <summary>
+            Returns a boolean indicating whether the given Vector4 is equal to this Vector4 instance.
+            </summary>
+            <param name="other">The Vector4 to compare this instance to.</param>
+            <returns>True if the other Vector4 is equal to this instance; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Dot(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Returns the dot product of two vectors.
+            </summary>
+            <param name="vector1">The first vector.</param>
+            <param name="vector2">The second vector.</param>
+            <returns>The dot product.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Min(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Returns a vector whose elements are the minimum of each of the pairs of elements in the two source vectors.
+            </summary>
+            <param name="value1">The first source vector.</param>
+            <param name="value2">The second source vector.</param>
+            <returns>The minimized vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Max(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Returns a vector whose elements are the maximum of each of the pairs of elements in the two source vectors.
+            </summary>
+            <param name="value1">The first source vector.</param>
+            <param name="value2">The second source vector.</param>
+            <returns>The maximized vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Abs(System.Numerics.Vector4)">
+            <summary>
+            Returns a vector whose elements are the absolute values of each of the source vector's elements.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The absolute value vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.SquareRoot(System.Numerics.Vector4)">
+            <summary>
+            Returns a vector whose elements are the square root of each of the source vector's elements.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The square root vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.op_Addition(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Adds two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The summed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.op_Subtraction(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Subtracts the second vector from the first.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The difference vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.op_Multiply(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Multiplies two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The product vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.op_Multiply(System.Numerics.Vector4,System.Single)">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="left">The source vector.</param>
+            <param name="right">The scalar value.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.op_Multiply(System.Single,System.Numerics.Vector4)">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="left">The scalar value.</param>
+            <param name="right">The source vector.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.op_Division(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Divides the first vector by the second.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The vector resulting from the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.op_Division(System.Numerics.Vector4,System.Single)">
+            <summary>
+            Divides the vector by the given scalar.
+            </summary>
+            <param name="value1">The source vector.</param>
+            <param name="value2">The scalar value.</param>
+            <returns>The result of the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.op_UnaryNegation(System.Numerics.Vector4)">
+            <summary>
+            Negates a given vector.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The negated vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.op_Equality(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Returns a boolean indicating whether the two given vectors are equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if the vectors are equal; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.op_Inequality(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Returns a boolean indicating whether the two given vectors are not equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if the vectors are not equal; False if they are equal.</returns>
+        </member>
+        <member name="P:System.SR.Arg_ArgumentOutOfRangeException">
+            <summary>Index was out of bounds:</summary>
+        </member>
+        <member name="P:System.SR.Arg_ElementsInSourceIsGreaterThanDestination">
+            <summary>Number of elements in source vector is greater than the destination array</summary>
+        </member>
+        <member name="P:System.SR.Arg_NullArgumentNullRef">
+            <summary>The method was called with a null array argument.</summary>
+        </member>
+        <member name="P:System.SR.Arg_TypeNotSupported">
+            <summary>Specified type is not supported</summary>
+        </member>
+        <member name="P:System.SR.Arg_InsufficientNumberOfElements">
+            <summary>At least {0} element(s) are expected in the parameter "{1}".</summary>
+        </member>
+    </members>
+</doc>

--- a/src/System.Reflection.DispatchProxy/src/System.Reflection.DispatchProxy.xml
+++ b/src/System.Reflection.DispatchProxy/src/System.Reflection.DispatchProxy.xml
@@ -4,6 +4,32 @@
         <name>System.Reflection.DispatchProxy</name>
     </assembly>
     <members>
+        <member name="T:System.Reflection.DispatchProxy">
+            <summary>
+            DispatchProxy provides a mechanism for the instantiation of proxy objects and handling of
+            their method dispatch.
+            </summary>
+        </member>
+        <member name="M:System.Reflection.DispatchProxy.Invoke(System.Reflection.MethodInfo,System.Object[])">
+            <summary>
+            Whenever any method on the generated proxy type is called, this method
+            will be invoked to dispatch control.
+            </summary>
+            <param name="targetMethod">The method the caller invoked</param>
+            <param name="args">The arguments the caller passed to the method</param>
+            <returns>The object to return to the caller, or <c>null</c> for void methods</returns>
+        </member>
+        <member name="M:System.Reflection.DispatchProxy.Create``2">
+            <summary>
+            Creates an object instance that derives from class <typeparamref name="TProxy"/>
+            and implements interface <typeparamref name="T"/>.
+            </summary>
+            <typeparam name="T">The interface the proxy should implement.</typeparam>
+            <typeparam name="TProxy">The base class to use for the proxy class.</typeparam>
+            <returns>An object instance that implements <typeparamref name="T"/>.</returns>
+            <exception cref="T:System.ArgumentException"><typeparamref name="T"/> is a class,
+            or <typeparamref name="TProxy"/> is sealed or does not have a parameterless constructor</exception>
+        </member>
         <member name="P:System.SR.BaseType_Cannot_Be_Sealed">
             <summary>The base type '{0}' cannot be sealed.</summary>
         </member>

--- a/src/System.Reflection.DispatchProxy/src/System.Reflection.DispatchProxy.xml
+++ b/src/System.Reflection.DispatchProxy/src/System.Reflection.DispatchProxy.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>System.Reflection.DispatchProxy</name>
+    </assembly>
+    <members>
+        <member name="P:System.SR.BaseType_Cannot_Be_Sealed">
+            <summary>The base type '{0}' cannot be sealed.</summary>
+        </member>
+        <member name="P:System.SR.BaseType_Must_Have_Default_Ctor">
+            <summary>The base type '{0}' must have a public parameterless constructor.</summary>
+        </member>
+        <member name="P:System.SR.InterfaceType_Must_Be_Interface">
+            <summary>The type '{0}' must be an interface, not a class.</summary>
+        </member>
+        <member name="P:System.SR.BaseType_Cannot_Be_Abstract">
+            <summary>The base type '{0}' cannot be abstract.</summary>
+        </member>
+        <member name="P:System.SR.PlatformNotSupported_ReflectionDispatchProxy">
+            <summary>This operation is not supported on .NET Standard as Reflection.Emit is not available.</summary>
+        </member>
+    </members>
+</doc>

--- a/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.ilproj
+++ b/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.ilproj
@@ -9,7 +9,6 @@
     <DebugOptimization>IMPL</DebugOptimization>
     <DebugOptimization Condition="'$(Configuration)' == 'Release'">OPT</DebugOptimization>
     <CoreCompileDependsOn>$(CoreCompileDependsOn);GenerateVersionFile</CoreCompileDependsOn>
-    <DocumentationFile>$(MSBuildThisFileDirectory)System.Runtime.CompilerServices.Unsafe.xml</DocumentationFile>
     <IlasmFlags>$(IlasmFlags) -DEBUG=$(DebugOptimization)</IlasmFlags>
     <PackageDescription>Provides the System.Runtime.CompilerServices.Unsafe class, which provides generic, low-level functionality for manipulating pointers.
 

--- a/src/System.Runtime.CompilerServices.Unsafe/ver/System.Runtime.CompilerServices.Unsafe.xml
+++ b/src/System.Runtime.CompilerServices.Unsafe/ver/System.Runtime.CompilerServices.Unsafe.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>System.Runtime.CompilerServices.Unsafe</name>
+    </assembly>
+    <members>
+    </members>
+</doc>

--- a/src/System.Runtime.CompilerServices.Unsafe/ver/System.Runtime.CompilerServices.Unsafe.xml
+++ b/src/System.Runtime.CompilerServices.Unsafe/ver/System.Runtime.CompilerServices.Unsafe.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0"?>
-<doc>
-    <assembly>
-        <name>System.Runtime.CompilerServices.Unsafe</name>
-    </assembly>
-    <members>
-    </members>
-</doc>

--- a/src/System.Threading.Tasks.Extensions/src/System.Threading.Tasks.Extensions.xml
+++ b/src/System.Threading.Tasks.Extensions/src/System.Threading.Tasks.Extensions.xml
@@ -1,0 +1,545 @@
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>System.Threading.Tasks.Extensions</name>
+    </assembly>
+    <members>
+        <member name="T:System.Runtime.CompilerServices.AsyncMethodBuilderAttribute">
+            <summary>
+            Indicates the type of the async method builder that should be used by a language compiler to
+            build the attributed type when used as the return type of an async method.
+            </summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.AsyncMethodBuilderAttribute.#ctor(System.Type)">
+            <summary>Initializes the <see cref="T:System.Runtime.CompilerServices.AsyncMethodBuilderAttribute"/>.</summary>
+            <param name="builderType">The <see cref="T:System.Type"/> of the associated builder.</param>
+        </member>
+        <member name="P:System.Runtime.CompilerServices.AsyncMethodBuilderAttribute.BuilderType">
+            <summary>Gets the <see cref="T:System.Type"/> of the associated builder.</summary>
+        </member>
+        <member name="T:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder">
+            <summary>Represents a builder for asynchronous methods that return a <see cref="T:System.Threading.Tasks.ValueTask"/>.</summary>
+        </member>
+        <member name="F:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder._methodBuilder">
+            <summary>The <see cref="T:System.Runtime.CompilerServices.AsyncTaskMethodBuilder"/> to which most operations are delegated.</summary>
+        </member>
+        <member name="F:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder._haveResult">
+            <summary>true if completed synchronously and successfully; otherwise, false.</summary>
+        </member>
+        <member name="F:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder._useBuilder">
+            <summary>true if the builder should be used for setting/getting the result; otherwise, false.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder.Create">
+            <summary>Creates an instance of the <see cref="T:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder"/> struct.</summary>
+            <returns>The initialized instance.</returns>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder.Start``1(``0@)">
+            <summary>Begins running the builder with the associated state machine.</summary>
+            <typeparam name="TStateMachine">The type of the state machine.</typeparam>
+            <param name="stateMachine">The state machine instance, passed by reference.</param>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder.SetStateMachine(System.Runtime.CompilerServices.IAsyncStateMachine)">
+            <summary>Associates the builder with the specified state machine.</summary>
+            <param name="stateMachine">The state machine instance to associate with the builder.</param>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder.SetResult">
+            <summary>Marks the task as successfully completed.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder.SetException(System.Exception)">
+            <summary>Marks the task as failed and binds the specified exception to the task.</summary>
+            <param name="exception">The exception to bind to the task.</param>
+        </member>
+        <member name="P:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder.Task">
+            <summary>Gets the task for this builder.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder.AwaitOnCompleted``2(``0@,``1@)">
+            <summary>Schedules the state machine to proceed to the next action when the specified awaiter completes.</summary>
+            <typeparam name="TAwaiter">The type of the awaiter.</typeparam>
+            <typeparam name="TStateMachine">The type of the state machine.</typeparam>
+            <param name="awaiter">The awaiter.</param>
+            <param name="stateMachine">The state machine.</param>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder.AwaitUnsafeOnCompleted``2(``0@,``1@)">
+            <summary>Schedules the state machine to proceed to the next action when the specified awaiter completes.</summary>
+            <typeparam name="TAwaiter">The type of the awaiter.</typeparam>
+            <typeparam name="TStateMachine">The type of the state machine.</typeparam>
+            <param name="awaiter">The awaiter.</param>
+            <param name="stateMachine">The state machine.</param>
+        </member>
+        <member name="T:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1">
+            <summary>Represents a builder for asynchronous methods that returns a <see cref="T:System.Threading.Tasks.ValueTask`1"/>.</summary>
+            <typeparam name="TResult">The type of the result.</typeparam>
+        </member>
+        <member name="F:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1._methodBuilder">
+            <summary>The <see cref="T:System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1"/> to which most operations are delegated.</summary>
+        </member>
+        <member name="F:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1._result">
+            <summary>The result for this builder, if it's completed before any awaits occur.</summary>
+        </member>
+        <member name="F:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1._haveResult">
+            <summary>true if <see cref="F:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1._result"/> contains the synchronous result for the async method; otherwise, false.</summary>
+        </member>
+        <member name="F:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1._useBuilder">
+            <summary>true if the builder should be used for setting/getting the result; otherwise, false.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1.Create">
+            <summary>Creates an instance of the <see cref="T:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1"/> struct.</summary>
+            <returns>The initialized instance.</returns>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1.Start``1(``0@)">
+            <summary>Begins running the builder with the associated state machine.</summary>
+            <typeparam name="TStateMachine">The type of the state machine.</typeparam>
+            <param name="stateMachine">The state machine instance, passed by reference.</param>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1.SetStateMachine(System.Runtime.CompilerServices.IAsyncStateMachine)">
+            <summary>Associates the builder with the specified state machine.</summary>
+            <param name="stateMachine">The state machine instance to associate with the builder.</param>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1.SetResult(`0)">
+            <summary>Marks the task as successfully completed.</summary>
+            <param name="result">The result to use to complete the task.</param>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1.SetException(System.Exception)">
+            <summary>Marks the task as failed and binds the specified exception to the task.</summary>
+            <param name="exception">The exception to bind to the task.</param>
+        </member>
+        <member name="P:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1.Task">
+            <summary>Gets the task for this builder.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1.AwaitOnCompleted``2(``0@,``1@)">
+            <summary>Schedules the state machine to proceed to the next action when the specified awaiter completes.</summary>
+            <typeparam name="TAwaiter">The type of the awaiter.</typeparam>
+            <typeparam name="TStateMachine">The type of the state machine.</typeparam>
+            <param name="awaiter">the awaiter</param>
+            <param name="stateMachine">The state machine.</param>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1.AwaitUnsafeOnCompleted``2(``0@,``1@)">
+            <summary>Schedules the state machine to proceed to the next action when the specified awaiter completes.</summary>
+            <typeparam name="TAwaiter">The type of the awaiter.</typeparam>
+            <typeparam name="TStateMachine">The type of the state machine.</typeparam>
+            <param name="awaiter">the awaiter</param>
+            <param name="stateMachine">The state machine.</param>
+        </member>
+        <member name="T:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable">
+            <summary>Provides an awaitable type that enables configured awaits on a <see cref="T:System.Threading.Tasks.ValueTask"/>.</summary>
+        </member>
+        <member name="F:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable._value">
+            <summary>The wrapped <see cref="T:System.Threading.Tasks.Task"/>.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable.#ctor(System.Threading.Tasks.ValueTask)">
+            <summary>Initializes the awaitable.</summary>
+            <param name="value">The wrapped <see cref="T:System.Threading.Tasks.ValueTask"/>.</param>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable.GetAwaiter">
+            <summary>Returns an awaiter for this <see cref="T:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable"/> instance.</summary>
+        </member>
+        <member name="T:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable.ConfiguredValueTaskAwaiter">
+            <summary>Provides an awaiter for a <see cref="T:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable"/>.</summary>
+        </member>
+        <member name="F:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable.ConfiguredValueTaskAwaiter._value">
+            <summary>The value being awaited.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable.ConfiguredValueTaskAwaiter.#ctor(System.Threading.Tasks.ValueTask)">
+            <summary>Initializes the awaiter.</summary>
+            <param name="value">The value to be awaited.</param>
+        </member>
+        <member name="P:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable.ConfiguredValueTaskAwaiter.IsCompleted">
+            <summary>Gets whether the <see cref="T:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable"/> has completed.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable.ConfiguredValueTaskAwaiter.GetResult">
+            <summary>Gets the result of the ValueTask.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable.ConfiguredValueTaskAwaiter.OnCompleted(System.Action)">
+            <summary>Schedules the continuation action for the <see cref="T:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable"/>.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable.ConfiguredValueTaskAwaiter.UnsafeOnCompleted(System.Action)">
+            <summary>Schedules the continuation action for the <see cref="T:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable"/>.</summary>
+        </member>
+        <member name="T:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1">
+            <summary>Provides an awaitable type that enables configured awaits on a <see cref="T:System.Threading.Tasks.ValueTask`1"/>.</summary>
+            <typeparam name="TResult">The type of the result produced.</typeparam>
+        </member>
+        <member name="F:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1._value">
+            <summary>The wrapped <see cref="T:System.Threading.Tasks.ValueTask`1"/>.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1.#ctor(System.Threading.Tasks.ValueTask{`0})">
+            <summary>Initializes the awaitable.</summary>
+            <param name="value">The wrapped <see cref="T:System.Threading.Tasks.ValueTask`1"/>.</param>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1.GetAwaiter">
+            <summary>Returns an awaiter for this <see cref="T:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1"/> instance.</summary>
+        </member>
+        <member name="T:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1.ConfiguredValueTaskAwaiter">
+            <summary>Provides an awaiter for a <see cref="T:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1"/>.</summary>
+        </member>
+        <member name="F:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1.ConfiguredValueTaskAwaiter._value">
+            <summary>The value being awaited.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1.ConfiguredValueTaskAwaiter.#ctor(System.Threading.Tasks.ValueTask{`0})">
+            <summary>Initializes the awaiter.</summary>
+            <param name="value">The value to be awaited.</param>
+        </member>
+        <member name="P:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1.ConfiguredValueTaskAwaiter.IsCompleted">
+            <summary>Gets whether the <see cref="T:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1"/> has completed.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1.ConfiguredValueTaskAwaiter.GetResult">
+            <summary>Gets the result of the ValueTask.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1.ConfiguredValueTaskAwaiter.OnCompleted(System.Action)">
+            <summary>Schedules the continuation action for the <see cref="T:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1"/>.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1.ConfiguredValueTaskAwaiter.UnsafeOnCompleted(System.Action)">
+            <summary>Schedules the continuation action for the <see cref="T:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1"/>.</summary>
+        </member>
+        <member name="T:System.Runtime.CompilerServices.ValueTaskAwaiter">
+            <summary>Provides an awaiter for a <see cref="T:System.Threading.Tasks.ValueTask"/>.</summary>
+        </member>
+        <member name="F:System.Runtime.CompilerServices.ValueTaskAwaiter.s_invokeActionDelegate">
+            <summary>Shim used to invoke an <see cref="T:System.Action"/> passed as the state argument to a <see cref="T:System.Action`1"/>.</summary>
+        </member>
+        <member name="F:System.Runtime.CompilerServices.ValueTaskAwaiter._value">
+            <summary>The value being awaited.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ValueTaskAwaiter.#ctor(System.Threading.Tasks.ValueTask)">
+            <summary>Initializes the awaiter.</summary>
+            <param name="value">The value to be awaited.</param>
+        </member>
+        <member name="P:System.Runtime.CompilerServices.ValueTaskAwaiter.IsCompleted">
+            <summary>Gets whether the <see cref="T:System.Threading.Tasks.ValueTask"/> has completed.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ValueTaskAwaiter.GetResult">
+            <summary>Gets the result of the ValueTask.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ValueTaskAwaiter.OnCompleted(System.Action)">
+            <summary>Schedules the continuation action for this ValueTask.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ValueTaskAwaiter.UnsafeOnCompleted(System.Action)">
+            <summary>Schedules the continuation action for this ValueTask.</summary>
+        </member>
+        <member name="T:System.Runtime.CompilerServices.ValueTaskAwaiter`1">
+            <summary>Provides an awaiter for a <see cref="T:System.Threading.Tasks.ValueTask`1"/>.</summary>
+        </member>
+        <member name="F:System.Runtime.CompilerServices.ValueTaskAwaiter`1._value">
+            <summary>The value being awaited.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ValueTaskAwaiter`1.#ctor(System.Threading.Tasks.ValueTask{`0})">
+            <summary>Initializes the awaiter.</summary>
+            <param name="value">The value to be awaited.</param>
+        </member>
+        <member name="P:System.Runtime.CompilerServices.ValueTaskAwaiter`1.IsCompleted">
+            <summary>Gets whether the <see cref="T:System.Threading.Tasks.ValueTask`1"/> has completed.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ValueTaskAwaiter`1.GetResult">
+            <summary>Gets the result of the ValueTask.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ValueTaskAwaiter`1.OnCompleted(System.Action)">
+            <summary>Schedules the continuation action for this ValueTask.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ValueTaskAwaiter`1.UnsafeOnCompleted(System.Action)">
+            <summary>Schedules the continuation action for this ValueTask.</summary>
+        </member>
+        <member name="T:System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags">
+            <summary>
+            Flags passed from <see cref="T:System.Threading.Tasks.ValueTask"/> and <see cref="T:System.Threading.Tasks.ValueTask`1"/> to
+            <see cref="M:System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted(System.Action{System.Object},System.Object,System.Int16,System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags)"/> and <see cref="M:System.Threading.Tasks.Sources.IValueTaskSource`1.OnCompleted(System.Action{System.Object},System.Object,System.Int16,System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags)"/>
+            to control behavior.
+            </summary>
+        </member>
+        <member name="F:System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags.None">
+            <summary>
+            No requirements are placed on how the continuation is invoked.
+            </summary>
+        </member>
+        <member name="F:System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags.UseSchedulingContext">
+            <summary>
+            Set if OnCompleted should capture the current scheduling context (e.g. SynchronizationContext)
+            and use it when queueing the continuation for execution.  If this is not set, the implementation
+            may choose to execute the continuation in an arbitrary location.
+            </summary>
+        </member>
+        <member name="F:System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags.FlowExecutionContext">
+            <summary>
+            Set if OnCompleted should capture the current ExecutionContext and use it to run the continuation.
+            </summary>
+        </member>
+        <member name="T:System.Threading.Tasks.Sources.ValueTaskSourceStatus">
+            <summary>Indicates the status of an <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource"/> or <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource`1"/>.</summary>
+        </member>
+        <member name="F:System.Threading.Tasks.Sources.ValueTaskSourceStatus.Pending">
+            <summary>The operation has not yet completed.</summary>
+        </member>
+        <member name="F:System.Threading.Tasks.Sources.ValueTaskSourceStatus.Succeeded">
+            <summary>The operation completed successfully.</summary>
+        </member>
+        <member name="F:System.Threading.Tasks.Sources.ValueTaskSourceStatus.Faulted">
+            <summary>The operation completed with an error.</summary>
+        </member>
+        <member name="F:System.Threading.Tasks.Sources.ValueTaskSourceStatus.Canceled">
+            <summary>The operation completed due to cancellation.</summary>
+        </member>
+        <member name="T:System.Threading.Tasks.Sources.IValueTaskSource">
+            <summary>Represents an object that can be wrapped by a <see cref="T:System.Threading.Tasks.ValueTask"/>.</summary>
+        </member>
+        <member name="M:System.Threading.Tasks.Sources.IValueTaskSource.GetStatus(System.Int16)">
+            <summary>Gets the status of the current operation.</summary>
+            <param name="token">Opaque value that was provided to the <see cref="T:System.Threading.Tasks.ValueTask"/>'s constructor.</param>
+        </member>
+        <member name="M:System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted(System.Action{System.Object},System.Object,System.Int16,System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags)">
+            <summary>Schedules the continuation action for this <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource"/>.</summary>
+            <param name="continuation">The continuation to invoke when the operation has completed.</param>
+            <param name="state">The state object to pass to <paramref name="continuation"/> when it's invoked.</param>
+            <param name="token">Opaque value that was provided to the <see cref="T:System.Threading.Tasks.ValueTask"/>'s constructor.</param>
+            <param name="flags">The flags describing the behavior of the continuation.</param>
+        </member>
+        <member name="M:System.Threading.Tasks.Sources.IValueTaskSource.GetResult(System.Int16)">
+            <summary>Gets the result of the <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource"/>.</summary>
+            <param name="token">Opaque value that was provided to the <see cref="T:System.Threading.Tasks.ValueTask"/>'s constructor.</param>
+        </member>
+        <member name="T:System.Threading.Tasks.Sources.IValueTaskSource`1">
+            <summary>Represents an object that can be wrapped by a <see cref="T:System.Threading.Tasks.ValueTask`1"/>.</summary>
+            <typeparam name="TResult">Specifies the type of data returned from the object.</typeparam>
+        </member>
+        <member name="M:System.Threading.Tasks.Sources.IValueTaskSource`1.GetStatus(System.Int16)">
+            <summary>Gets the status of the current operation.</summary>
+            <param name="token">Opaque value that was provided to the <see cref="T:System.Threading.Tasks.ValueTask"/>'s constructor.</param>
+        </member>
+        <member name="M:System.Threading.Tasks.Sources.IValueTaskSource`1.OnCompleted(System.Action{System.Object},System.Object,System.Int16,System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags)">
+            <summary>Schedules the continuation action for this <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource`1"/>.</summary>
+            <param name="continuation">The continuation to invoke when the operation has completed.</param>
+            <param name="state">The state object to pass to <paramref name="continuation"/> when it's invoked.</param>
+            <param name="token">Opaque value that was provided to the <see cref="T:System.Threading.Tasks.ValueTask"/>'s constructor.</param>
+            <param name="flags">The flags describing the behavior of the continuation.</param>
+        </member>
+        <member name="M:System.Threading.Tasks.Sources.IValueTaskSource`1.GetResult(System.Int16)">
+            <summary>Gets the result of the <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource`1"/>.</summary>
+            <param name="token">Opaque value that was provided to the <see cref="T:System.Threading.Tasks.ValueTask"/>'s constructor.</param>
+        </member>
+        <member name="T:System.Threading.Tasks.ValueTask">
+            <summary>Provides an awaitable result of an asynchronous operation.</summary>
+            <remarks>
+            <see cref="T:System.Threading.Tasks.ValueTask"/>s are meant to be directly awaited.  To do more complicated operations with them, a <see cref="T:System.Threading.Tasks.Task"/>
+            should be extracted using <see cref="M:System.Threading.Tasks.ValueTask.AsTask"/>.  Such operations might include caching an instance to be awaited later,
+            registering multiple continuations with a single operation, awaiting the same task multiple times, and using combinators over
+            multiple operations.
+            </remarks>
+        </member>
+        <member name="F:System.Threading.Tasks.ValueTask.s_canceledTask">
+            <summary>A task canceled using `new CancellationToken(true)`.</summary>
+        </member>
+        <member name="P:System.Threading.Tasks.ValueTask.CompletedTask">
+            <summary>A successfully completed task.</summary>
+        </member>
+        <member name="F:System.Threading.Tasks.ValueTask._obj">
+            <summary>null if representing a successful synchronous completion, otherwise a <see cref="T:System.Threading.Tasks.Task"/> or a <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource"/>.</summary>
+        </member>
+        <member name="F:System.Threading.Tasks.ValueTask._token">
+            <summary>Opaque value passed through to the <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource"/>.</summary>
+        </member>
+        <member name="F:System.Threading.Tasks.ValueTask._continueOnCapturedContext">
+            <summary>true to continue on the capture context; otherwise, true.</summary>
+            <remarks>Stored in the <see cref="T:System.Threading.Tasks.ValueTask"/> rather than in the configured awaiter to utilize otherwise padding space.</remarks>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask.#ctor(System.Threading.Tasks.Task)">
+            <summary>Initialize the <see cref="T:System.Threading.Tasks.ValueTask"/> with a <see cref="T:System.Threading.Tasks.Task"/> that represents the operation.</summary>
+            <param name="task">The task.</param>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask.#ctor(System.Threading.Tasks.Sources.IValueTaskSource,System.Int16)">
+            <summary>Initialize the <see cref="T:System.Threading.Tasks.ValueTask"/> with a <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource"/> object that represents the operation.</summary>
+            <param name="source">The source.</param>
+            <param name="token">Opaque value passed through to the <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource"/>.</param>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask.GetHashCode">
+            <summary>Returns the hash code for this instance.</summary>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask.Equals(System.Object)">
+            <summary>Returns a value indicating whether this value is equal to a specified <see cref="T:System.Object"/>.</summary>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask.Equals(System.Threading.Tasks.ValueTask)">
+            <summary>Returns a value indicating whether this value is equal to a specified <see cref="T:System.Threading.Tasks.ValueTask"/> value.</summary>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask.op_Equality(System.Threading.Tasks.ValueTask,System.Threading.Tasks.ValueTask)">
+            <summary>Returns a value indicating whether two <see cref="T:System.Threading.Tasks.ValueTask"/> values are equal.</summary>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask.op_Inequality(System.Threading.Tasks.ValueTask,System.Threading.Tasks.ValueTask)">
+            <summary>Returns a value indicating whether two <see cref="T:System.Threading.Tasks.ValueTask"/> values are not equal.</summary>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask.AsTask">
+            <summary>
+            Gets a <see cref="T:System.Threading.Tasks.Task"/> object to represent this ValueTask.
+            </summary>
+            <remarks>
+            It will either return the wrapped task object if one exists, or it'll
+            manufacture a new task object to represent the result.
+            </remarks>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask.Preserve">
+            <summary>Gets a <see cref="T:System.Threading.Tasks.ValueTask"/> that may be used at any point in the future.</summary>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask.GetTaskForValueTaskSource(System.Threading.Tasks.Sources.IValueTaskSource)">
+            <summary>Creates a <see cref="T:System.Threading.Tasks.Task"/> to represent the <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource"/>.</summary>
+            <remarks>
+            The <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource"/> is passed in rather than reading and casting <see cref="F:System.Threading.Tasks.ValueTask._obj"/>
+            so that the caller can pass in an object it's already validated.
+            </remarks>
+        </member>
+        <member name="T:System.Threading.Tasks.ValueTask.ValueTaskSourceAsTask">
+            <summary>Type used to create a <see cref="T:System.Threading.Tasks.Task"/> to represent a <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource"/>.</summary>
+        </member>
+        <member name="F:System.Threading.Tasks.ValueTask.ValueTaskSourceAsTask._source">
+            <summary>The associated <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource"/>.</summary>
+        </member>
+        <member name="F:System.Threading.Tasks.ValueTask.ValueTaskSourceAsTask._token">
+            <summary>The token to pass through to operations on <see cref="F:System.Threading.Tasks.ValueTask.ValueTaskSourceAsTask._source"/></summary>
+        </member>
+        <member name="P:System.Threading.Tasks.ValueTask.IsCompleted">
+            <summary>Gets whether the <see cref="T:System.Threading.Tasks.ValueTask"/> represents a completed operation.</summary>
+        </member>
+        <member name="P:System.Threading.Tasks.ValueTask.IsCompletedSuccessfully">
+            <summary>Gets whether the <see cref="T:System.Threading.Tasks.ValueTask"/> represents a successfully completed operation.</summary>
+        </member>
+        <member name="P:System.Threading.Tasks.ValueTask.IsFaulted">
+            <summary>Gets whether the <see cref="T:System.Threading.Tasks.ValueTask"/> represents a failed operation.</summary>
+        </member>
+        <member name="P:System.Threading.Tasks.ValueTask.IsCanceled">
+            <summary>Gets whether the <see cref="T:System.Threading.Tasks.ValueTask"/> represents a canceled operation.</summary>
+            <remarks>
+            If the <see cref="T:System.Threading.Tasks.ValueTask"/> is backed by a result or by a <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource"/>,
+            this will always return false.  If it's backed by a <see cref="T:System.Threading.Tasks.Task"/>, it'll return the
+            value of the task's <see cref="P:System.Threading.Tasks.Task.IsCanceled"/> property.
+            </remarks>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask.ThrowIfCompletedUnsuccessfully">
+            <summary>Throws the exception that caused the <see cref="T:System.Threading.Tasks.ValueTask"/> to fail.  If it completed successfully, nothing is thrown.</summary>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask.GetAwaiter">
+            <summary>Gets an awaiter for this <see cref="T:System.Threading.Tasks.ValueTask"/>.</summary>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask.ConfigureAwait(System.Boolean)">
+            <summary>Configures an awaiter for this <see cref="T:System.Threading.Tasks.ValueTask"/>.</summary>
+            <param name="continueOnCapturedContext">
+            true to attempt to marshal the continuation back to the captured context; otherwise, false.
+            </param>
+        </member>
+        <member name="T:System.Threading.Tasks.ValueTask`1">
+            <summary>Provides a value type that can represent a synchronously available value or a task object.</summary>
+            <typeparam name="TResult">Specifies the type of the result.</typeparam>
+            <remarks>
+            <see cref="T:System.Threading.Tasks.ValueTask`1"/>s are meant to be directly awaited.  To do more complicated operations with them, a <see cref="T:System.Threading.Tasks.Task"/>
+            should be extracted using <see cref="M:System.Threading.Tasks.ValueTask`1.AsTask"/> or <see cref="M:System.Threading.Tasks.ValueTask`1.Preserve"/>.  Such operations might include caching an instance to
+            be awaited later, registering multiple continuations with a single operation, awaiting the same task multiple times, and using
+            combinators over multiple operations.
+            </remarks>
+        </member>
+        <member name="F:System.Threading.Tasks.ValueTask`1.s_canceledTask">
+            <summary>A task canceled using `new CancellationToken(true)`. Lazily created only when first needed.</summary>
+        </member>
+        <member name="F:System.Threading.Tasks.ValueTask`1._obj">
+            <summary>null if <see cref="F:System.Threading.Tasks.ValueTask`1._result"/> has the result, otherwise a <see cref="T:System.Threading.Tasks.Task`1"/> or a <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource`1"/>.</summary>
+        </member>
+        <member name="F:System.Threading.Tasks.ValueTask`1._result">
+            <summary>The result to be used if the operation completed successfully synchronously.</summary>
+        </member>
+        <member name="F:System.Threading.Tasks.ValueTask`1._token">
+            <summary>Opaque value passed through to the <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource`1"/>.</summary>
+        </member>
+        <member name="F:System.Threading.Tasks.ValueTask`1._continueOnCapturedContext">
+            <summary>true to continue on the captured context; otherwise, false.</summary>
+            <remarks>Stored in the <see cref="T:System.Threading.Tasks.ValueTask`1"/> rather than in the configured awaiter to utilize otherwise padding space.</remarks>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask`1.#ctor(`0)">
+            <summary>Initialize the <see cref="T:System.Threading.Tasks.ValueTask`1"/> with a <typeparamref name="TResult"/> result value.</summary>
+            <param name="result">The result.</param>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask`1.#ctor(System.Threading.Tasks.Task{`0})">
+            <summary>Initialize the <see cref="T:System.Threading.Tasks.ValueTask`1"/> with a <see cref="T:System.Threading.Tasks.Task`1"/> that represents the operation.</summary>
+            <param name="task">The task.</param>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask`1.#ctor(System.Threading.Tasks.Sources.IValueTaskSource{`0},System.Int16)">
+            <summary>Initialize the <see cref="T:System.Threading.Tasks.ValueTask`1"/> with a <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource`1"/> object that represents the operation.</summary>
+            <param name="source">The source.</param>
+            <param name="token">Opaque value passed through to the <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource"/>.</param>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask`1.#ctor(System.Object,`0,System.Int16,System.Boolean)">
+            <summary>Non-verified initialization of the struct to the specified values.</summary>
+            <param name="obj">The object.</param>
+            <param name="result">The result.</param>
+            <param name="token">The token.</param>
+            <param name="continueOnCapturedContext">true to continue on captured context; otherwise, false.</param>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask`1.GetHashCode">
+            <summary>Returns the hash code for this instance.</summary>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask`1.Equals(System.Object)">
+            <summary>Returns a value indicating whether this value is equal to a specified <see cref="T:System.Object"/>.</summary>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask`1.Equals(System.Threading.Tasks.ValueTask{`0})">
+            <summary>Returns a value indicating whether this value is equal to a specified <see cref="T:System.Threading.Tasks.ValueTask`1"/> value.</summary>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask`1.op_Equality(System.Threading.Tasks.ValueTask{`0},System.Threading.Tasks.ValueTask{`0})">
+            <summary>Returns a value indicating whether two <see cref="T:System.Threading.Tasks.ValueTask`1"/> values are equal.</summary>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask`1.op_Inequality(System.Threading.Tasks.ValueTask{`0},System.Threading.Tasks.ValueTask{`0})">
+            <summary>Returns a value indicating whether two <see cref="T:System.Threading.Tasks.ValueTask`1"/> values are not equal.</summary>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask`1.AsTask">
+            <summary>
+            Gets a <see cref="T:System.Threading.Tasks.Task`1"/> object to represent this ValueTask.
+            </summary>
+            <remarks>
+            It will either return the wrapped task object if one exists, or it'll
+            manufacture a new task object to represent the result.
+            </remarks>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask`1.Preserve">
+            <summary>Gets a <see cref="T:System.Threading.Tasks.ValueTask`1"/> that may be used at any point in the future.</summary>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask`1.GetTaskForValueTaskSource(System.Threading.Tasks.Sources.IValueTaskSource{`0})">
+            <summary>Creates a <see cref="T:System.Threading.Tasks.Task`1"/> to represent the <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource`1"/>.</summary>
+            <remarks>
+            The <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource`1"/> is passed in rather than reading and casting <see cref="F:System.Threading.Tasks.ValueTask`1._obj"/>
+            so that the caller can pass in an object it's already validated.
+            </remarks>
+        </member>
+        <member name="T:System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask">
+            <summary>Type used to create a <see cref="T:System.Threading.Tasks.Task`1"/> to represent a <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource`1"/>.</summary>
+        </member>
+        <member name="F:System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask._source">
+            <summary>The associated <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource"/>.</summary>
+        </member>
+        <member name="F:System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask._token">
+            <summary>The token to pass through to operations on <see cref="F:System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask._source"/></summary>
+        </member>
+        <member name="P:System.Threading.Tasks.ValueTask`1.IsCompleted">
+            <summary>Gets whether the <see cref="T:System.Threading.Tasks.ValueTask`1"/> represents a completed operation.</summary>
+        </member>
+        <member name="P:System.Threading.Tasks.ValueTask`1.IsCompletedSuccessfully">
+            <summary>Gets whether the <see cref="T:System.Threading.Tasks.ValueTask`1"/> represents a successfully completed operation.</summary>
+        </member>
+        <member name="P:System.Threading.Tasks.ValueTask`1.IsFaulted">
+            <summary>Gets whether the <see cref="T:System.Threading.Tasks.ValueTask`1"/> represents a failed operation.</summary>
+        </member>
+        <member name="P:System.Threading.Tasks.ValueTask`1.IsCanceled">
+            <summary>Gets whether the <see cref="T:System.Threading.Tasks.ValueTask`1"/> represents a canceled operation.</summary>
+            <remarks>
+            If the <see cref="T:System.Threading.Tasks.ValueTask`1"/> is backed by a result or by a <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource`1"/>,
+            this will always return false.  If it's backed by a <see cref="T:System.Threading.Tasks.Task"/>, it'll return the
+            value of the task's <see cref="P:System.Threading.Tasks.Task.IsCanceled"/> property.
+            </remarks>
+        </member>
+        <member name="P:System.Threading.Tasks.ValueTask`1.Result">
+            <summary>Gets the result.</summary>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask`1.GetAwaiter">
+            <summary>Gets an awaiter for this <see cref="T:System.Threading.Tasks.ValueTask`1"/>.</summary>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask`1.ConfigureAwait(System.Boolean)">
+            <summary>Configures an awaiter for this <see cref="T:System.Threading.Tasks.ValueTask`1"/>.</summary>
+            <param name="continueOnCapturedContext">
+            true to attempt to marshal the continuation back to the captured context; otherwise, false.
+            </param>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask`1.ToString">
+            <summary>Gets a string-representation of this <see cref="T:System.Threading.Tasks.ValueTask`1"/>.</summary>
+        </member>
+    </members>
+</doc>

--- a/src/System.Xml.XPath.XmlDocument/src/System.Xml.XPath.XmlDocument.xml
+++ b/src/System.Xml.XPath.XmlDocument/src/System.Xml.XPath.XmlDocument.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>System.Xml.XPath.XmlDocument</name>
+    </assembly>
+    <members>
+        <member name="T:System.Xml.XmlDocumentXPathExtensions">
+            <summary>
+            Provides extension methods for the XmlDocument and XmlNode for document navigation.
+            </summary>
+        </member>
+        <member name="M:System.Xml.XmlDocumentXPathExtensions.SelectNodes(System.Xml.XmlNode,System.String)">
+            <summary>
+            Selects a list of nodes matching the specified XPath expression.
+            </summary>
+            <param name="node">The node where the navigator is initially positioned.</param>
+            <param name="xpath">The XPath expression to match.</param>
+            <returns>A collection of nodes that match the specified XPath expression.</returns>
+        </member>
+        <member name="M:System.Xml.XmlDocumentXPathExtensions.SelectNodes(System.Xml.XmlNode,System.String,System.Xml.XmlNamespaceManager)">
+            <summary>
+            Selects a list of nodes matching the specified XPath expression. Any prefixes found in the XPath expression are resolved using the supplied namespace manager.
+            </summary>
+            <param name="node">The node where the navigator is initially positioned.</param>
+            <param name="xpath">The XPath expression to match.</param>
+            <param name="nsmgr">A namespace manager to resolve XPath expression prefix namespaces.</param>
+            <returns>A collection of nodes that match the specified XPath expression.</returns>
+        </member>
+        <member name="M:System.Xml.XmlDocumentXPathExtensions.SelectSingleNode(System.Xml.XmlNode,System.String)">
+            <summary>
+            Selects the first node that matches the XPath expression.
+            </summary>
+            <param name="node">The node where the navigator is initially positioned.</param>
+            <param name="xpath">The XPath expression to match.</param>
+            <returns>The first node that matches the XPath query, or null if no matching node is found.</returns>
+        </member>
+        <member name="M:System.Xml.XmlDocumentXPathExtensions.SelectSingleNode(System.Xml.XmlNode,System.String,System.Xml.XmlNamespaceManager)">
+            <summary>
+            Selects the first node that matches the XPath expression. Any prefixes found in the XPath expression are resolved using the supplied namespace manager.
+            </summary>
+            <param name="node">The node where the navigator is initially positioned.</param>
+            <param name="xpath">The XPath expression to match.</param>
+            <param name="nsmgr">A namespace manager to resolve XPath expression prefix namespaces.</param>
+            <returns>The first node that matches the XPath query, or null if no matching node is found.</returns>
+        </member>
+        <member name="M:System.Xml.XmlDocumentXPathExtensions.CreateNavigator(System.Xml.XmlNode)">
+            <summary>
+            Creates an XPath navigator for navigating the specified node.
+            </summary>
+            <param name="node">The node where the navigator is initially positioned.</param>
+            <returns>An XPath navigator object.</returns>
+        </member>
+        <member name="M:System.Xml.XmlDocumentXPathExtensions.ToXPathNavigable(System.Xml.XmlNode)">
+            <summary>
+            Creates an IXPathNavigable instance used for producing navigators.
+            </summary>
+            <param name="node">The node in which the implementation should position newly created navigators.</param>
+            <returns>An IXPathNavigable instance</returns>
+        </member>
+        <member name="M:System.Xml.XmlDocumentXPathExtensions.CreateNavigator(System.Xml.XmlDocument)">
+            <summary>
+            Creates a new XPath navigator object for navigating the specified document.
+            </summary>
+            <param name="document">The document from which the XPath navigator is created.</param>
+            <returns>An XPath navigator object.</returns>
+        </member>
+        <member name="M:System.Xml.XmlDocumentXPathExtensions.CreateNavigator(System.Xml.XmlDocument,System.Xml.XmlNode)">
+            <summary>
+            Creates an XPath navigator object for navigating the specified document positioned on the specified node.
+            </summary>
+            <param name="document">The document from which the XPath navigator is created.</param>
+            <param name="node">The node where the navigator is initially positioned.</param>
+            <returns>An XPath navigator object.</returns>
+        </member>
+    </members>
+</doc>


### PR DESCRIPTION
Fixes https://github.com/dotnet/maintenance-packages/issues/133

Currently the repo is not autogenerating the intellisense xmls out of the triple slash comments.

Two assemblies, Microsoft.IO.Redist and System.Runtime.CompilerServices.Unsafe, already had an xml file commited in the src folder and explicitly included in the csproj. So I brought all the xmls in the last nupkg releases of all the other assemblies, and moved the DocumentationFile property down to the root directory.

I published the packages locally and was able to confirm that they now include their respective xmls inside each of the lib/<tfm>/ folders (only when there is a valid dll, not when there are placeholders).