### PR TITLE
Fix ValueTuple conflict warnings using RedistList

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,6 +11,7 @@
     <PackageVersion Include="Microsoft.DotNet.RemoteExecutor" Version="$(MicrosoftDotNetRemoteExecutorVersion)" />
     <PackageVersion Include="Microsoft.DotNet.XUnitExtensions" Version="$(MicrosoftDotNetXUnitExtensionsVersion)" />
     <PackageVersion Include="Microsoft.DotNet.Build.Tasks.TargetFramework" Version="$(MicrosoftDotNetBuildTasksTargetFrameworkVersion)" />
+    <PackageVersion Include="Microsoft.DotNet.Build.Tasks.Templating" Version="$(MicrosoftDotNetBuildTasksTemplatingVersion)" />
   </ItemGroup>
 
   <!-- These versions are not updated by dependency flow as they aren't produced live anymore. -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -19,5 +19,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>4b01306353c43c151d713d152f48a4d523c41960</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Templating" Version="8.0.0-beta.25611.2">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>4b01306353c43c151d713d152f48a4d523c41960</Sha>
+    </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,5 +12,6 @@
     <MicrosoftDotNetRemoteExecutorVersion>8.0.0-beta.25611.2</MicrosoftDotNetRemoteExecutorVersion>
     <MicrosoftDotNetXUnitExtensionsVersion>8.0.0-beta.25611.2</MicrosoftDotNetXUnitExtensionsVersion>
     <MicrosoftDotNetBuildTasksTargetFrameworkVersion>8.0.0-beta.25611.2</MicrosoftDotNetBuildTasksTargetFrameworkVersion>
+    <MicrosoftDotNetBuildTasksTemplatingVersion>8.0.0-beta.25611.2</MicrosoftDotNetBuildTasksTemplatingVersion>
   </PropertyGroup>
 </Project>

--- a/eng/placeholderpackaging.targets
+++ b/eng/placeholderpackaging.targets
@@ -8,7 +8,7 @@
     <!-- Prevent including the build output in the package. -->
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <!-- Hook up a target to include the placeholder file in the package. -->
-    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificBuildOutput);_AddPlaceholderFileToPackage</TargetsForTfmSpecificContentInPackage>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddPlaceholderFileToPackage</TargetsForTfmSpecificContentInPackage>
     <!-- TFMs that are only used as placeholders should not include any default items. -->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/src/System.ValueTuple/src/System.ValueTuple.csproj
+++ b/src/System.ValueTuple/src/System.ValueTuple.csproj
@@ -32,6 +32,7 @@
     <When Condition="'$(TargetFramework)' == 'net47'">
       <PropertyGroup>
         <EnableDefaultItems>false</EnableDefaultItems>
+        <OmitResources>true</OmitResources>
       </PropertyGroup>
 
       <ItemGroup>
@@ -50,4 +51,32 @@
     <Error Text="NetFrameworkMinimum got changed to '$(NetFrameworkMinimum)'. Consider removing this implementation or the whole library." />
   </Target>
 
+  <PropertyGroup>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);CreateRedistList</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Templating" PrivateAssets="All"/>
+    <RedistListInputPath Include="ValueTupleFrameworkList.xml" />
+    <RedistListOutputPath Include="$(IntermediateOutputPath)ValueTupleFrameworkList.xml" />
+  </ItemGroup>
+
+  <Target Name="CreateRedistList"
+          Condition="'$(TargetFramework)' == 'net471'"
+          Inputs="@(RedistListInputPath)"
+          Outputs="@(RedistListOutputPath)">
+    <ItemGroup>
+      <CreateRedistListTemplateProperty Include="AssemblyVersion=$(AssemblyVersion)" />
+    </ItemGroup>
+
+    <GenerateFileFromTemplate
+      TemplateFile="@(RedistListInputPath)"
+      Properties="@(CreateRedistListTemplateProperty)"
+      OutputPath="@(RedistListOutputPath)" />
+
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="@(RedistListOutputPath)" PackagePath="build\net471" />
+      <TfmSpecificPackageFile Include="@(RedistListOutputPath)" PackagePath="buildTransitive\net471" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/System.ValueTuple/src/ValueTupleFrameworkList.xml
+++ b/src/System.ValueTuple/src/ValueTupleFrameworkList.xml
@@ -1,0 +1,3 @@
+<FileList Redist="System.ValueTuple" Name="System.ValueTuple" RuntimeVersion="4.5" ToolsVersion="4.0" ShortName="ValueTuple">
+    <File AssemblyName="System.ValueTuple" Version="${AssemblyVersion}" PublicKeyToken="cc7b13ffcd2ddd51" Culture="neutral" ProcessorArchitecture="MSIL" InGac="true"/>
+</FileList>

