### PR TITLE
Don't filter files to show in VS

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -82,4 +82,13 @@
     </AssemblyMetadata>
   </ItemGroup>
 
+  <!-- The Default behavior in VS is to show files for the first target framework in TargetFrameworks property.
+       This is required to show all the files corresponding to all target frameworks in VS.
+       https://github.com/dotnet/project-system/issues/935 -->
+  <ItemGroup Condition="'$(DefaultLanguageSourceExtension)' != '' and
+                        ('$(BuildingInsideVisualStudio)' == 'true' or '$(DesignTimeBuild)' == 'true')">
+    <None Include="$(MSBuildProjectDirectory)\**\*$(DefaultLanguageSourceExtension)"
+          Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(Compile)" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/maintenance-packages/issues/147

The Default behavior in VS is to show files for the first target framework in TargetFrameworks property. This is required to show all the files corresponding to all target frameworks in VS.

https://github.com/dotnet/project-system/issues/935

With this change:

![image](https://github.com/user-attachments/assets/3a683ecb-0206-493c-8981-16163f138758)
