### PR TITLE
Fix S.R.CS.Unsafe AssemblyVersion and move properties to Versioning.props

### DIFF
--- a/src/Microsoft.IO.Redist/src/Microsoft.IO.Redist.csproj
+++ b/src/Microsoft.IO.Redist/src/Microsoft.IO.Redist.csproj
@@ -13,7 +13,7 @@
 
   <!-- Package servicing properties -->
   <PropertyGroup>
-    <IsPackable>false</IsPackable>
+    <IsPackable>true</IsPackable>
     <VersionPrefix>6.1.2</VersionPrefix>
     <VersionPrefix Condition="'$(IsPackable)' == 'true'">6.1.3</VersionPrefix>
     <PackageValidationBaselineVersion>6.1.2</PackageValidationBaselineVersion>

--- a/src/System.Memory/src/System.Memory.csproj
+++ b/src/System.Memory/src/System.Memory.csproj
@@ -11,7 +11,7 @@
 
   <!-- Package servicing properties -->
   <PropertyGroup>
-    <IsPackable>false</IsPackable>
+    <IsPackable>true</IsPackable>
     <VersionPrefix>4.6.2</VersionPrefix>
     <VersionPrefix Condition="'$(IsPackable)' == 'true'">4.6.3</VersionPrefix>
     <AssemblyVersion Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.0.4.0</AssemblyVersion>

--- a/src/System.Net.WebSockets.WebSocketProtocol/src/System.Net.WebSockets.WebSocketProtocol.csproj
+++ b/src/System.Net.WebSockets.WebSocketProtocol/src/System.Net.WebSockets.WebSocketProtocol.csproj
@@ -9,7 +9,7 @@
 
   <!-- Package servicing properties -->
   <PropertyGroup>
-    <IsPackable>false</IsPackable>
+    <IsPackable>true</IsPackable>
     <VersionPrefix>5.1.2</VersionPrefix>
     <VersionPrefix Condition="'$(IsPackable)' == 'true'">5.1.3</VersionPrefix>
     <PackageValidationBaselineVersion>5.1.2</PackageValidationBaselineVersion>

--- a/src/System.Runtime.CompilerServices.Unsafe/Versioning.props
+++ b/src/System.Runtime.CompilerServices.Unsafe/Versioning.props
@@ -1,9 +1,12 @@
 <Project>
 
   <PropertyGroup>
-    <IsPackable>false</IsPackable>
+    <IsPackable>true</IsPackable>
     <VersionPrefix>6.1.1</VersionPrefix>
     <VersionPrefix Condition="'$(IsPackable)' == 'true'">6.1.2</VersionPrefix>
+    <AssemblyVersion Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">6.0.2.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(IsPackable)' == 'true' and $([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">6.0.3.0</AssemblyVersion>
+    <PackageValidationBaselineVersion>6.1.1</PackageValidationBaselineVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.ilproj
+++ b/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.ilproj
@@ -18,13 +18,6 @@
   <!-- VersionPrefix and IsPackable are defined in the parent folder's Versioning.props file. -->
   <Import Project="..\Versioning.props" />
 
-  <!-- Package servicing properties -->
-  <PropertyGroup>
-    <AssemblyVersion Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">6.0.1.0</AssemblyVersion>
-    <AssemblyVersion Condition="'$(IsPackable)' == 'true' and $([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">6.0.2.0</AssemblyVersion>
-    <PackageValidationBaselineVersion>6.1.0</PackageValidationBaselineVersion>
-  </PropertyGroup>
-  
   <PropertyGroup Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp' and '$(IsPlaceholderTargetFramework)' != 'true'">
     <ExtraMacros>#define netcoreapp</ExtraMacros>
     <CoreAssembly>System.Runtime</CoreAssembly>

--- a/src/System.Runtime.CompilerServices.Unsafe/ver/Versioning.csproj
+++ b/src/System.Runtime.CompilerServices.Unsafe/ver/Versioning.csproj
@@ -8,8 +8,4 @@
 
   <Import Project="..\Versioning.props" />
 
-  <PropertyGroup>
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
-
 </Project>

--- a/src/System.Runtime.CompilerServices.Unsafe/ver/Versioning.csproj
+++ b/src/System.Runtime.CompilerServices.Unsafe/ver/Versioning.csproj
@@ -8,4 +8,8 @@
 
   <Import Project="..\Versioning.props" />
 
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
 </Project>

--- a/src/System.Threading.Tasks.Extensions/src/System.Threading.Tasks.Extensions.csproj
+++ b/src/System.Threading.Tasks.Extensions/src/System.Threading.Tasks.Extensions.csproj
@@ -10,7 +10,7 @@
 
   <!-- Package servicing properties -->
   <PropertyGroup>
-    <IsPackable>false</IsPackable>
+    <IsPackable>true</IsPackable>
     <VersionPrefix>4.6.2</VersionPrefix>
     <VersionPrefix Condition="'$(IsPackable)' == 'true'">4.6.3</VersionPrefix>
     <AssemblyVersion Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">4.2.3.0</AssemblyVersion>


### PR DESCRIPTION
This was missed due to being in a separate file.

These will now be in the same file as the other versioning ones, and will also affect the tests and resource versions but that would not be a problem.