### PR TITLE
Pass DotNetFinalVersionKind via yaml as a global property

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <PreReleaseVersionLabel>rtm</PreReleaseVersionLabel>
     <PreReleaseVersionIteration></PreReleaseVersionIteration>
-    <!-- Enables removing prerelease labels. -->
-    <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <!-- Opt-out repo features -->
     <UseVSTestRunner>true</UseVSTestRunner>
     <UsingToolXliff>false</UsingToolXliff>

--- a/eng/pipelines/maintenance-packages.yml
+++ b/eng/pipelines/maintenance-packages.yml
@@ -83,10 +83,15 @@ extends:
               fetchDepth: 0
               clean: true
             steps:
+            # Manually run an Azure DevOps job with the variable 'DotNetFinalVersionKind' set to 'release' to
+            # generate a stable version (package names without preview suffix strings).
+            # For nightly builds this value should be empty (default value).
+            # https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Versioning.md#package-versioning
             - script: eng\common\cibuild.cmd
                 -configuration Release
                 -prepareMachine
                 /p:Test=false
+                /p:DotNetFinalVersionKind=$(DotNetFinalVersionKind)
                 $(_AdditionalBuildArgs)
                 $(_InternalBuildArgs)
               displayName: $(_BuildJobDisplayName)


### PR DESCRIPTION
For easier manipulation when we want to generate stable packages.