### PR TITLE
Remove hardcoded assembly version from System.Json

### DIFF
--- a/src/System.Json/src/System.Json.csproj
+++ b/src/System.Json/src/System.Json.csproj
@@ -10,8 +10,6 @@
     <IsPackable>true</IsPackable>
     <VersionPrefix>4.7.1</VersionPrefix>
     <VersionPrefix Condition="'$(IsPackable)' == 'true'">4.8.0</VersionPrefix>
-    <AssemblyVersion>2.0.8.0</AssemblyVersion>
-    <AssemblyVersion Condition="'$(IsPackable)' == 'true'">2.0.9.0</AssemblyVersion>
     <PackageValidationBaselineVersion>4.7.1</PackageValidationBaselineVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Align the package and assembly version for System.Json by upgrading the assembly version from 2.0.8.0 to 4.8.0.0.