### PR TITLE
Turn off packages and bump versions

### DIFF
--- a/src/Microsoft.IO.Redist/src/Microsoft.IO.Redist.csproj
+++ b/src/Microsoft.IO.Redist/src/Microsoft.IO.Redist.csproj
@@ -13,10 +13,10 @@
 
   <!-- Package servicing properties -->
   <PropertyGroup>
-    <IsPackable>true</IsPackable>
-    <VersionPrefix>6.1.1</VersionPrefix>
-    <VersionPrefix Condition="'$(IsPackable)' == 'true'">6.1.2</VersionPrefix>
-    <PackageValidationBaselineVersion>6.1.1</PackageValidationBaselineVersion>
+    <IsPackable>false</IsPackable>
+    <VersionPrefix>6.1.2</VersionPrefix>
+    <VersionPrefix Condition="'$(IsPackable)' == 'true'">6.1.3</VersionPrefix>
+    <PackageValidationBaselineVersion>6.1.2</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Buffers/src/System.Buffers.csproj
+++ b/src/System.Buffers/src/System.Buffers.csproj
@@ -10,12 +10,12 @@
 
   <!-- Package servicing properties -->
   <PropertyGroup>
-    <IsPackable>true</IsPackable>
-    <VersionPrefix>4.6.0</VersionPrefix>
-    <VersionPrefix Condition="'$(IsPackable)' == 'true'">4.6.1</VersionPrefix>
-    <AssemblyVersion Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.0.4.0</AssemblyVersion>
-    <AssemblyVersion Condition="'$(IsPackable)' == 'true' and $([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.0.5.0</AssemblyVersion>
-    <PackageValidationBaselineVersion>4.6.0</PackageValidationBaselineVersion>
+    <IsPackable>false</IsPackable>
+    <VersionPrefix>4.6.1</VersionPrefix>
+    <VersionPrefix Condition="'$(IsPackable)' == 'true'">4.6.2</VersionPrefix>
+    <AssemblyVersion Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.0.5.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(IsPackable)' == 'true' and $([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.0.6.0</AssemblyVersion>
+    <PackageValidationBaselineVersion>4.6.1</PackageValidationBaselineVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/System.Memory/src/System.Memory.csproj
+++ b/src/System.Memory/src/System.Memory.csproj
@@ -11,12 +11,12 @@
 
   <!-- Package servicing properties -->
   <PropertyGroup>
-    <IsPackable>true</IsPackable>
-    <VersionPrefix>4.6.1</VersionPrefix>
-    <VersionPrefix Condition="'$(IsPackable)' == 'true'">4.6.2</VersionPrefix>
-    <AssemblyVersion Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.0.3.0</AssemblyVersion>
-    <AssemblyVersion Condition="'$(IsPackable)' == 'true' and $([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.0.4.0</AssemblyVersion> <!-- Keep the new assembly version under 4.1.x.x! -->
-    <PackageValidationBaselineVersion>4.6.0</PackageValidationBaselineVersion>
+    <IsPackable>false</IsPackable>
+    <VersionPrefix>4.6.2</VersionPrefix>
+    <VersionPrefix Condition="'$(IsPackable)' == 'true'">4.6.3</VersionPrefix>
+    <AssemblyVersion Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.0.4.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(IsPackable)' == 'true' and $([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.0.5.0</AssemblyVersion> <!-- Keep the new assembly version under 4.1.x.x! -->
+    <PackageValidationBaselineVersion>4.6.2</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsPlaceholderTargetFramework)' != 'true'">

--- a/src/System.Net.WebSockets.WebSocketProtocol/src/System.Net.WebSockets.WebSocketProtocol.csproj
+++ b/src/System.Net.WebSockets.WebSocketProtocol/src/System.Net.WebSockets.WebSocketProtocol.csproj
@@ -9,10 +9,10 @@
 
   <!-- Package servicing properties -->
   <PropertyGroup>
-    <IsPackable>true</IsPackable>
-    <VersionPrefix>5.1.1</VersionPrefix>
-    <VersionPrefix Condition="'$(IsPackable)' == 'true'">5.1.2</VersionPrefix>
-    <PackageValidationBaselineVersion>5.1.1</PackageValidationBaselineVersion>
+    <IsPackable>false</IsPackable>
+    <VersionPrefix>5.1.2</VersionPrefix>
+    <VersionPrefix Condition="'$(IsPackable)' == 'true'">5.1.3</VersionPrefix>
+    <PackageValidationBaselineVersion>5.1.2</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == '$(NetMinimum)'">

--- a/src/System.Numerics.Vectors/src/System.Numerics.Vectors.csproj
+++ b/src/System.Numerics.Vectors/src/System.Numerics.Vectors.csproj
@@ -10,12 +10,12 @@
 
   <!-- Package servicing properties -->
   <PropertyGroup>
