### PR TITLE
Remove obsolete DotNet-VSTS-Bot reference

### DIFF
--- a/eng/common/templates/job/execute-sdl.yml
+++ b/eng/common/templates/job/execute-sdl.yml
@@ -36,7 +36,6 @@ jobs:
   displayName: Run SDL tool
   condition: and(succeededOrFailed(), eq( ${{ parameters.enable }}, 'true'))
   variables:
-    - group: DotNet-VSTS-Bot
     - name: AzDOProjectName
       value: ${{ parameters.AzDOProjectName }}
     - name: AzDOPipelineId


### PR DESCRIPTION
Remove the final active maintenance-packages reference to variable group 10 (DotNet-VSTS-Bot). The group contains only the expired dn-bot-dotnet-build-rw-code-rw PAT and must be deleted before the Key Vault secret can be removed.

This focused change avoids the unrelated restore failures currently blocking dependency-flow PR #249.

Tracking: AB#11023