### PR TITLE
Ensure we include a framework reference to ValueTuple

### DIFF
--- a/src/System.ValueTuple/src/System.ValueTuple.csproj
+++ b/src/System.ValueTuple/src/System.ValueTuple.csproj
@@ -39,6 +39,13 @@
         <Compile Include="TypeForwards.cs" />
       </ItemGroup>
     </When>
+
+    <!-- Ensure a framework assembly reference where inbox. -->
+    <When Condition="'$(TargetFramework)' == 'net471'">
+      <ItemGroup>
+        <Reference Include="System.ValueTuple" />
+      </ItemGroup>
+    </When>
   </Choose>
 
   <!-- Also put into build folder for packages.config support. -->


### PR DESCRIPTION
... when targeting .NET versions where it is inbox.

Without this ValueTuple won't be passed to the compiler if transitive references don't also reference System.Runtime (netstandard1x).

Follow up to #252.  

I was thinking through all the scenarios and tested this locally to determine it is necessary to include a reference.  I used the normal nuget mechanism to provide that reference, rather than adding to the targets file.

Repro attached: 
[reduced.zip](https://github.com/user-attachments/files/25223364/reduced.zip)