--- a/src/System.ValueTuple/src/buildTransitive/net471/System.ValueTuple.targets
+++ b/src/System.ValueTuple/src/buildTransitive/net471/System.ValueTuple.targets
@@ -1,16 +1,22 @@
 <Project>
-  <!-- Ensure we bring in the System.ValueTuple facade from the targeting pack
-       SpecificVersion="true" prevents a warning from ResolveAssemblyReference about a mismatch in reference versions 
-       that will be ignored at runtime by .NETFramework's assembly unification -->
+
+  <!-- Add a RedistList containing ValueTuple.  This will cause MSBuild to auto-unify to the version in this list. -->
   <ItemGroup>
-    <Reference Include="System.ValueTuple" SpecificVersion="true" />
+    <RedistList Include="$(MSBuildThisFileDirectory)ValueTupleFrameworkList.xml" />
   </ItemGroup>
 
-  <!-- System.ValueTuple is inbox on .NET Framework >= 4.7.1 and therefore any potential redirect for it should be removed.
-       This is necessary as the assembly version in the already shipped packages is higher than what's provided inbox on .NET Framework. -->
-  <Target Name="RemoveValueTupleRedirectForNet471AndAbove" DependsOnTargets="ResolveAssemblyReferences" BeforeTargets="GenerateBindingRedirects">
+  <!-- Add the ValueTuple facade directory to the target framework directories.
+       This lets MSBuild find the unified assembly and treat it as a reference assembly, like other facades.
+       This is done in a target rather than statically setting DesignTimeFacadeDirectories so that we can
+       place the new directory at the end, and avoid additional probing for normal framework assemblies. -->
+  <Target Name="_AddValueTupleFrameworkDirectory" AfterTargets="GetReferenceAssemblyPaths">
+    <PropertyGroup>
+      <ValueTupleFacadeDirectory>$([MSBuild]::NormalizeDirectory($(MSBuildThisFileDirectory), '..', '..', 'lib', 'net47'))</ValueTupleFacadeDirectory>
+      <TargetFrameworkDirectory>$(TargetFrameworkDirectory);$(ValueTupleFacadeDirectory)</TargetFrameworkDirectory>
+    </PropertyGroup>
+
     <ItemGroup>
-      <SuggestedBindingRedirects Remove="System.ValueTuple, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" />
+      <DesignTimeFacadeDirectories Include="$(ValueTupleFacadeDirectory)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
#243 

This passes a framework list to RAR to use for assembly unification.  It also provides a path to a matching facade assembly from the net47 path in the package.

This works most closely to how RAR does with other facades in the framework.  The redist list is used for unification decisions.  RAR supports many lists and chooses the highest version from all.

This silences the warnings at build time, while providing the higher version reference instead of the lower one from the targeting pack.  The reference will be private=false, aka non-copy-local, just like the facades resolved from the targeting pack.

At runtime unification behaves as normal.  I'm hoping this strikes the balance of minimizing the runtime impact of the ValueTuple package while still giving a satisfactory dev experience (no confusing warnings).  I've tested this using repros provided in #243 as well as a bunch of adhoc tests I created.