-    <IsPackable>true</IsPackable>
-    <VersionPrefix>4.6.0</VersionPrefix>
-    <VersionPrefix Condition="'$(IsPackable)' == 'true'">4.6.1</VersionPrefix>
-    <AssemblyVersion Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.1.5.0</AssemblyVersion>
-    <AssemblyVersion Condition="'$(IsPackable)' == 'true' and $([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.1.6.0</AssemblyVersion>
-    <PackageValidationBaselineVersion>4.6.0</PackageValidationBaselineVersion>
+    <IsPackable>false</IsPackable>
+    <VersionPrefix>4.6.1</VersionPrefix>
+    <VersionPrefix Condition="'$(IsPackable)' == 'true'">4.6.2</VersionPrefix>
+    <AssemblyVersion Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.1.6.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(IsPackable)' == 'true' and $([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.1.7.0</AssemblyVersion>
+    <PackageValidationBaselineVersion>4.6.1</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Reflection.DispatchProxy/src/System.Reflection.DispatchProxy.csproj
+++ b/src/System.Reflection.DispatchProxy/src/System.Reflection.DispatchProxy.csproj
@@ -10,12 +10,12 @@
 
   <!-- Package servicing properties -->
   <PropertyGroup>
-    <IsPackable>true</IsPackable>
-    <VersionPrefix>4.8.1</VersionPrefix>
-    <VersionPrefix Condition="'$(IsPackable)' == 'true'">4.8.2</VersionPrefix>
-    <AssemblyVersion Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.0.8.0</AssemblyVersion>
-    <AssemblyVersion Condition="'$(IsPackable)' == 'true' and $([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.0.9.0</AssemblyVersion>
-    <PackageValidationBaseLineVersion>4.8.0</PackageValidationBaseLineVersion>
+    <IsPackable>false</IsPackable>
+    <VersionPrefix>4.8.2</VersionPrefix>
+    <VersionPrefix Condition="'$(IsPackable)' == 'true'">4.8.3</VersionPrefix>
+    <AssemblyVersion Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.0.9.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(IsPackable)' == 'true' and $([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.0.10.0</AssemblyVersion>
+    <PackageValidationBaseLineVersion>4.8.2</PackageValidationBaseLineVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Threading.Tasks.Extensions/src/System.Threading.Tasks.Extensions.csproj
+++ b/src/System.Threading.Tasks.Extensions/src/System.Threading.Tasks.Extensions.csproj
@@ -10,12 +10,12 @@
 
   <!-- Package servicing properties -->
   <PropertyGroup>
-    <IsPackable>true</IsPackable>
-    <VersionPrefix>4.6.1</VersionPrefix>
-    <VersionPrefix Condition="'$(IsPackable)' == 'true'">4.6.2</VersionPrefix>
-    <AssemblyVersion Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.2.2.0</AssemblyVersion>
-    <AssemblyVersion Condition="'$(IsPackable)' == 'true' and $([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.2.3.0</AssemblyVersion><!-- Keep the new assembly version under 4.3.x.x! -->
-    <PackageValidationBaselineVersion>4.6.0</PackageValidationBaselineVersion>
+    <IsPackable>false</IsPackable>
+    <VersionPrefix>4.6.2</VersionPrefix>
+    <VersionPrefix Condition="'$(IsPackable)' == 'true'">4.6.3</VersionPrefix>
+    <AssemblyVersion Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.2.3.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(IsPackable)' == 'true' and $([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.2.4.0</AssemblyVersion><!-- Keep the new assembly version under 4.3.x.x! -->
+    <PackageValidationBaselineVersion>4.6.2</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.ValueTuple/src/System.ValueTuple.csproj
+++ b/src/System.ValueTuple/src/System.ValueTuple.csproj
@@ -11,12 +11,12 @@
 
   <!-- Package servicing properties -->
   <PropertyGroup>
-    <IsPackable>true</IsPackable>
-    <VersionPrefix>4.6.0</VersionPrefix>
-    <VersionPrefix Condition="'$(IsPackable)' == 'true'">4.6.1</VersionPrefix>
-    <AssemblyVersion>4.0.4.0</AssemblyVersion>
-    <AssemblyVersion Condition="'$(IsPackable)' == 'true'">4.0.5.0</AssemblyVersion>
-    <PackageValidationBaselineVersion>4.6.0</PackageValidationBaselineVersion>
+    <IsPackable>false</IsPackable>
+    <VersionPrefix>4.6.1</VersionPrefix>
+    <VersionPrefix Condition="'$(IsPackable)' == 'true'">4.6.2</VersionPrefix>
+    <AssemblyVersion>4.0.5.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(IsPackable)' == 'true'">4.0.6.0</AssemblyVersion>
+    <PackageValidationBaselineVersion>4.6.1</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <Choose>


### PR DESCRIPTION
The ost recent versions in nuget.org are:

- Microsoft.IO.Redist 6.1.2
- System.Buffers 4.6.1
- System.Memory 4.6.2
- System.Net.WebSockets.WebSocketProtocol 5.1.2
- System.Numerics.Vectors 4.6.1
- System.Reflection.DispatchProxy 4.8.2
- System.Threading.Tasks.Extensions 4.6.2
- System.ValueTuple 4.6.1

This was done manually. I have an issue open to track the work to automate these PRs: https://github.com/dotnet/maintenance-packages/issues/217