### PR TITLE
Bring missing signing configuration

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -5,5 +5,31 @@
     <AllowEmptySignList>true</AllowEmptySignList>
     <AllowEmptySignPostBuildList>true</AllowEmptySignPostBuildList>
   </PropertyGroup>
+  
+  <ItemGroup>
+    <!--
+      Replace the default items to sign with the specific set we want. This allows the build to call
+      Arcade's Sign.proj multiple times for different sets of files as the build progresses.
+    -->
+    <ItemsToSign Remove="@(ItemsToSign)" />
+
+    <!-- Exclude symbol packages from getting a NuGet signature. These are never pushed to NuGet.org or
+         other feeds (in fact, that have identical identity to their non-symbol variant) -->
+    <DownloadedSymbolPackages Include="$(ArtifactsDir)**\*.symbols.nupkg" />
+    <DownloadedSymbolPackagesWithoutPaths Include="@(DownloadedSymbolPackages->'%(Filename)%(Extension)')" />
+    <FileSignInfo Include="@(DownloadedSymbolPackagesWithoutPaths->Distinct())" CertificateName="None" />
+    
+    <!-- Update existing defaults from arcade that were using Microsoft400 to use the .NET-specific cert -->
+    <FileExtensionSignInfo Update="@(FileExtensionSignInfo->WithMetadataValue('CertificateName','Microsoft400'))" CertificateName="MicrosoftDotNet500" />
+    <StrongNameSignInfo Update="@(StrongNameSignInfo->WithMetadataValue('CertificateName','Microsoft400'))" CertificateName="MicrosoftDotNet500" />
+    <FileSignInfo Update="@(FileSignInfo->WithMetadataValue('CertificateName','Microsoft400'))" CertificateName="MicrosoftDotNet500" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(IsPackable)' == 'true'">
+    <ItemsToSignWithPaths Include="$(ArtifactsDir)**\*.nupkg" />
+    <ItemsToSignWithoutPaths Include="@(ItemsToSignWithPaths->'%(Filename)%(Extension)')" />
+    <ItemsToSignPostBuild Include="@(ItemsToSignWithoutPaths->Distinct())" Condition="'$(PostBuildSign)' == 'true'" />
+    <ItemsToSign Include="@(ItemsToSignWithPaths->Distinct())" Condition="'$(PostBuildSign)' != 'true'" />
+  </ItemGroup>
 
 </Project>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -4,32 +4,7 @@
     <!-- This repository uses incremental servicing therefore packages might not be produced. -->
     <AllowEmptySignList>true</AllowEmptySignList>
     <AllowEmptySignPostBuildList>true</AllowEmptySignPostBuildList>
+    <UseDotNetCertificate>true</UseDotNetCertificate>
   </PropertyGroup>
-  
-  <ItemGroup>
-    <!--
-      Replace the default items to sign with the specific set we want. This allows the build to call
-      Arcade's Sign.proj multiple times for different sets of files as the build progresses.
-    -->
-    <ItemsToSign Remove="@(ItemsToSign)" />
-
-    <!-- Exclude symbol packages from getting a NuGet signature. These are never pushed to NuGet.org or
-         other feeds (in fact, that have identical identity to their non-symbol variant) -->
-    <DownloadedSymbolPackages Include="$(ArtifactsDir)**\*.symbols.nupkg" />
-    <DownloadedSymbolPackagesWithoutPaths Include="@(DownloadedSymbolPackages->'%(Filename)%(Extension)')" />
-    <FileSignInfo Include="@(DownloadedSymbolPackagesWithoutPaths->Distinct())" CertificateName="None" />
-    
-    <!-- Update existing defaults from arcade that were using Microsoft400 to use the .NET-specific cert -->
-    <FileExtensionSignInfo Update="@(FileExtensionSignInfo->WithMetadataValue('CertificateName','Microsoft400'))" CertificateName="MicrosoftDotNet500" />
-    <StrongNameSignInfo Update="@(StrongNameSignInfo->WithMetadataValue('CertificateName','Microsoft400'))" CertificateName="MicrosoftDotNet500" />
-    <FileSignInfo Update="@(FileSignInfo->WithMetadataValue('CertificateName','Microsoft400'))" CertificateName="MicrosoftDotNet500" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(IsPackable)' == 'true'">
-    <ItemsToSignWithPaths Include="$(ArtifactsDir)**\*.nupkg" />
-    <ItemsToSignWithoutPaths Include="@(ItemsToSignWithPaths->'%(Filename)%(Extension)')" />
-    <ItemsToSignPostBuild Include="@(ItemsToSignWithoutPaths->Distinct())" Condition="'$(PostBuildSign)' == 'true'" />
-    <ItemsToSign Include="@(ItemsToSignWithPaths->Distinct())" Condition="'$(PostBuildSign)' != 'true'" />
-  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
I noticed runtime does some additional work in eng/Signing.props (release/9.0) that we don't have here, so I'm bringing it: https://github.com/dotnet/runtime/blob/release/9.0/eng/Signing.props

