### PR TITLE
Remove PostBuildSign

### DIFF
--- a/eng/pipelines/common-variables.yml
+++ b/eng/pipelines/common-variables.yml
@@ -23,5 +23,3 @@ variables:
         /p:TeamName=$(_TeamName)
         /p:DotNetPublishUsingPipelines=true
         /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-    - name: PostBuildSign
-      value: true


### PR DESCRIPTION
PostBuildSigning requires an [additional release and signing step](https://github.com/dotnet/arcade/blob/488a796fd621ef6a81ef08f27e32ae43af1bb96c/Documentation/CorePackages/PostBuildSigning.md) after build.  We aren't doing that for maintenance-packages, so just sign during the build.