### PR TITLE
Stable branding

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
+    <PreReleaseVersionLabel>rtm</PreReleaseVersionLabel>
+    <PreReleaseVersionIteration></PreReleaseVersionIteration>
     <!-- Opt-out repo features -->
     <UseVSTestRunner>true</UseVSTestRunner>
     <UsingToolXliff>false</UsingToolXliff>


### PR DESCRIPTION
Changing PreReleaseVersionLabel to rtm and emptying PreReleaseVersionIteration so that the nupkg name removes the "preview" word and only shows the version.

Building and packing now shows only `-ci-` and does not show `-preview-` anymore:

```
        Directory: C:\Users\calope\source\repos\maintenance-packages\artifacts\packages\Release\Shipping

Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a---        2024-10-30   2:36 PM          34203   Microsoft.Bcl.HashCode.6.0.0-ci.24530.1.nupkg
-a---        2024-10-30   2:36 PM          60620   Microsoft.Bcl.HashCode.6.0.0-ci.24530.1.symbols.nupkg
-a---        2024-10-30   2:36 PM          81886   Microsoft.IO.Redist.6.1.0-ci.24530.1.nupkg
-a---        2024-10-30   2:36 PM         109974   Microsoft.IO.Redist.6.1.0-ci.24530.1.symbols.nupkg
-a---        2024-10-30   2:36 PM          26380   System.Buffers.4.6.0-ci.24530.1.nupkg
-a---        2024-10-30   2:36 PM          37869   System.Buffers.4.6.0-ci.24530.1.symbols.nupkg
-a---        2024-10-30   2:36 PM         925083   System.Data.SqlClient.4.9.0-ci.24530.1.nupkg
-a---        2024-10-30   2:36 PM        1358054   System.Data.SqlClient.4.9.0-ci.24530.1.symbols.nupkg
-a---        2024-10-30   2:36 PM          49258   System.Json.4.8.0-ci.24530.1.nupkg
-a---        2024-10-30   2:36 PM          78301   System.Json.4.8.0-ci.24530.1.symbols.nupkg
-a---        2024-10-30   2:36 PM         151236   System.Memory.4.6.0-ci.24530.1.nupkg
-a---        2024-10-30   2:36 PM         220397   System.Memory.4.6.0-ci.24530.1.symbols.nupkg
-a---        2024-10-30   2:36 PM          88468   System.Net.WebSockets.WebSocketProtocol.5.1.0-ci.24530.1.nupkg
-a---        2024-10-30   2:36 PM         123430   System.Net.WebSockets.WebSocketProtocol.5.1.0-ci.24530.1.symbols.nupkg
-a---        2024-10-30   2:36 PM          86864   System.Numerics.Vectors.4.6.0-ci.24530.1.nupkg
-a---        2024-10-30   2:36 PM         121500   System.Numerics.Vectors.4.6.0-ci.24530.1.symbols.nupkg
-a---        2024-10-30   2:36 PM          33248   System.Reflection.DispatchProxy.4.8.0-ci.24530.1.nupkg
-a---        2024-10-30   2:36 PM          53136   System.Reflection.DispatchProxy.4.8.0-ci.24530.1.symbols.nupkg
-a---        2024-10-30   2:36 PM          20718   System.Runtime.CompilerServices.Unsafe.6.1.0-ci.24530.1.nupkg
-a---        2024-10-30   2:36 PM          22599   System.Runtime.CompilerServices.Unsafe.6.1.0-ci.24530.1.symbols.nupkg
-a---        2024-10-30   2:36 PM          33142   System.Threading.Tasks.Extensions.4.6.0-ci.24530.1.nupkg
-a---        2024-10-30   2:36 PM          45809   System.Threading.Tasks.Extensions.4.6.0-ci.24530.1.symbols.nupkg
-a---        2024-10-30   2:36 PM          20856   System.Xml.XPath.XmlDocument.4.7.0-ci.24530.1.nupkg
-a---        2024-10-30   2:36 PM          35707   System.Xml.XPath.XmlDocument.4.7.0-ci.24530.1.symbols.nupkg
```