- Empty the default ItemsToSign
- Exclude *symbols.nupkg files from signing
- Update all the default arcade items that use a CertificateName Microsoft400 to use the .NET-specific certificate
- Finally, on the condition of IsPackable==true (_in runtime, it uses PrepareArtifacts==true, which is set by the installer in runtime, we don't have it here_):
  - Mark all the artifacts nupkgs to sign post build without their full path
  - Mark all the artifacts nupkgs to sign (not post build) with their full path

Note: Locally, signing is done with DryRun enabled, so nothing really happens:

```
$ signtool verify /pa .\artifacts\bin\Microsoft.Bcl.HashCode\Release\net6.0\Microsoft.Bcl.HashCode.dll
File: .\artifacts\bin\Microsoft.Bcl.HashCode\Release\net6.0\Microsoft.Bcl.HashCode.dll
Index  Algorithm  Timestamp    
========================================
SignTool Error: No signature found.

Number of errors: 1
```

But I am not comfortable overriding the DryRun option because there's a step that uploads symbols to the symbol servers:
```
  SignToolTask starting.
  DryRun: True
  Signing mode: Real
  MicroBuild signing logs will be in (Signing*.binlog): C:\Users\calope\source\repos\maintenance-packages\artifacts\log\Rel 
  ease\
  MicroBuild signing configuration will be in (Round*.proj): C:\Users\calope\source\repos\maintenance-packages\artifacts\tm 
  p\Release\
  Round 0: Signing 32 files.
  Repacking 24 containers.
  Repacking 24 containers in parallel.
  Round 1: Signing 24 files.
  Build artifacts signed and validated.
  SignToolTask execution finished.
  Publishing symbol packages to MSDL ...
  Performing symbol publish  (Dry Run)..
  SymbolServerPath: https://microsoftpublicsymbols.artifacts.visualstudio.com/DefaultCollection
  ExpirationInDays specified: 3650
  Symbol publish finished
  Publishing symbol packages to SymWeb ...
  Performing symbol publish  (Dry Run)..
  SymbolServerPath: https://microsoft.artifacts.visualstudio.com/DefaultCollection
  ExpirationInDays specified: 3650
  Symbol publish finished
```

But I can confirm that the round*.proj files show the expected results as configured:

Round0.proj (before):
```xml
        <FilesToSign Include="C%3A%5CUsers%5Ccalope%5Csource%5Crepos%5Cmaintenance-packages%5Cartifacts%5Ctmp%5CRelease%5CContainerSigning%5C118%5Clib%2Fnet462%2FSystem.Numerics.Vectors.dll">
            <Authenticode>Microsoft400</Authenticode>
            <StrongName>StrongName</StrongName>
        </FilesToSign>
```
Round0.proj (after):
```xml
        <FilesToSign Include="C%3A%5CUsers%5Ccalope%5Csource%5Crepos%5Cmaintenance-packages%5Cartifacts%5Ctmp%5CRelease%5CContainerSigning%5C118%5Clib%2Fnet462%2FSystem.Numerics.Vectors.dll">
            <Authenticode>MicrosoftDotNet500</Authenticode>
            <StrongName>StrongName</StrongName>
        </FilesToSign>
```

Round1.proj (before):
```xml
        <FilesToSign Include="C%3A%5CUsers%5Ccalope%5Csource%5Crepos%5Cmaintenance-packages%5Cartifacts%5Cpackages%5CRelease%5CShipping%5CMicrosoft.Bcl.HashCode.6.0.0-ci.24530.1.symbols.nupkg">
            <Authenticode>NuGet</Authenticode>
        </FilesToSign>
```

Round1.proj (after):
```cs
// No more symbols nupkg being signed
```