### PR TITLE
Fix assembly informational version in System.Xml.XPath.XmlDocument

### DIFF
--- a/src/System.Xml.XPath.XmlDocument/src/System.Xml.XPath.XmlDocument.csproj
+++ b/src/System.Xml.XPath.XmlDocument/src/System.Xml.XPath.XmlDocument.csproj
@@ -10,7 +10,7 @@
   <PropertyGroup>
     <IsPackable>true</IsPackable>
     <VersionPrefix>4.3.0</VersionPrefix>
-    <VersionPrefix Condition="'$(IsPackable)' == 'true'">4.4.0</VersionPrefix>
+    <VersionPrefix Condition="'$(IsPackable)' == 'true'">4.7.0</VersionPrefix><!-- Ensures AssemblyInformationalVersion is larger than the last released -->
     <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <AssemblyVersion Condition="'$(IsPackable)' == 'true'">4.0.3.0</AssemblyVersion>
     <PackageValidationBaselineVersion>4.3.0</PackageValidationBaselineVersion>

--- a/src/System.Xml.XPath.XmlDocument/src/System.Xml.XPath.XmlDocument.csproj
+++ b/src/System.Xml.XPath.XmlDocument/src/System.Xml.XPath.XmlDocument.csproj
@@ -11,8 +11,6 @@
     <IsPackable>true</IsPackable>
     <VersionPrefix>4.3.0</VersionPrefix>
     <VersionPrefix Condition="'$(IsPackable)' == 'true'">4.7.0</VersionPrefix><!-- Ensures AssemblyInformationalVersion is larger than the last released -->
-    <AssemblyVersion>4.0.2.0</AssemblyVersion>
-    <AssemblyVersion Condition="'$(IsPackable)' == 'true'">4.0.3.0</AssemblyVersion>
     <PackageValidationBaselineVersion>4.3.0</PackageValidationBaselineVersion>
   </PropertyGroup>
 

--- a/src/System.Xml.XPath.XmlDocument/src/System.Xml.XPath.XmlDocument.csproj
+++ b/src/System.Xml.XPath.XmlDocument/src/System.Xml.XPath.XmlDocument.csproj
@@ -11,6 +11,8 @@
     <IsPackable>true</IsPackable>
     <VersionPrefix>4.3.0</VersionPrefix>
     <VersionPrefix Condition="'$(IsPackable)' == 'true'">4.4.0</VersionPrefix>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(IsPackable)' == 'true'">4.0.3.0</AssemblyVersion>
     <PackageValidationBaselineVersion>4.3.0</PackageValidationBaselineVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/maintenance-packages/issues/100

Before:

- [assembly: AssemblyFileVersion("4.6.24705.01")]
- [assembly: AssemblyInformationalVersion("4.6.24705.01. Commit Hash: 4d1af962ca0fede10beb01d197367c2f90e92c97")]
- [assembly: AssemblyVersion("4.0.2.0")]

After:
- [assembly: AssemblyFileVersion("4.700.24.52901")]
- [assembly: AssemblyInformationalVersion("4.7.0-dev.24529.1+f2633cbdb1640f2588165f27e9a97a113ec3780f")]
- [assembly: AssemblyVersion("4.0.3.0")]

Note that in this change I'm using:
- VersionPrefix = 4.3.0 
- VersionPrefix (with IsPackable=true) = 4.7.0

This helped me ensure that AssemblyInformationalVersion was greater than in the last release. I do not know where that 4.6 is coming from.

I tried using VersionPrefix = 4.6.0 but I get the error below, so I needed it to match the Version that shows up [in NuGet.org](https://www.nuget.org/packages/System.Xml.XPath.XmlDocument/4.3.0).
```
C:\Users\calope\source\repos\maintenance-packages\src\System.Xml.XPath.XmlDocument\src\System.Xml.XPath.XmlDocument.csproj : error NU1102: Unable to find package System.Xml.XPath.XmlDocument with version (= 4.6.24705.1) [C:\Users\calope\source\repos\maintenance-packages\.dotnet\sdk\8.0.403\NuGet.targets]
C:\Users\calope\source\repos\maintenance-packages\src\System.Xml.XPath.XmlDocument\src\System.Xml.XPath.XmlDocument.csproj : error NU1102:   - Found 14 version(s) in dotnet-public [ Nearest version: 4.3.0 ] [C:\Users\calope\source\repos\maintenance-packages\.dotnet\sdk\8.0.403\NuGet.targets]
C:\Users\calope\source\repos\maintenance-packages\src\System.Xml.XPath.XmlDocument\src\System.Xml.XPath.XmlDocument.csproj : error NU1102:   - Found 0 version(s) in dotnet-eng [C:\Users\calope\source\repos\maintenance-packages\.dotnet\sdk\8.0.403\NuGet.targets]
```