### PR TITLE
Enable DotNetFinalVersionKind to remove the patch version and prerelease qualifiers from package names

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,6 +2,9 @@
   <PropertyGroup>
     <PreReleaseVersionLabel>rtm</PreReleaseVersionLabel>
     <PreReleaseVersionIteration></PreReleaseVersionIteration>
+    <!-- Enable to remove prerelease label. -->
+    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>
+    <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
     <!-- Opt-out repo features -->
     <UseVSTestRunner>true</UseVSTestRunner>
     <UsingToolXliff>false</UsingToolXliff>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,9 +2,8 @@
   <PropertyGroup>
     <PreReleaseVersionLabel>rtm</PreReleaseVersionLabel>
     <PreReleaseVersionIteration></PreReleaseVersionIteration>
-    <!-- Enable to remove prerelease label. -->
-    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>
-    <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
+    <!-- Enables removing prerelease labels. -->
+    <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <!-- Opt-out repo features -->
     <UseVSTestRunner>true</UseVSTestRunner>
     <UsingToolXliff>false</UsingToolXliff>


### PR DESCRIPTION
I missed this property in my previous PR. Without it, the packages are still getting pushed to the `dotnet-libraries` feed with the prerelease qualifiers and the patch version in their names. Example: https://dnceng.visualstudio.com/public/_artifacts/feed/dotnet-libraries/NuGet/System.Numerics.Vectors/overview/4.6.0-rtm.24531.3

After merging this, each release will be pushed to its own isolated feed, and the package names will not contain any prerelease qualifiers and patch versions in their names.

We don't have to merge this right away. Let's wait until we finish fine tuning the last details in the repo.