### PR TITLE
Add Vector.Sum<T> for netstandard2.0

### DIFF
--- a/src/System.Numerics.Vectors/src/System.Numerics.Vectors.xml
+++ b/src/System.Numerics.Vectors/src/System.Numerics.Vectors.xml
@@ -2057,6 +2057,13 @@
             <param name="right">The second source vector.</param>
             <returns>The dot product.</returns>
         </member>
+        <member name="M:System.Numerics.Vector.Sum``1(System.Numerics.Vector{``0})">
+            <summary>
+            Returns the sum of all the elements inside the specified vector.
+            </summary>
+            <param name="value">The vector whose elements will be summed.</param>
+            <returns>The sum of all the elements inside <paramref name="value"/>.</returns>
+        </member>
         <member name="M:System.Numerics.Vector.SquareRoot``1(System.Numerics.Vector{``0})">
             <summary>
             Returns a new vector whose elements are the square roots of the given vector's elements.

--- a/src/System.Numerics.Vectors/src/System/Numerics/Vector_Operations.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Vector_Operations.cs
@@ -586,6 +586,17 @@ namespace System.Numerics
         }
 
         /// <summary>
+        /// Returns the sum of all the elements inside the specified vector.
+        /// </summary>
+        /// <param name="value">The vector whose elements will be summed.</param>
+        /// <returns>The sum of all the elements inside <paramref name="value"/>.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static T Sum<T>(Vector<T> value) where T : struct
+        {
+            return Dot(value, Vector<T>.One);
+        }
+
+        /// <summary>
         /// Returns a new vector whose elements are the square roots of the given vector's elements.
         /// </summary>
         /// <param name="value">The source vector.</param>

--- a/src/System.Numerics.Vectors/tests/GenericVectorTests.cs
+++ b/src/System.Numerics.Vectors/tests/GenericVectorTests.cs
@@ -1807,6 +1807,40 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
+        public void SumByte() { TestSum<Byte>(); }
+        [Fact]
+        public void SumSByte() { TestSum<SByte>(); }
+        [Fact]
+        public void SumUInt16() { TestSum<UInt16>(); }
+        [Fact]
+        public void SumInt16() { TestSum<Int16>(); }
+        [Fact]
+        public void SumUInt32() { TestSum<UInt32>(); }
+        [Fact]
+        public void SumInt32() { TestSum<Int32>(); }
+        [Fact]
+        public void SumUInt64() { TestSum<UInt64>(); }
+        [Fact]
+        public void SumInt64() { TestSum<Int64>(); }
+        [Fact]
+        public void SumSingle() { TestSum<Single>(); }
+        [Fact]
+        public void SumDouble() { TestSum<Double>(); }
+        private void TestSum<T>() where T : struct
+        {
+            T[] values = Util.GenerateRandomValues<T>(Vector<T>.Count);
+            Vector<T> vector = new Vector<T>(values);
+
+            T sum = Vector.Sum(vector);
+            T expected = Util.Zero<T>();
+            for (int g = 0; g < Vector<T>.Count; g++)
+            {
+                expected = Util.Add(expected, values[g]);
+            }
+            Assert.Equal(expected, sum);
+        }
+
+        [Fact]
         public void MaxByte() { TestMax<Byte>(); }
         [Fact]
         public void MaxSByte() { TestMax<SByte>(); }

--- a/src/System.Numerics.Vectors/tests/GenericVectorTests.tt
+++ b/src/System.Numerics.Vectors/tests/GenericVectorTests.tt
@@ -1336,6 +1336,29 @@ namespace System.Numerics.Tests
     {
 #>
         [Fact]
+        public void Sum<#=type.Name#>() { TestSum<<#=type.Name#>>(); }
+<#
+    }
+#>
+        private void TestSum<T>() where T : struct
+        {
+            T[] values = Util.GenerateRandomValues<T>(Vector<T>.Count);
+            Vector<T> vector = new Vector<T>(values);
+
+            T sum = Vector.Sum(vector);
+            T expected = Util.Zero<T>();
+            for (int g = 0; g < Vector<T>.Count; g++)
+            {
+                expected = Util.Add(expected, values[g]);
+            }
+            Assert.Equal(expected, sum);
+        }
+
+<# 
+    foreach (var type in supportedTypes)
+    {
+#>
+        [Fact]
         public void Max<#=type.Name#>() { TestMax<<#=type.Name#>>(); }
 <#
     }


### PR DESCRIPTION
## Summary

Adds `Vector.Sum<T>(Vector<T>)` to the `System.Numerics.Vectors` package for netstandard2.0 and .NET Framework consumers.

