### PR TITLE
Revert setting DotNetFinalVersionKind to release

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,8 +2,6 @@
   <PropertyGroup>
     <PreReleaseVersionLabel>rtm</PreReleaseVersionLabel>
     <PreReleaseVersionIteration></PreReleaseVersionIteration>
-    <!-- Enables removing prerelease labels. -->
-    <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <!-- Opt-out repo features -->
     <UseVSTestRunner>true</UseVSTestRunner>
     <UsingToolXliff>false</UsingToolXliff>


### PR DESCRIPTION
We were able to confirm that the stable builds work as expected. [The commit](https://github.com/dotnet/maintenance-packages/commit/a8adb65c79e4ce8df1614563f872be189b6dbdbe) in `main` that set the `DotNetFinalVersionKind` property to `release` caused the expected things to happen:

- The prerelease/preview suffix was removed from the package versions: https://product-construction-prod.wittysky-0c79e3cc.westus2.azurecontainerapps.io/channel/1648/github:dotnet:maintenance-packages/build/latest
- The `dotnet-libraries` feed stopped being used for publishing the packages. As an example, Microsoft.Bcl.HashCode still shows the rtm as the last package published (before the commit mentioned above). https://dnceng.visualstudio.com/public/_artifacts/feed/dotnet-libraries/NuGet/Microsoft.Bcl.HashCode/overview/6.0.0-rtm.24531.5
- A new isolated feed was automatically created to publish the stable packages: https://dnceng.visualstudio.com/public/_artifacts/feed/darc-pub-dotnet-maintenance-packages-a8adb65c . Note that the first characters of the commit are suffixed to the name of the feed.

But creating isolated feeds and being in perpetual "stable" state is unnecessarily risky. We need to be able to first test packages before publishing the stable version.

So in conversation with @ViktorHofer and as suggested by @ericstj [here](https://github.com/dotnet/maintenance-packages/pull/153#issuecomment-2452397149), we will opt for keeping the branch in prerelease mode (by simply deleting the property) and when the time comes to publish a new version, we will manually trigger a job passing DotNetFinalVersionKind as an environment variable with the release value.

Note: I am testing the env var usage internally and separate to this PR.