### PR TITLE
Fix DispatchProxy.Invoke for .NET Standard 2.0

### DIFF
--- a/src/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxy.cs
+++ b/src/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxy.cs
@@ -23,14 +23,7 @@ namespace System.Reflection
         /// <param name="targetMethod">The method the caller invoked</param>
         /// <param name="args">The arguments the caller passed to the method</param>
         /// <returns>The object to return to the caller, or <c>null</c> for void methods</returns>
-#if NETSTANDARD2_0
-        protected object Invoke(MethodInfo targetMethod, object[] args)
-        {
-            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ReflectionDispatchProxy);
-        }
-#else
         protected abstract object Invoke(MethodInfo targetMethod, object[] args);
-#endif
 
         /// <summary>
         /// Creates an object instance that derives from class <typeparamref name="TProxy"/>


### PR DESCRIPTION
Fixes https://github.com/dotnet/maintenance-packages/issues/194

This is what ILSpy shows for the DLL of the nupkg version 4.7.0:
![image](https://github.com/user-attachments/assets/4a8b24dd-0ca6-4f9f-be67-2cde26cab3ed)