This API has been available in the .NET runtime since .NET 6.0 but was never included in this package. Other comparable static methods (Dot, Abs, Min, Max, SquareRoot, etc.) are all present.

Fixes #272

## Implementation

`Sum` is implemented as `Dot(value, Vector<T>.One)` rather than a standalone method with its own `ScalarAdd` loop:

```csharp
[MethodImpl(MethodImplOptions.AggressiveInlining)]
public static T Sum<T>(Vector<T> value) where T : struct
{
    return Dot(value, Vector<T>.One);
}
```

### Why Dot?

The .NET Framework JIT has a hardcoded list of `Vector` methods it recognizes as intrinsics. `Dot` is on that list; a new `Sum` method is not. Adding `[Intrinsic]` to a new method doesn't help — the Framework JIT ignores it for methods it doesn't know about.

A standalone `Sum` using the `ScalarAdd`/`typeof(T)` pattern (same as `DotProduct`) would run the full managed code path on .NET Framework: a generic loop where each iteration does a 10-way `typeof(T)` chain. Benchmarks show this is **11-17x slower** than routing through `Dot`.

By expressing `Sum` as `Dot(value, One)`, we piggyback on `Dot`'s existing intrinsification. The multiply-by-one is essentially free at the hardware level.

### Runtime behavior

On .NET 6+, the package's `_._` placeholder means this code is never used — the runtime's intrinsified `Vector.Sum` takes over via type forwarding. The Dot-based implementation only matters on .NET Framework, where it provides SIMD-accelerated performance.

We verified this: calling `Vector.Sum` through a netstandard2.0 library on .NET 6/8 produces identical performance to calling the runtime's `Vector.Sum` directly (0.85 ns vs 0.85 ns, ratio 1.00). The type forwarding works with zero overhead.

## Benchmarks

All methods go through a **netstandard2.0 class library** compiled once, then consumed by each runtime — simulating the real scenario for library authors.

```
BenchmarkDotNet v0.14.0, X64 RyuJIT AVX2
OperationsPerInvoke=10000
```

### What's being benchmarked

Each row corresponds to a different Sum strategy, all compiled into a netstandard2.0 library:

```csharp
// Package Sum — our fix (calls Dot under the hood on Framework,
// type-forwards to runtime's Vector.Sum on .NET 6+)
float PackageSum(Vector<float> v) => Vector.Sum(v);

// Runtime Sum — calling the runtime's Vector.Sum directly (net6.0+ only)
float RuntimeSum(Vector<float> v) => Vector.Sum(v);

// Dot workaround — what people do today
float DotWorkaround(Vector<float> v) => Vector.Dot(v, Vector<float>.One);

// #if polyfill — compiles the #else branch on netstandard2.0, locked to manual loop
#if NET6_0_OR_GREATER
float IfdefPolyfill(Vector<float> v) => Vector.Sum(v);
#else
float IfdefPolyfill(Vector<float> v) { var s = 0f; for (...) s += v[i]; return s; }
#endif

// ScalarAdd chain — what a naive internal Sum implementation would do
float ScalarAddChain(Vector<float> v) => SumGeneric(v);
// (generic loop with typeof(T) dispatch on every addition)
```

### Results

| Method | .NET Framework 4.8.1 | .NET 6.0 | .NET 8.0 |
|--------|-----:|-----:|-----:|
| **Package Sum (Dot-based)** | **1.61 ns** | **0.87 ns** | **0.86 ns** |
| Runtime Sum (direct) | N/A | 0.85 ns | 0.85 ns |
| Dot(v, One) workaround | 1.63 ns | 0.33 ns | 0.33 ns |
| `#if` polyfill (manual loop) | 2.07 ns | 2.06 ns | 2.07 ns |
| ScalarAdd typeof chain | 18.64 ns | 14.75 ns | 14.85 ns |

Key observations:

- **Package Sum ≈ Runtime Sum on .NET 6/8** (0.86 vs 0.85 ns) — type forwarding resolves to the same intrinsified implementation with zero overhead.
- **Package Sum ≈ Dot workaround on .NET Framework** (~1.6 ns) — both route through the same JIT-intrinsified `Dot` path.
- **Package Sum on .NET 6/8** (0.86 ns) is slightly slower than raw `Dot` (0.33 ns) because the runtime's `Vector.Sum` uses a different instruction sequence (shuffle+add vs dpps). This is a JIT codegen detail, not a package issue.
- **`#if` polyfill is locked at ~2.1 ns everywhere** — a netstandard2.0 library compiles the `#else` manual loop, which never improves regardless of the consumer's runtime. The package fix is **2.4x faster on .NET 6/8**.
- **ScalarAdd chain is 11-17x slower** — this is why we use `Dot` instead of a standalone implementation.