### PR TITLE
Remove auditSources from NuGet.config

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -10,10 +10,6 @@
     <!-- dotnet10 contains the latest Microsoft.DotNet.ApiCompat.Task -->
     <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />
   </packageSources>
-  <auditSources>
-    <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-  </auditSources>
   <disabledPackageSources>
     <clear />
   </disabledPackageSources>


### PR DESCRIPTION
The api.nuget.org source will clash with the CFSClean network isolation policy and the same data is provided by AzDO now.
