### PR TITLE
Enable maintenance-packages in source build

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+# Users referenced in this file will automatically be requested as reviewers for PRs that modify the given paths.
+# See https://help.github.com/articles/about-code-owners/
+
+/eng/SourceBuild*                                                                 @dotnet/source-build
+/src/Microsoft.Bcl.HashCode                                                       @dotnet/area-system-runtime
+/src/Microsoft.IO.Redist                                                          @dotnet/area-system-io
+/src/System.Buffers                                                               @dotnet/area-system-buffers
+/src/System.Data.SqlClient                                                        @cheenamalhotra @david-engel
+/src/System.Json
+/src/System.Memory                                                                @dotnet/area-system-memory
+/src/System.Net.WebSockets.WebSocketProtocol                                      @dotnet/ncl
+/src/System.Numerics.Vectors                                                      @dotnet/area-system-numerics
+/src/System.Reflection.DispatchProxy                                              @dotnet/area-system-reflection
+/src/System.Runtime.CompilerServices.Unsafe                                       @dotnet/area-system-runtime-compilerservices
+/src/System.Threading.Tasks.Extensions                                            @dotnet/area-system-threading-tasks @stephentoub
+/src/System.Xml.XPath.XmlDocument                                                 @dotnet/area-system-xml

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,6 +19,8 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>
     <BeforeTargetFrameworkInferenceTargets>$(RepositoryEngineeringDir)BeforeTargetFrameworkInference.targets</BeforeTargetFrameworkInferenceTargets>
+    <!-- maintenance-packages doesn't support Arcade-driven target framework filtering. -->
+    <NoTargetFrameworkFiltering>true</NoTargetFrameworkFiltering>
   </PropertyGroup>
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,7 +19,7 @@
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
     <GlobalPackageReference Include="Microsoft.DotNet.ApiCompat.Task" Version="9.0.100-preview.2.24102.10" />
   </ItemGroup>
 

--- a/eng/SourceBuildPreBuiltBaseline.xml
+++ b/eng/SourceBuildPreBuiltBaseline.xml
@@ -1,0 +1,8 @@
+<!-- Whenever altering this or other Source Build files, please include @dotnet/source-build as a reviewer. -->
+<!-- See https://aka.ms/dotnet/prebuilts for guidance on what pre-builts are and how to eliminate them. -->
+
+<UsageData>
+  <IgnorePatterns>
+    <UsagePattern IdentityGlob="Microsoft.SourceBuild.Intermediate.*/*" />
+  </IgnorePatterns>
+</UsageData>

--- a/eng/SourceBuilld.props
+++ b/eng/SourceBuilld.props
@@ -1,0 +1,8 @@
+<Project>
+
+  <PropertyGroup>
+    <GitHubRepositoryName>maintenance-packages</GitHubRepositoryName>
+    <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
+  </PropertyGroup>
+
+</Project>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -25,5 +25,10 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>f7fb1fec01b91be69e4dcc5290a0bff3f28e214f</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="8.0.0-alpha.1.24415.1">
+      <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
+      <Sha>fe3794a68bd668d36d4d5014a9e6c9d22c0e6d86</Sha>
+      <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
+    </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -3,6 +3,12 @@
   <ProductDependencies>
   </ProductDependencies>
   <ToolsetDependencies>
+    <!-- Intermediate is necessary for source build. -->
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.arcade" Version="8.0.0-beta.24516.1">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>f7fb1fec01b91be69e4dcc5290a0bff3f28e214f</Sha>
+      <SourceBuild RepoName="arcade" ManagedOnly="true" />
+    </Dependency>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.24516.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>f7fb1fec01b91be69e4dcc5290a0bff3f28e214f</Sha>

--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <EnablePackageValidation Condition="'$(EnablePackageValidation)' == ''">true</EnablePackageValidation>
+    <EnablePackageValidation Condition="'$(EnablePackageValidation)' == '' AND '$(DotNetBuildFromSource)' != 'true'">true</EnablePackageValidation>
     <PlaceholderFile>$(MSBuildThisFileDirectory)_._</PlaceholderFile>
     <BeforePack>$(BeforePack);AddNETStandardCompatErrorFileForPackaging</BeforePack>
     <PackageReadmeFile Condition="'$(PackageReadmeFile)' == '' and Exists('PACKAGE.md')">PACKAGE.md</PackageReadmeFile>


### PR DESCRIPTION
This enables source-build pass on maintenance-packages.  https://github.com/dotnet/source-build/issues/4684

If there are any blockers with this we could resort back to conditioning the uptake of these packages so that SB would only see versions that are available in SBRP, but I want to try to do the better thing first.

With this change I still see the following prebuilts that I would like help resolving:
```
: error : 8 new pre-builts discovered! Detailed usage report can be found at /workspaces/maintenance-packages/artifacts/source-build/self/prebuilt-report/baseline-comparison.xml.
: error : See https://aka.ms/dotnet/prebuilts for guidance on what pre-builts are and how to eliminate them.
: error : Package IDs are:
: error : Microsoft.AspNetCore.App.Ref.6.0.35
: error : Microsoft.NET.Sdk.IL.8.0.0
: error : Microsoft.NETCore.App.Ref.6.0.35
: error : Microsoft.NETFramework.ReferenceAssemblies.1.0.3
: error : Microsoft.NETFramework.ReferenceAssemblies.net462.1.0.3
: error : Microsoft.NETFramework.ReferenceAssemblies.net472.1.0.3
: error : runtime.linux-x64.Microsoft.NETCore.ILAsm.6.0.0
: error : runtime.linux-x64.Microsoft.NETCore.ILDAsm.6.0.0
```

The ref-packs are a common problem that everyone should hit, maybe we're just missing something.
For IL, we need a way to consume those outputs of runtime as a toolset dependency.