### PR TITLE
Disable source indexing

### DIFF
--- a/eng/pipelines/maintenance-packages.yml
+++ b/eng/pipelines/maintenance-packages.yml
@@ -84,7 +84,6 @@ extends:
           enableMicrobuild: true
           enablePublishUsingPipelines: true
           publishAssetsImmediately: true
-          enableSourceIndex: ${{ and(eq(variables._RunAsInternal, True), eq(variables['Build.SourceBranch'], 'refs/heads/internal/main')) }}
           workspace:
             clean: all
           jobs:


### PR DESCRIPTION
None of the packages shipping from this repo need to be in source.dot.net.