### PR TITLE
Fix ValueTuple consumption on >= net471

### DIFF
--- a/src/System.ValueTuple/src/System.ValueTuple.csproj
+++ b/src/System.ValueTuple/src/System.ValueTuple.csproj
@@ -11,7 +11,7 @@
 
   <!-- Package servicing properties -->
   <PropertyGroup>
-    <IsPackable>false</IsPackable>
+    <IsPackable>true</IsPackable>
     <VersionPrefix>4.6.0</VersionPrefix>
     <VersionPrefix Condition="'$(IsPackable)' == 'true'">4.7.0</VersionPrefix>
     <AssemblyVersion>4.0.4.0</AssemblyVersion>
@@ -39,6 +39,12 @@
       </ItemGroup>
     </When>
   </Choose>
+
+  <!-- Also put into build folder for packages.config support. -->
+  <ItemGroup>
+    <Content Include="buildTransitive\net471\System.ValueTuple.targets" PackagePath="buildTransitive\net471\$(PackageId).targets" />
+    <Content Include="buildTransitive\net471\System.ValueTuple.targets" PackagePath="build\net471\$(PackageId).targets" />
+  </ItemGroup>
 
   <Target Name="FailForUpdatedNetFrameworkMinimum" Condition="'$(NetFrameworkMinimum)' != 'net462'">
     <Error Text="NetFrameworkMinimum got changed to '$(NetFrameworkMinimum)'. Consider removing this implementation or the whole library." />

--- a/src/System.ValueTuple/src/System.ValueTuple.csproj
+++ b/src/System.ValueTuple/src/System.ValueTuple.csproj
@@ -13,7 +13,7 @@
   <PropertyGroup>
     <IsPackable>true</IsPackable>
     <VersionPrefix>4.6.0</VersionPrefix>
-    <VersionPrefix Condition="'$(IsPackable)' == 'true'">4.7.0</VersionPrefix>
+    <VersionPrefix Condition="'$(IsPackable)' == 'true'">4.6.1</VersionPrefix>
     <AssemblyVersion>4.0.4.0</AssemblyVersion>
     <AssemblyVersion Condition="'$(IsPackable)' == 'true'">4.0.5.0</AssemblyVersion>
     <PackageValidationBaselineVersion>4.6.0</PackageValidationBaselineVersion>

--- a/src/System.ValueTuple/src/buildTransitive/net471/System.ValueTuple.targets
+++ b/src/System.ValueTuple/src/buildTransitive/net471/System.ValueTuple.targets
@@ -1,0 +1,11 @@
+<Project>
+
+  <!-- System.ValueTuple is inbox on .NET Framework >= 4.7.1 and therefore any potential redirect for it should be removed.
+       This is necessary as the assembly version in the already shipped packages is higher than what's provided inbox on .NET Framework. -->
+  <Target Name="RemoveValueTupleRedirectForNet471AndAbove" DependsOnTargets="ResolveAssemblyReferences" BeforeTargets="GenerateBindingRedirects">
+    <ItemGroup>
+      <SuggestedBindingRedirects Remove="System.ValueTuple, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" />
+    </ItemGroup>
+  </Target>
+
+</Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/maintenance-packages/issues/213

System.ValueTuple is inbox on .NET Framework >= 4.7.1 and therefore any potential redirect for it should be removed. This is necessary as the assembly version in the already shipped packages is higher than what's provided inbox on .NET Framework

Package layout:

![image](https://github.com/user-attachments/assets/b9bdd00d-7e18-4f91-8577-46b194a47c7c)
