### PR TITLE
Bring back net6.0 TFM to System.Runtime.CompilerServices.Unsafe

### DIFF
--- a/src/System.Runtime.CompilerServices.Unsafe/Versioning.props
+++ b/src/System.Runtime.CompilerServices.Unsafe/Versioning.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <IsPackable>false</IsPackable>
+    <IsPackable>true</IsPackable>
     <VersionPrefix>6.1.0</VersionPrefix>
     <VersionPrefix Condition="'$(IsPackable)' == 'true'">6.1.1</VersionPrefix>
   </PropertyGroup>

--- a/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.ilproj
+++ b/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.ilproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
 
   <PropertyGroup>
-    <TargetFrameworks>$(NetFrameworkMinimum);netstandard2.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkMinimum);netstandard2.0;$(NetMinimum);net7.0</TargetFrameworks>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <AssemblyVersion>6.0.0.0</AssemblyVersion> <!-- NO-INCREMENT: This version is frozen for .NET Standard and .NETCoreApp because the assembly ships inbox. -->
     <SetIsTrimmable>true</SetIsTrimmable>
@@ -12,7 +12,7 @@
     <IlasmFlags>$(IlasmFlags) -DEBUG=$(DebugOptimization)</IlasmFlags>
     <PackageDescription>Provides the System.Runtime.CompilerServices.Unsafe class, which provides generic, low-level functionality for manipulating pointers.</PackageDescription>
     <DocumentationFile>$(MSBuildProjectDirectory)\$(AssemblyName).xml</DocumentationFile>
-    <IsPlaceholderTargetFramework Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp'">true</IsPlaceholderTargetFramework>
+    <IsPlaceholderTargetFramework Condition="'$(TargetFramework)' == 'net7.0'">true</IsPlaceholderTargetFramework>
   </PropertyGroup>
 
   <!-- VersionPrefix and IsPackable are defined in the parent folder's Versioning.props file. -->
@@ -23,6 +23,11 @@
     <AssemblyVersion Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">6.0.1.0</AssemblyVersion>
     <AssemblyVersion Condition="'$(IsPackable)' == 'true' and $([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">6.0.2.0</AssemblyVersion>
     <PackageValidationBaselineVersion>6.1.0</PackageValidationBaselineVersion>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp' and '$(IsPlaceholderTargetFramework)' != 'true'">
+    <ExtraMacros>#define netcoreapp</ExtraMacros>
+    <CoreAssembly>System.Runtime</CoreAssembly>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">


### PR DESCRIPTION
Fixes https://github.com/dotnet/maintenance-packages/issues/174

Here's the comparison of the last DLL shipped out of release/6.0 (first tree item & left tab) vs the m-p version with the fix in this PR (second tree item vs right tab):

![image](https://github.com/user-attachments/assets/0e81dcd2-8379-4454-be35-01e831fed0bd)

And the Unsafe type shows all the same APIs too.