### PR TITLE
Remove Mariner 2.0 pipeline references

### DIFF
--- a/eng/pipelines/maintenance-packages-pr.yml
+++ b/eng/pipelines/maintenance-packages-pr.yml
@@ -31,7 +31,7 @@ variables:
 resources:
   containers:
   - container: LinuxContainer
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-fpm-amd64
 
 stages:
 - stage: build

--- a/eng/pipelines/maintenance-packages.yml
+++ b/eng/pipelines/maintenance-packages.yml
@@ -69,7 +69,7 @@ extends:
       os: windows
     containers:
       LinuxContainer:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-fpm-amd64
     stages:
     - stage: build
       displayName: CI


### PR DESCRIPTION
> [!NOTE]
> This PR was AI/Copilot-generated.

## Summary
Update the remaining maintenance-packages pipeline container references to the current Azure Linux FPM image.

- replace `mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm`
- with `mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-fpm-amd64`

Follow-up to dotnet/runtime#126528.