### PR TITLE
Add a workflow that checks for the 'NO MERGE' label and prevents PR merge

### DIFF
--- a/.github/workflows/check-no-merge-label.yml
+++ b/.github/workflows/check-no-merge-label.yml
@@ -1,0 +1,25 @@
+name: check-no-merge-label
+
+permissions:
+  pull-requests: read
+
+on:
+  pull_request_target:
+    types: [opened, reopened, labeled, unlabeled]
+    branches:
+      - 'main'
+
+jobs:
+  check-labels:
+    if: github.repository == 'dotnet/maintenance-packages'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check 'NO MERGE' label
+      run: |
+        echo "Merging permission is disabled when the 'NO MERGE' label is applied."
+        if [ "${{ contains(github.event.pull_request.labels.*.name, 'NO MERGE') }}" = "false" ]; then
+          exit 0
+        else
+          echo "::error:: The 'NO MERGE' label was applied to the PR. Merging is disabled."
+          exit 1
+        fi


### PR DESCRIPTION
Matches the workflow we have in runtime: https://github.com/dotnet/runtime/blob/release/8.0/.github/workflows/check-no-merge-label.yml

Note that the label in maintenance-packages is not `NO-MERGE`, but `NO MERGE`: https://github.com/dotnet/maintenance-packages/labels

My understanding from @jeffhandley 's explanation is that the current PR won't be able to test this workflow. It will have to be tested after merging, either with currently open PRs (which will require pressing the workflow approval in the CI section) or in subsequent PRs.