### PR TITLE
Update PACKAGE.md

### DIFF
--- a/src/System.Threading.Tasks.Extensions/src/PACKAGE.md
+++ b/src/System.Threading.Tasks.Extensions/src/PACKAGE.md
@@ -7,7 +7,7 @@ Provides additional types for efficiently representing asynchronous operations.
 The main types provided by this library are:
 
 - System.Threading.Tasks.ValueTask
-- System.Threading.Tasks.ValueTask<TResult>
+- System.Threading.Tasks.ValueTask&lt;TResult&gt;
 
 ## Additional Documentation
 


### PR DESCRIPTION
Type parameter &lt;TResult&gt; was not visible because of unescaped less-than/greater-than signs.